### PR TITLE
Encode screenshot as JPEG when it has the extension

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1193,7 +1193,14 @@ namespace BizHawk.Client.EmuHawk
 			using (var bb = Config.ScreenshotCaptureOsd ? CaptureOSD() : MakeScreenshotImage())
 			{
 				using var img = bb.ToSysdrawingBitmap();
-				img.Save(fi.FullName, ImageFormat.Png);
+				if (Path.GetExtension(path).ToUpper() == ".JPG")
+				{
+					img.Save(fi.FullName, ImageFormat.Jpeg);
+				}
+				else
+				{
+					img.Save(fi.FullName, ImageFormat.Png);
+				}
 			}
 
 			AddOnScreenMessage($"{fi.Name} saved.");


### PR DESCRIPTION
I want to create jpeg screenshots from a Lua script, but while ".jpg" is recognized in `AddFrame` from `ImageSequenceWriter.cs`, it is not in `TakeScreenshot`. This might solve issue #1666.