### PR TITLE
Add fast-forward rewinds and rewind speed multipliers.

### DIFF
--- a/src/BizHawk.Client.Common/config/RewindConfig.cs
+++ b/src/BizHawk.Client.Common/config/RewindConfig.cs
@@ -34,6 +34,12 @@
 		/// </summary>
 		int TargetRewindInterval { get; }
 
+		/// <summary>
+		/// Number of rewind states to go back per press of the rewind button, without and with fast forwarding.
+		/// </summary>
+		int speedMultiplier { get; }
+		int fastSpeedMultiplier { get; }
+
 		public enum BackingStoreType
 		{
 			Memory,
@@ -52,6 +58,8 @@
 		public bool UseFixedRewindInterval { get; set; } = false;
 		public int TargetFrameLength { get; set; } = 600;
 		public int TargetRewindInterval { get; set; } = 5;
+		public int speedMultiplier { get; set; } = 1;
+		public int fastSpeedMultiplier { get; set; } = 5;
 		public IRewindSettings.BackingStoreType BackingStore { get; set; } = IRewindSettings.BackingStoreType.Memory;
 	}
 }

--- a/src/BizHawk.Client.Common/rewind/IRewinder.cs
+++ b/src/BizHawk.Client.Common/rewind/IRewinder.cs
@@ -15,7 +15,7 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Rewind 1 or 2 saved frames, depending on whether the last frame is stale.
 		/// </summary>
-		bool Rewind();
+		bool Rewind(bool fastForward);
 
 		void Suspend();
 		void Resume();

--- a/src/BizHawk.Client.Common/rewind/IRewinder.cs
+++ b/src/BizHawk.Client.Common/rewind/IRewinder.cs
@@ -13,9 +13,9 @@ namespace BizHawk.Client.Common
 
 		void Capture(int frame);
 		/// <summary>
-		/// Rewind 1 or 2 saved frames, avoiding frameToAvoid if possible.
+		/// Rewind 1 or 2 saved frames, depending on whether the last frame is stale.
 		/// </summary>
-		bool Rewind(int frameToAvoid);
+		bool Rewind();
 
 		void Suspend();
 		void Resume();

--- a/src/BizHawk.Client.Common/rewind/Zwinder.cs
+++ b/src/BizHawk.Client.Common/rewind/Zwinder.cs
@@ -20,11 +20,16 @@ namespace BizHawk.Client.Common
 		private readonly ZwinderBuffer _buffer;
 		private readonly IStatable _stateSource;
 
+		private readonly int speedMultipler;
+		private readonly int fastSpeedMultipler;
+
 		public Zwinder(IStatable stateSource, IRewindSettings settings)
 		{
 			_buffer = new ZwinderBuffer(settings);
 			_stateSource = stateSource;
 			Active = true;
+			speedMultipler = settings.speedMultiplier;
+			fastSpeedMultipler = settings.fastSpeedMultiplier;
 		}
 
 		/// <summary>
@@ -82,7 +87,7 @@ namespace BizHawk.Client.Common
 			}
 			else
 			{
-				int rewindSteps = fastForward ? 5 : 1;
+				int rewindSteps = fastForward ? fastSpeedMultipler : speedMultipler;
 				if (HasStaleFrame) ++rewindSteps;
 				var index = rewindSteps > Count ? 0 : Count - rewindSteps;
 				var state = _buffer.GetState(index);

--- a/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
+++ b/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
@@ -81,7 +81,7 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Number of states that could be in the state ringbuffer, Mask for the state ringbuffer
 		/// </summary>
-		private const int STATEMASK = 16383;
+		private const int STATEMASK = 262143;
 
 		/// <summary>
 		/// How many states are actually in the state ringbuffer

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -4607,7 +4607,7 @@ namespace BizHawk.Client.EmuHawk
 					// Try to avoid the previous frame:  We want to frame advance right after rewinding so we can give a useful
 					// framebuffer.
 					var frameToAvoid = Emulator.Frame - 1;
-					runFrame = Rewinder.Rewind(frameToAvoid);
+					runFrame = Rewinder.Rewind();
 					if (Emulator.Frame == frameToAvoid)
 					{
 						// The rewinder was unable to satisfy our request.  Prefer showing a stale framebuffer to

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3025,14 +3025,14 @@ namespace BizHawk.Client.EmuHawk
 				runFrame = true;
 			}
 
-			bool isRewinding = Rewind(ref runFrame, currentTimestamp, out var returnToRecording);
+			var isFastForwarding = InputManager.ClientControls["Fast Forward"] || IsTurboing || InvisibleEmulation;
+			bool isRewinding = Rewind(ref runFrame, currentTimestamp, isFastForwarding, out var returnToRecording);
 
 			float atten = 0;
 
 			// BlockFrameAdvance (true when input it being editted in TAStudio) supercedes all other frame advance conditions
 			if ((runFrame || force) && !BlockFrameAdvance)
 			{
-				var isFastForwarding = InputManager.ClientControls["Fast Forward"] || IsTurboing || InvisibleEmulation;
 				var isFastForwardingOrRewinding = isFastForwarding || isRewinding || _unthrottled;
 
 				if (isFastForwardingOrRewinding != _lastFastForwardingOrRewinding)
@@ -4526,7 +4526,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private bool Rewind(ref bool runFrame, long currentTimestamp, out bool returnToRecording)
+		private bool Rewind(ref bool runFrame, long currentTimestamp, bool isFastForwarding, out bool returnToRecording)
 		{
 			var isRewinding = false;
 
@@ -4607,7 +4607,7 @@ namespace BizHawk.Client.EmuHawk
 					// Try to avoid the previous frame:  We want to frame advance right after rewinding so we can give a useful
 					// framebuffer.
 					var frameToAvoid = Emulator.Frame - 1;
-					runFrame = Rewinder.Rewind();
+					runFrame = Rewinder.Rewind(isFastForwarding);
 					if (Emulator.Frame == frameToAvoid)
 					{
 						// The rewinder was unable to satisfy our request.  Prefer showing a stale framebuffer to

--- a/src/BizHawk.Client.EmuHawk/config/RewindConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/RewindConfig.Designer.cs
@@ -41,6 +41,8 @@
 			this.label6 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.FullnessLabel = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.groupBox4 = new System.Windows.Forms.GroupBox();
+			this.TargetRewindIntervalRadioButton = new System.Windows.Forms.RadioButton();
+			this.TargetFrameLengthRadioButton = new System.Windows.Forms.RadioButton();
 			this.locSingleRowFLP1 = new BizHawk.WinForms.Controls.LocSingleRowFLP();
 			this.labelEx3 = new BizHawk.WinForms.Controls.LabelEx();
 			this.labelEx2 = new BizHawk.WinForms.Controls.LabelEx();
@@ -73,8 +75,10 @@
 			this.label16 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.BackupSavestatesCheckbox = new System.Windows.Forms.CheckBox();
 			this.label12 = new BizHawk.WinForms.Controls.LocLabelEx();
-			this.TargetFrameLengthRadioButton = new System.Windows.Forms.RadioButton();
-			this.TargetRewindIntervalRadioButton = new System.Windows.Forms.RadioButton();
+			this.SpeedMultiplierNumeric = new System.Windows.Forms.NumericUpDown();
+			this.FastSpeedMultiplierNumeric = new System.Windows.Forms.NumericUpDown();
+			this.label2 = new System.Windows.Forms.Label();
+			this.label5 = new System.Windows.Forms.Label();
 			((System.ComponentModel.ISupportInitialize)(this.BufferSizeUpDown)).BeginInit();
 			this.groupBox4.SuspendLayout();
 			this.locSingleRowFLP1.SuspendLayout();
@@ -85,6 +89,8 @@
 			((System.ComponentModel.ISupportInitialize)(this.nudCompression)).BeginInit();
 			this.groupBox7.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.BigScreenshotNumeric)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.SpeedMultiplierNumeric)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.FastSpeedMultiplierNumeric)).BeginInit();
 			this.SuspendLayout();
 			// 
 			// OK
@@ -123,7 +129,7 @@
 			// UseCompression
 			// 
 			this.UseCompression.AutoSize = true;
-			this.UseCompression.Location = new System.Drawing.Point(15, 194);
+			this.UseCompression.Location = new System.Drawing.Point(15, 240);
 			this.UseCompression.Name = "UseCompression";
 			this.UseCompression.Size = new System.Drawing.Size(324, 17);
 			this.UseCompression.TabIndex = 5;
@@ -192,6 +198,10 @@
 			// 
 			// groupBox4
 			// 
+			this.groupBox4.Controls.Add(this.label5);
+			this.groupBox4.Controls.Add(this.label2);
+			this.groupBox4.Controls.Add(this.FastSpeedMultiplierNumeric);
+			this.groupBox4.Controls.Add(this.SpeedMultiplierNumeric);
 			this.groupBox4.Controls.Add(this.TargetRewindIntervalRadioButton);
 			this.groupBox4.Controls.Add(this.TargetFrameLengthRadioButton);
 			this.groupBox4.Controls.Add(this.locSingleRowFLP1);
@@ -213,10 +223,32 @@
 			this.groupBox4.Controls.Add(this.StateSizeLabel);
 			this.groupBox4.Location = new System.Drawing.Point(12, 12);
 			this.groupBox4.Name = "groupBox4";
-			this.groupBox4.Size = new System.Drawing.Size(371, 248);
+			this.groupBox4.Size = new System.Drawing.Size(371, 287);
 			this.groupBox4.TabIndex = 2;
 			this.groupBox4.TabStop = false;
 			this.groupBox4.Text = "RewindSettings";
+			// 
+			// TargetRewindIntervalRadioButton
+			// 
+			this.TargetRewindIntervalRadioButton.AutoSize = true;
+			this.TargetRewindIntervalRadioButton.Location = new System.Drawing.Point(15, 162);
+			this.TargetRewindIntervalRadioButton.Name = "TargetRewindIntervalRadioButton";
+			this.TargetRewindIntervalRadioButton.Size = new System.Drawing.Size(210, 17);
+			this.TargetRewindIntervalRadioButton.TabIndex = 49;
+			this.TargetRewindIntervalRadioButton.TabStop = true;
+			this.TargetRewindIntervalRadioButton.Text = "Rewinds every fixed number of frames: ";
+			this.TargetRewindIntervalRadioButton.UseVisualStyleBackColor = true;
+			// 
+			// TargetFrameLengthRadioButton
+			// 
+			this.TargetFrameLengthRadioButton.AutoSize = true;
+			this.TargetFrameLengthRadioButton.Location = new System.Drawing.Point(15, 138);
+			this.TargetFrameLengthRadioButton.Name = "TargetFrameLengthRadioButton";
+			this.TargetFrameLengthRadioButton.Size = new System.Drawing.Size(125, 17);
+			this.TargetFrameLengthRadioButton.TabIndex = 48;
+			this.TargetFrameLengthRadioButton.TabStop = true;
+			this.TargetFrameLengthRadioButton.Text = "Desired frame length:";
+			this.TargetFrameLengthRadioButton.UseVisualStyleBackColor = true;
 			// 
 			// locSingleRowFLP1
 			// 
@@ -249,7 +281,7 @@
 			// cbDeltaCompression
 			// 
 			this.cbDeltaCompression.AutoSize = true;
-			this.cbDeltaCompression.Location = new System.Drawing.Point(15, 217);
+			this.cbDeltaCompression.Location = new System.Drawing.Point(15, 263);
 			this.cbDeltaCompression.Name = "cbDeltaCompression";
 			this.cbDeltaCompression.Size = new System.Drawing.Size(332, 17);
 			this.cbDeltaCompression.TabIndex = 35;
@@ -529,27 +561,67 @@
 			this.label12.Name = "label12";
 			this.label12.Text = "Compression Level";
 			// 
-			// TargetFrameLengthRadioButton
+			// SpeedMultiplierNumeric
 			// 
-			this.TargetFrameLengthRadioButton.AutoSize = true;
-			this.TargetFrameLengthRadioButton.Location = new System.Drawing.Point(15, 138);
-			this.TargetFrameLengthRadioButton.Name = "TargetFrameLengthRadioButton";
-			this.TargetFrameLengthRadioButton.Size = new System.Drawing.Size(125, 17);
-			this.TargetFrameLengthRadioButton.TabIndex = 48;
-			this.TargetFrameLengthRadioButton.TabStop = true;
-			this.TargetFrameLengthRadioButton.Text = "Desired frame length:";
-			this.TargetFrameLengthRadioButton.UseVisualStyleBackColor = true;
+			this.SpeedMultiplierNumeric.Location = new System.Drawing.Point(194, 188);
+			this.SpeedMultiplierNumeric.Maximum = new decimal(new int[] {
+			500000,
+			0,
+			0,
+			0});
+			this.SpeedMultiplierNumeric.Minimum = new decimal(new int[] {
+			1,
+			0,
+			0,
+			0});
+			this.SpeedMultiplierNumeric.Name = "SpeedMultiplierNumeric";
+			this.SpeedMultiplierNumeric.Size = new System.Drawing.Size(52, 20);
+			this.SpeedMultiplierNumeric.TabIndex = 7;
+			this.SpeedMultiplierNumeric.Value = new decimal(new int[] {
+			1,
+			0,
+			0,
+			0});
 			// 
-			// TargetRewindIntervalRadioButton
+			// FastSpeedMultiplierNumeric
 			// 
-			this.TargetRewindIntervalRadioButton.AutoSize = true;
-			this.TargetRewindIntervalRadioButton.Location = new System.Drawing.Point(15, 162);
-			this.TargetRewindIntervalRadioButton.Name = "TargetRewindIntervalRadioButton";
-			this.TargetRewindIntervalRadioButton.Size = new System.Drawing.Size(210, 17);
-			this.TargetRewindIntervalRadioButton.TabIndex = 49;
-			this.TargetRewindIntervalRadioButton.TabStop = true;
-			this.TargetRewindIntervalRadioButton.Text = "Rewinds every fixed number of frames: ";
-			this.TargetRewindIntervalRadioButton.UseVisualStyleBackColor = true;
+			this.FastSpeedMultiplierNumeric.Location = new System.Drawing.Point(194, 214);
+			this.FastSpeedMultiplierNumeric.Maximum = new decimal(new int[] {
+			500000,
+			0,
+			0,
+			0});
+			this.FastSpeedMultiplierNumeric.Minimum = new decimal(new int[] {
+			1,
+			0,
+			0,
+			0});
+			this.FastSpeedMultiplierNumeric.Name = "FastSpeedMultiplierNumeric";
+			this.FastSpeedMultiplierNumeric.Size = new System.Drawing.Size(52, 20);
+			this.FastSpeedMultiplierNumeric.TabIndex = 62;
+			this.FastSpeedMultiplierNumeric.Value = new decimal(new int[] {
+			1,
+			0,
+			0,
+			0});
+			// 
+			// label2
+			// 
+			this.label2.AutoSize = true;
+			this.label2.Location = new System.Drawing.Point(12, 190);
+			this.label2.Name = "label2";
+			this.label2.Size = new System.Drawing.Size(176, 13);
+			this.label2.TabIndex = 63;
+			this.label2.Text = "Rewind speed (without fast foward):";
+			// 
+			// label5
+			// 
+			this.label5.AutoSize = true;
+			this.label5.Location = new System.Drawing.Point(12, 217);
+			this.label5.Name = "label5";
+			this.label5.Size = new System.Drawing.Size(164, 13);
+			this.label5.TabIndex = 64;
+			this.label5.Text = "Rewind speed (with fast forward):";
 			// 
 			// RewindConfig
 			// 
@@ -583,6 +655,8 @@
 			this.groupBox7.ResumeLayout(false);
 			this.groupBox7.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)(this.BigScreenshotNumeric)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.SpeedMultiplierNumeric)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.FastSpeedMultiplierNumeric)).EndInit();
 			this.ResumeLayout(false);
 
 		}
@@ -603,9 +677,9 @@
 		private System.Windows.Forms.GroupBox groupBox4;
 		private BizHawk.WinForms.Controls.LocLabelEx RewindFramesUsedLabel;
 		private BizHawk.WinForms.Controls.LocLabelEx label7;
-        private BizHawk.WinForms.Controls.LocLabelEx ApproxFramesLabel;
-        private BizHawk.WinForms.Controls.LocLabelEx label8;
-        private BizHawk.WinForms.Controls.LocLabelEx EstTimeLabel;
+		private BizHawk.WinForms.Controls.LocLabelEx ApproxFramesLabel;
+		private BizHawk.WinForms.Controls.LocLabelEx label8;
+		private BizHawk.WinForms.Controls.LocLabelEx EstTimeLabel;
 				private BizHawk.WinForms.Controls.LocLabelEx label11;
 				private System.Windows.Forms.GroupBox groupBox6;
 				private System.Windows.Forms.RadioButton rbStatesText;
@@ -635,5 +709,9 @@
 		private WinForms.Controls.LabelEx labelEx1;
 		private System.Windows.Forms.RadioButton TargetFrameLengthRadioButton;
 		private System.Windows.Forms.RadioButton TargetRewindIntervalRadioButton;
+		private System.Windows.Forms.Label label5;
+		private System.Windows.Forms.Label label2;
+		private System.Windows.Forms.NumericUpDown FastSpeedMultiplierNumeric;
+		private System.Windows.Forms.NumericUpDown SpeedMultiplierNumeric;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
@@ -147,7 +147,7 @@ namespace BizHawk.Client.EmuHawk
 			var bufferSize = 1L << (int) BufferSizeUpDown.Value;
 			labelEx1.Text = bufferSize.ToString();
 			bufferSize *= 1024 * 1024;
-			var estFrames = bufferSize / _avgStateSize;
+			var estFrames = Math.Min(bufferSize / _avgStateSize, 262143.0);
 
 			double estTotalFrames = estFrames;
 			double minutes = estTotalFrames / 60 / 60;

--- a/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
@@ -53,6 +53,9 @@ namespace BizHawk.Client.EmuHawk
 			TargetRewindIntervalRadioButton.Checked = _config.Rewind.UseFixedRewindInterval;
 			TargetFrameLengthNumeric.Value = Math.Max(_config.Rewind.TargetFrameLength, TargetFrameLengthNumeric.Minimum);
 			TargetRewindIntervalNumeric.Value = Math.Max(_config.Rewind.TargetRewindInterval, TargetRewindIntervalNumeric.Minimum);
+			SpeedMultiplierNumeric.Value = Math.Max(_config.Rewind.speedMultiplier, SpeedMultiplierNumeric.Minimum);
+			FastSpeedMultiplierNumeric.Value = Math.Max(_config.Rewind.fastSpeedMultiplier, FastSpeedMultiplierNumeric.Minimum);
+
 			StateSizeLabel.Text = FormatKB(_avgStateSize);
 			CalculateEstimates();
 
@@ -117,6 +120,8 @@ namespace BizHawk.Client.EmuHawk
 			_config.Rewind.UseFixedRewindInterval = PutRewindSetting(_config.Rewind.UseFixedRewindInterval, TargetRewindIntervalRadioButton.Checked);
 			_config.Rewind.TargetFrameLength = PutRewindSetting(_config.Rewind.TargetFrameLength, (int)TargetFrameLengthNumeric.Value);
 			_config.Rewind.TargetRewindInterval = PutRewindSetting(_config.Rewind.TargetRewindInterval, (int)TargetRewindIntervalNumeric.Value);
+			_config.Rewind.speedMultiplier = PutRewindSetting(_config.Rewind.speedMultiplier, (int)SpeedMultiplierNumeric.Value);
+			_config.Rewind.fastSpeedMultiplier = PutRewindSetting(_config.Rewind.fastSpeedMultiplier, (int)FastSpeedMultiplierNumeric.Value);
 			_config.Rewind.UseDelta = PutRewindSetting(_config.Rewind.UseDelta, cbDeltaCompression.Checked);
 
 			// These settings are not used by DoRewindSettings


### PR DESCRIPTION
No changes to TAStudio. Outside of TAStudio, there's now an option to specify two rewind speed multipliers: one for normal rewinds, and one for rewinds while fast-forwarding.

![grafik](https://user-images.githubusercontent.com/8490534/147604896-4e380a86-2fba-45f4-8511-12a900e1196d.png)

If the rewind speed is `k`, then a single press of the rewind key will go back `k` states in the rewind buffer instead of just `1`. In practice, this makes the overall rewind speed when holding down the rewind key around `k` times faster, at the cost of having less precision. (It also leads to less mashing if you want to rewind multiple times back-to-back.) Having two separate rewind speeds allows you to profit from this increased speed by holding fast-forward without affecting the precision of your usual rewinds.

I've gotten a lot of mileage out of these fast-forward rewinds while playing some SMW glitch puzzle home brew, where rewinds play a similar role to the "undo" feature from e.g. Baba is you. Rewinding back >4k frames because you messed up an earlier step is not uncommon and not having to worry about making manual save states allows you to really focus on the puzzles. (Loading a save state would also clear the rewind buffer.) I have hit the 16k rewind limit at some point and it really sucked, so I bumped that up. (I don't see why it was that low to begin with.)
