### PR TITLE
Fix SXROM Detection

### DIFF
--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/SxROM.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/SxROM.cs
@@ -589,8 +589,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		{
 			switch (Cart.BoardType)
 			{
-				case "MAPPER001": //ines 2 might get here
-					if (Cart.WramSize != 32)
+				case "MAPPER0001":
+					if (Cart.WramSize < 32)
 						return false;
 					AssertPrg(128, 256, 512); AssertChr(0); AssertVram(8); AssertWram(32);
 					break;
@@ -636,7 +636,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			{
 				case "MAPPER001":
 					// we try to heuristic match to iNES 001 roms with big PRG only
-					if (Cart.PrgSize <= 256 || Cart.WramSize > 8)
+					if (Cart.PrgSize <= 256)
 						return false;
 					AssertPrg(512); AssertChr(0);
 					Cart.VramSize = 8;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/SxROM.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/SxROM.cs
@@ -589,7 +589,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		{
 			switch (Cart.BoardType)
 			{
-				case "MAPPER0001":
+				case "MAPPER0001-00":
 					if (Cart.WramSize < 32)
 						return false;
 					AssertPrg(128, 256, 512); AssertChr(0); AssertVram(8); AssertWram(32);

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/SxROM.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/SxROM.cs
@@ -589,6 +589,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		{
 			switch (Cart.BoardType)
 			{
+				case "MAPPER001": //ines 2 might get here
+					if (Cart.WramSize != 32)
+						return false;
+					AssertPrg(128, 256, 512); AssertChr(0); AssertVram(8); AssertWram(32);
+					break;
 				case "HVC-SXROM": //final fantasy 1& 2
 					AssertPrg(128, 256, 512); AssertChr(0); AssertVram(8); AssertWram(32);
 					break;
@@ -631,7 +636,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			{
 				case "MAPPER001":
 					// we try to heuristic match to iNES 001 roms with big PRG only
-					if (Cart.PrgSize <= 256)
+					if (Cart.PrgSize <= 256 || Cart.WramSize > 8)
 						return false;
 					AssertPrg(512); AssertChr(0);
 					Cart.VramSize = 8;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.iNES.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.iNES.cs
@@ -52,11 +52,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				// only add submapper if it is non-zero
 				if (submapper != 0)
 				{
-					CartV2.BoardType = $"MAPPER{mapper:d4}-{submapper:d2}";
+					CartV2.BoardType = $"MAPPER{mapper:d3}-{submapper:d2}";
 				}
 				else
 				{
-					CartV2.BoardType = $"MAPPER{mapper:d4}";
+					CartV2.BoardType = $"MAPPER{mapper:d3}";
 				}
 				
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.iNES.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.iNES.cs
@@ -48,17 +48,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 				int mapper = data[6] >> 4 | data[7] & 0xf0 | data[8] << 8 & 0xf00;
 				int submapper = data[8] >> 4;
-
-				// only add submapper if it is non-zero
-				if (submapper != 0)
-				{
-					CartV2.BoardType = $"MAPPER{mapper:d3}-{submapper:d2}";
-				}
-				else
-				{
-					CartV2.BoardType = $"MAPPER{mapper:d3}";
-				}
-				
+				CartV2.BoardType = $"MAPPER{mapper:d4}-{submapper:d2}";
 
 				int vrambat = iNES2Wram(data[11] >> 4);
 				int vramnon = iNES2Wram(data[11] & 15);


### PR DESCRIPTION
 fixes #3168. 

Skeptical about these changes as I also discovered iNES 2.0 detection ended up producing 4 digits for the board number instead of 3 like iNES 1.0 does. I assume 3 digits is the intended width (otherwise iNES 2.0 seems to just be useless?). Not sure if this is correct however. EDIT: Might be related to https://github.com/TASEmulators/BizHawk/issues/3082#issuecomment-1017690152