### PR TITLE
[WIP] Make input callbacks actually useful by passing gamepad index

### DIFF
--- a/src/BizHawk.Client.Common/lua/INamedLuaFunction.cs
+++ b/src/BizHawk.Client.Common/lua/INamedLuaFunction.cs
@@ -6,7 +6,7 @@ namespace BizHawk.Client.Common
 {
 	public interface INamedLuaFunction
 	{
-		Action InputCallback { get; }
+		Action<int> InputCallback { get; }
 
 		Guid Guid { get; }
 

--- a/src/BizHawk.Client.Common/lua/NamedLuaFunction.cs
+++ b/src/BizHawk.Client.Common/lua/NamedLuaFunction.cs
@@ -43,7 +43,7 @@ namespace BizHawk.Client.Common
 					logCallback($"error running function attached by the event {Event}\nError message: {ex.Message}");
 				}
 			};
-			InputCallback = () => Callback(Array.Empty<object>());
+			InputCallback = gamepadIndex => Callback(new object[] { gamepadIndex });
 			MemCallback = (addr, val, flags) => Callback(new object[] { addr, val, flags });
 		}
 
@@ -68,7 +68,7 @@ namespace BizHawk.Client.Common
 
 		private Action<object[]> Callback { get; }
 
-		public Action InputCallback { get; }
+		public Action<int> InputCallback { get; }
 
 		public MemoryCallbackDelegate MemCallback { get; }
 

--- a/src/BizHawk.Emulation.Common/Base Implementations/InputCallbackSystem.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/InputCallbackSystem.cs
@@ -9,18 +9,18 @@ namespace BizHawk.Emulation.Common
 	/// by any core
 	/// </summary>
 	/// <seealso cref="IInputCallbackSystem" />
-	public class InputCallbackSystem : List<Action>, IInputCallbackSystem
+	public class InputCallbackSystem : List<Action<int>>, IInputCallbackSystem
 	{
-		public void Call()
+		public void Call(int gamepadIndex)
 		{
 			foreach (var action in this)
 			{
-				action();
+				action(gamepadIndex);
 			}
 		}
 
 		// TODO: these just happen to be all the add/remove methods the client uses, to be thorough the others should be overriden as well
-		public void RemoveAll(IEnumerable<Action> actions)
+		public void RemoveAll(IEnumerable<Action<int>> actions)
 		{
 			var hadAny = this.Any();
 
@@ -34,7 +34,7 @@ namespace BizHawk.Emulation.Common
 			Changes(hadAny, hasAny);
 		}
 
-		public new void Add(Action item)
+		public new void Add(Action<int> item)
 		{
 			var hadAny = this.Any();
 			base.Add(item);
@@ -43,7 +43,7 @@ namespace BizHawk.Emulation.Common
 			Changes(hadAny, hasAny);
 		}
 
-		public new bool Remove(Action item)
+		public new bool Remove(Action<int> item)
 		{
 			var hadAny = this.Any();
 			var result = base.Remove(item);

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryBasedInputCallbackSystem.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryBasedInputCallbackSystem.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Emulation.Common
 	/// </summary>
 	public class MemoryBasedInputCallbackSystem : IInputCallbackSystem
 	{
-		private readonly List<Action> _inputCallbacks = new List<Action>();
+		private readonly List<Action<int>> _inputCallbacks = new();
 
 		public MemoryBasedInputCallbackSystem(IDebuggable debuggableCore, string scope, IEnumerable<uint> addresses)
 		{
@@ -39,36 +39,36 @@ namespace BizHawk.Emulation.Common
 		{
 			foreach (var action in _inputCallbacks)
 			{
-				action.Invoke();
+				action.Invoke(0);
 			}
 		}
 
-		public IEnumerator<Action> GetEnumerator() => _inputCallbacks.GetEnumerator();
+		public IEnumerator<Action<int>> GetEnumerator() => _inputCallbacks.GetEnumerator();
 
 		IEnumerator IEnumerable.GetEnumerator() => _inputCallbacks.GetEnumerator();
 
-		public void Add(Action item) => _inputCallbacks.Add(item);
+		public void Add(Action<int> item) => _inputCallbacks.Add(item);
 
 		public void Clear()
 		{
 			_inputCallbacks.Clear();
 		}
 
-		public bool Contains(Action item) => _inputCallbacks.Contains(item);
+		public bool Contains(Action<int> item) => _inputCallbacks.Contains(item);
 
-		public void CopyTo(Action[] array, int arrayIndex) => _inputCallbacks.CopyTo(array, arrayIndex);
+		public void CopyTo(Action<int>[] array, int arrayIndex) => _inputCallbacks.CopyTo(array, arrayIndex);
 
-		public bool Remove(Action item) => _inputCallbacks.Remove(item);
+		public bool Remove(Action<int> item) => _inputCallbacks.Remove(item);
 
 		public int Count => _inputCallbacks.Count;
 		public bool IsReadOnly => false;
 
-		public void Call()
+		public void Call(int gamepadIndex)
 		{
 			throw new InvalidOperationException("This implementation does not require being called directly");
 		}
 
-		public void RemoveAll(IEnumerable<Action> actions)
+		public void RemoveAll(IEnumerable<Action<int>> actions)
 		{
 			foreach (var action in actions)
 			{

--- a/src/BizHawk.Emulation.Common/Interfaces/IInputCallbackSystem.cs
+++ b/src/BizHawk.Emulation.Common/Interfaces/IInputCallbackSystem.cs
@@ -8,16 +8,17 @@ namespace BizHawk.Emulation.Common
 	/// gets and sets input callbacks in the core.  An input callback should fire any time input is
 	/// polled by the core
 	/// </summary>
-	public interface IInputCallbackSystem : ICollection<Action>
+	public interface IInputCallbackSystem : ICollection<Action<int>>
 	{
 		/// <summary>
 		/// Will iterate and call every callback
 		/// </summary>
-		void Call();
+		/// <param name="gamepadIndex">1-indexed</param>
+		void Call(int gamepadIndex);
 
 		/// <summary>
 		/// Will remove the given list of callbacks
 		/// </summary>
-		void RemoveAll(IEnumerable<Action> actions);
+		void RemoveAll(IEnumerable<Action<int>> actions);
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Calculators/Emu83/Emu83.cs
+++ b/src/BizHawk.Emulation.Cores/Calculators/Emu83/Emu83.cs
@@ -87,7 +87,7 @@ namespace BizHawk.Emulation.Cores.Calculators.Emu83
 
 		private byte ReadKeyboard(byte _keyboardMask)
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 
 			// ref TI-9X
 			int ret = 0xFF;

--- a/src/BizHawk.Emulation.Cores/Calculators/TI83/TI83.cs
+++ b/src/BizHawk.Emulation.Cores/Calculators/TI83/TI83.cs
@@ -270,7 +270,7 @@ namespace BizHawk.Emulation.Cores.Calculators.TI83
 
 		private byte ReadKeyboard()
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 
 			// ref TI-9X
 			int ret = 0xFF;

--- a/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/Machine/CPCBase.Input.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/Machine/CPCBase.Input.cs
@@ -45,7 +45,7 @@
 		/// </summary>
 		public void PollInput()
 		{
-			CPC.InputCallbacks.Call();
+			CPC.InputCallbacks.Call(1);
 
 			lock (this)
 			{

--- a/src/BizHawk.Emulation.Cores/Computers/AppleII/AppleII.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/AppleII/AppleII.cs
@@ -209,7 +209,7 @@ namespace BizHawk.Emulation.Cores.Computers.AppleII
 					MemoryCallbacks.CallMemoryCallbacks(addr, 0, flags, "System Bus");
 				}
 			};
-			_machine.Memory.InputCallback = InputCallbacks.Call;
+			_machine.Memory.InputCallback = () => InputCallbacks.Call(1);
 		}
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/C64.MotherboardInput.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/C64.MotherboardInput.cs
@@ -28,7 +28,7 @@
 
 		public void PollInput()
 		{
-			_c64.InputCallbacks.Call();
+			_c64.InputCallbacks.Call(1);
 
 			// scan joysticks
 			_pollIndex = 0;

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/SpectrumBase.Input.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/SpectrumBase.Input.cs
@@ -48,7 +48,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 		/// </summary>
 		public void PollInput()
 		{
-			Spectrum.InputCallbacks.Call();
+			Spectrum.InputCallbacks.Call(1);
 
 			lock (this)
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.Core.cs
@@ -326,7 +326,7 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal byte ReadControls1(bool peek)
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 			
 			byte value = _controllerDeck.ReadPort1(_controller);
 
@@ -341,7 +341,7 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal byte ReadControls2(bool peek)
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(2);
 			byte value = _controllerDeck.ReadPort2(_controller);
 
 			if (!peek)

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.IEmulator.cs
@@ -249,17 +249,18 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 
 		public void GetControllerState(IController controller)
 		{
-			InputCallbacks.Call();
-
+			InputCallbacks.Call(1);
 			p1_state = _controllerDeck.ReadPort1(controller);
-			p2_state = _controllerDeck.ReadPort2(controller);
 			p1_fire = _controllerDeck.ReadFire1(controller);
-			p2_fire = _controllerDeck.ReadFire2(controller);
 			p1_fire_2x = _controllerDeck.ReadFire1_2x(controller);
-			p2_fire_2x = _controllerDeck.ReadFire2_2x(controller);
 			p1_is_2button = _controllerDeck.Is_2_button1(controller);
-			p2_is_2button = _controllerDeck.Is_2_button2(controller);
 			p1_is_lightgun = _controllerDeck.Is_LightGun1(controller, out p1_lightgun_x, out p1_lightgun_y);
+
+			InputCallbacks.Call(2);
+			p2_state = _controllerDeck.ReadPort2(controller);
+			p2_fire = _controllerDeck.ReadFire2(controller);
+			p2_fire_2x = _controllerDeck.ReadFire2_2x(controller);
+			p2_is_2button = _controllerDeck.Is_2_button2(controller);
 			p2_is_lightgun = _controllerDeck.Is_LightGun2(controller, out p2_lightgun_x, out p2_lightgun_y);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.InputPollable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.InputPollable.cs
@@ -29,8 +29,6 @@ namespace BizHawk.Emulation.Cores.Consoles.ChannelF
 		{
 			bool noInput = true;
 
-			InputCallbacks.Call();
-
 			lock (this)
 			{
 				for (int i = 0; i < ButtonsConsole.Length; i++)
@@ -55,6 +53,7 @@ namespace BizHawk.Emulation.Cores.Consoles.ChannelF
 					}
 				}
 
+				InputCallbacks.Call(1);
 				for (int i = 0; i < ButtonsRight.Length; i++)
 				{
 					var key = "P1 " + ButtonsRight[i];
@@ -67,6 +66,7 @@ namespace BizHawk.Emulation.Cores.Consoles.ChannelF
 					}
 				}
 
+				InputCallbacks.Call(2);
 				for (int i = 0; i < ButtonsLeft.Length; i++)
 				{
 					var key = "P2 " + ButtonsLeft[i];

--- a/src/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.cs
@@ -111,11 +111,11 @@ namespace BizHawk.Emulation.Cores.Intellivision
 
 		private void GetControllerState(IController controller)
 		{
-			InputCallbacks.Call();
-
+			InputCallbacks.Call(1);
 			ushort port1 = _controllerDeck.ReadPort1(controller);
 			_psg.Register[15] = (ushort)(0xFF - port1);
 
+			InputCallbacks.Call(2);
 			ushort port2 = _controllerDeck.ReadPort2(controller);
 			_psg.Register[14] = (ushort)(0xFF - port2);
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IEmulator.cs
@@ -123,8 +123,9 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 
 		public void GetControllerState(IController controller)
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 			controller_state_1 = _controllerDeck.ReadPort1(controller);
+			InputCallbacks.Call(2);
 			controller_state_2 = _controllerDeck.ReadPort2(controller);
 
 			kb_state_row = 8; // nothing pressed

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.cs
@@ -212,7 +212,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 
 		private void snes_controller_latch()
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(99); //TODO
 		}
 
 		private readonly int[] palette = new int[0x8000];

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IInputPollable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IInputPollable.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 		private void InputCb()
 		{
 			// most things are already handled in the core, this is just for event.oninputpoll
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 		}
 		private InputCallbackSystem _inputCallbacks = new InputCallbackSystem();
 		public IInputCallbackSystem InputCallbacks => _inputCallbacks;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IEmulator.cs
@@ -356,7 +356,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 
 		public void GetControllerState(IController controller)
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 			controller_state = _controllerDeck.ReadPort1(controller);
 			(Acc_X_state, Acc_Y_state) = _controllerDeck.ReadAcc1(controller);
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IEmulator.cs
@@ -218,8 +218,9 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 
 		public void GetControllerState(IController controller)
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 			L_controller = _controllerDeck.ReadPort1(controller);
+			InputCallbacks.Call(2);
 			R_controller = _controllerDeck.ReadPort2(controller);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IEmulator.cs
@@ -412,9 +412,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 
 		public void GetControllerState(IController controller)
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 			L_controller = _controllerDeck.ReadPort1(controller);
+			InputCallbacks.Call(2);
 			C_controller = _controllerDeck.ReadPort2(controller);
+			InputCallbacks.Call(3);
 			R_controller = _controllerDeck.ReadPort3(controller);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IEmulator.cs
@@ -990,10 +990,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 
 		public void GetControllerState(IController controller)
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 			A_controller = _controllerDeck.ReadPort1(controller);
+			InputCallbacks.Call(2);
 			B_controller = _controllerDeck.ReadPort2(controller);
+			InputCallbacks.Call(3);
 			C_controller = _controllerDeck.ReadPort3(controller);
+			InputCallbacks.Call(4);
 			D_controller = _controllerDeck.ReadPort4(controller);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
@@ -277,7 +277,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 
 		private LibGambatte.Buttons ControllerCallback(IntPtr p)
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(99); //TODO
 			IsLagFrame = false;
 			if (IsSgb)
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64Input.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64Input.cs
@@ -46,7 +46,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 		/// <param name="i">Id of controller to update and shove</param>
 		public int GetControllerInput(int i)
 		{
-			_emuCore.InputCallbacks.Call();
+			_emuCore.InputCallbacks.Call(i + 1);
 			ThisFrameInputPolled = true;
 
 			// Analog stick right = +X

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -850,7 +850,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			{
 				controller_was_latched = true;
 				lagged = false;
-				InputCallbacks.Call();
+				InputCallbacks.Call(99); //TODO
 			}
 			current_strobe = new_strobe;
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SameBoy/SameBoy.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SameBoy/SameBoy.cs
@@ -137,7 +137,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Sameboy
 		private void InputCallback()
 		{
 			IsLagFrame = false;
-			_inputCallbacks.Call();
+			_inputCallbacks.Call(1);
 		}
 
 		public bool LinkConnected

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubGBHawk/SubGBHawk.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubGBHawk/SubGBHawk.IEmulator.cs
@@ -53,7 +53,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubGBHawk
 			pass_a_frame = false;
 			_GBCore._islag = false;
 
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 
 			DoFrame(controller);
 

--- a/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.Input.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.Input.cs
@@ -28,10 +28,10 @@
 
 		private byte ReadInput()
 		{
-			InputCallbacks.Call();
+			int player = _selectedController + 1;
+			InputCallbacks.Call(player);
 			byte value = 0x3F;
 
-			int player = _selectedController + 1;
 			if (player < 6)
 			{
 				_lagged = false;

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IEmulator.cs
@@ -262,10 +262,12 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 
 		public void GetControllerState(IController controller)
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 			L.cntr_rd_0 = (byte)(controller.IsPressed("P1 Start") ? 0x7F : 0xFF);
 			L.cntr_rd_1 = _controllerDeck.ReadPort1(controller);
 			L.cntr_rd_2 = 0xFF;
+
+			InputCallbacks.Call(2);
 			R.cntr_rd_0 = (byte)(controller.IsPressed("P2 Start") ? 0x7F : 0xFF);
 			R.cntr_rd_1 = _controllerDeck.ReadPort2(controller);
 			R.cntr_rd_2 = 0xFF;

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.Input.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.Input.cs
@@ -25,7 +25,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 
 		private byte ReadControls1()
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 			_lagged = false;
 			byte value = 0xFF;
 
@@ -62,7 +62,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 
 		private byte ReadControls2()
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(2);
 			_lagged = false;
 			byte value = 0xFF;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IInputPollable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IInputPollable.cs
@@ -16,7 +16,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 
 		private void input_callback()
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(99); //TODO
 			IsLagFrame = false;
 		}
 	}

--- a/src/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.cs
@@ -165,7 +165,7 @@ namespace BizHawk.Emulation.Cores.WonderSwan
 
 		private void ButtonCallback()
 		{
-			InputCallbacks.Call();
+			InputCallbacks.Call(1);
 		}
 
 		private void InitDebugCallbacks()

--- a/src/BizHawk.Emulation.Cores/Waterbox/WaterboxCore.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/WaterboxCore.cs
@@ -40,7 +40,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			_serviceProvider = new BasicServiceProvider(this);
 			SystemId = c.SystemId;
 			CoreComm = comm;
-			_inputCallback = InputCallbacks.Call;
+			_inputCallback = () => InputCallbacks.Call(99); //TODO
 		}
 
 		protected T PreInit<T>(WaterboxOptions options, IEnumerable<Delegate> allExtraDelegates = null)


### PR DESCRIPTION
A check in the Impl. column indicates that the core's `IInputPollable` implementation has been updated i.e. to call `InputCallbacks.Call(int)` with a meaningful parameter. Cores which aren't `IInputPollable` or which implemented `IInputPollable.InputCallbacks` as a throw are not included in the table.

Core | Impl. | Field-tested
--:|:-:|:-:
A7800Hawk | ☑ | ☐
Atari2600Hawk | ☑ | ☐
BSNESv115+ | ☐ | ☐
C64Hawk | ☑ | ☐
CPCHawk | ☑ | ☐
ChannelFHawk | ☑ | ☐
Cygne | ☑ | ☐
Emu83 | ☑ | ☐
GBHawk | ☑ | ☐
GBHawkLink | ☑ | ☐
GBHawkLink3x | ☑ | ☐
GBHawkLink4x | ☑ | ☐
GGHawkLink | ☑ | ☐
Gambatte | ☐ | ☐
Genplus-gx | ☐ | ☐
IntelliHawk | ☑ | ☐
mGBA | ☑ | ☐
Mupen64Plus | ☑ | ☐
NesHawk | ☐ | ☐
O2Hawk | ☑ | ☐
PCEHawk | ☑ | ☐
SMSHawk | ☑ | ☐
SameBoy | ☑ | ☐
SubGBHawk | ☑ | ☐
TI83Hawk | ☑ | ☐
Virtu | ☑ | ☐
All Waterbox cores | ☐ | ☐
ZXHawk | ☑ | ☐

Notes:
- (Old) BSNES instantiates a `InputCallbackSystem` but never triggers it?
- Not sure if GambatteLink re-uses Gambatte implementation.
- Callback with param n should be immediately before player n is processed. If there is conceptually a player 0, either system/disc controls or a keyboard, those may be processed before or after the callback for player 1.
- Markdown checkboxes don't work in tables >:(