### PR TITLE
Support editing nyma settings without the core loaded

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -62,6 +62,7 @@ using BizHawk.Emulation.Cores.Sega.GGHawkLink;
 using BizHawk.Emulation.Cores.Sega.MasterSystem;
 using BizHawk.Emulation.Cores.Sony.PS2;
 using BizHawk.Emulation.Cores.Sony.PSX;
+using BizHawk.Emulation.Cores.Waterbox;
 using BizHawk.Emulation.Cores.WonderSwan;
 using BizHawk.WinForms.Controls;
 
@@ -1898,6 +1899,10 @@ namespace BizHawk.Client.EmuHawk
 			OpenGenericCoreConfig($"{coreName} Settings");
 		}
 
+		private DialogResult OpenNymaConfigFor<T>(NymaCore.NymaSettingsInfo settingsInfo)
+			where T : IEmulator
+			=> GenericCoreConfig.DoNymaDialogFor(this, GetSettingsAdapterFor<T>(), settingsInfo, isMovieActive: MovieSession.Movie.IsActive());
+
 		private DialogResult OpenVirtuSettingsDialog()
 			=> OpenGenericCoreConfigFor<AppleII>("Apple II Settings");
 
@@ -2821,9 +2826,8 @@ namespace BizHawk.Client.EmuHawk
 			items.Add(CreateCoreSubmenu(VSystemCategory.Other, CoreNames.Emu83, CreateSettingsItem("Palette...", (_, _) => OpenTI83PaletteSettingsDialog(GetSettingsAdapterFor<Emu83>()))));
 
 			// Faust
-			var faustSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenGenericCoreConfig($"{CoreNames.Faust} Settings"));
+			var faustSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenNymaConfigFor<Faust>(Faust.CachedSettingsInfo(CreateCoreComm())));
 			var faustSubmenu = CreateCoreSubmenu(VSystemCategory.Consoles, CoreNames.Faust, faustSettingsItem);
-			faustSubmenu.DropDownOpened += (_, _) => faustSettingsItem.Enabled = Emulator is Faust;
 			items.Add(faustSubmenu);
 
 			// Gambatte
@@ -2869,9 +2873,8 @@ namespace BizHawk.Client.EmuHawk
 			items.Add(CreateCoreSubmenu(VSystemCategory.Handhelds, CoreNames.Handy, CreateGenericCoreConfigItem<Lynx>(CoreNames.Handy))); // as Handy doesn't implement `IStatable<,>`, this opens an empty `GenericCoreConfig`, which is dumb, but matches the existing behaviour
 
 			// HyperNyma
-			var hyperNymaSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenGenericCoreConfig($"{CoreNames.HyperNyma} Settings"));
+			var hyperNymaSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenNymaConfigFor<HyperNyma>(HyperNyma.CachedSettingsInfo(CreateCoreComm())));
 			var hyperNymaSubmenu = CreateCoreSubmenu(VSystemCategory.Consoles, CoreNames.HyperNyma, hyperNymaSettingsItem);
-			hyperNymaSubmenu.DropDownOpened += (_, _) => hyperNymaSettingsItem.Enabled = Emulator is HyperNyma;
 			items.Add(hyperNymaSubmenu);
 
 			// IntelliHawk
@@ -2934,9 +2937,8 @@ namespace BizHawk.Client.EmuHawk
 			items.Add(mupen64PlusSubmenu);
 
 			// NeoPop
-			var neoPopSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenGenericCoreConfig($"{CoreNames.NeoPop} Settings"));
+			var neoPopSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenNymaConfigFor<NeoGeoPort>(NeoGeoPort.CachedSettingsInfo(CreateCoreComm())));
 			var neoPopSubmenu = CreateCoreSubmenu(VSystemCategory.Handhelds, CoreNames.NeoPop, neoPopSettingsItem);
-			neoPopSubmenu.DropDownOpened += (_, _) => neoPopSettingsItem.Enabled = Emulator is NeoGeoPort;
 			items.Add(neoPopSubmenu);
 
 			// NesHawk
@@ -2962,9 +2964,8 @@ namespace BizHawk.Client.EmuHawk
 			items.Add(nesHawkSubmenu);
 
 			// Nymashock
-			var nymashockSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenGenericCoreConfig($"{CoreNames.Nymashock} Settings"));
+			var nymashockSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenNymaConfigFor<Nymashock>(Nymashock.CachedSettingsInfo(CreateCoreComm())));
 			var nymashockSubmenu = CreateCoreSubmenu(VSystemCategory.Consoles, CoreNames.Nymashock, nymashockSettingsItem);
-			nymashockSubmenu.DropDownOpened += (_, _) => nymashockSettingsItem.Enabled = Emulator is Nymashock;
 			items.Add(nymashockSubmenu);
 
 			// O2Hawk
@@ -3008,9 +3009,8 @@ namespace BizHawk.Client.EmuHawk
 			items.Add(sameBoySubmenu);
 
 			// Saturnus
-			var saturnusSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenGenericCoreConfig($"{CoreNames.Saturnus} Settings"));
+			var saturnusSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenNymaConfigFor<Saturnus>(Saturnus.CachedSettingsInfo(CreateCoreComm())));
 			var saturnusSubmenu = CreateCoreSubmenu(VSystemCategory.Consoles, CoreNames.Saturnus, saturnusSettingsItem);
-			saturnusSubmenu.DropDownOpened += (_, _) => saturnusSettingsItem.Enabled = Emulator is Saturnus;
 			items.Add(saturnusSubmenu);
 
 			// SMSHawk
@@ -3049,15 +3049,13 @@ namespace BizHawk.Client.EmuHawk
 			items.Add(CreateCoreSubmenu(VSystemCategory.Other, CoreNames.TI83Hawk, CreateSettingsItem("Palette...", (_, _) => OpenTI83PaletteSettingsDialog(GetSettingsAdapterFor<TI83>()))));
 
 			// T. S. T.
-			var tstSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenGenericCoreConfig($"{CoreNames.TST} Settings"));
+			var tstSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenNymaConfigFor<Tst>(Tst.CachedSettingsInfo(CreateCoreComm())));
 			var tstSubmenu = CreateCoreSubmenu(VSystemCategory.Consoles, CoreNames.TST, tstSettingsItem);
-			tstSubmenu.DropDownOpened += (_, _) => tstSettingsItem.Enabled = Emulator is Tst;
 			items.Add(tstSubmenu);
 
 			// TurboNyma
-			var turboNymaSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenGenericCoreConfig($"{CoreNames.TurboNyma} Settings"));
+			var turboNymaSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenNymaConfigFor<TurboNyma>(TurboNyma.CachedSettingsInfo(CreateCoreComm())));
 			var turboNymaSubmenu = CreateCoreSubmenu(VSystemCategory.Consoles, CoreNames.TurboNyma, turboNymaSettingsItem);
-			turboNymaSubmenu.DropDownOpened += (_, _) => turboNymaSettingsItem.Enabled = Emulator is TurboNyma;
 			items.Add(turboNymaSubmenu);
 
 			// uzem
@@ -3072,9 +3070,8 @@ namespace BizHawk.Client.EmuHawk
 			items.Add(virtuSubmenu);
 
 			// Virtual Boyee
-			var virtualBoyeeSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenGenericCoreConfig($"{CoreNames.VirtualBoyee} Settings"));
+			var virtualBoyeeSettingsItem = CreateSettingsItem("Settings...", (_, _) => OpenNymaConfigFor<VirtualBoyee>(VirtualBoyee.CachedSettingsInfo(CreateCoreComm())));
 			var virtualBoyeeSubmenu = CreateCoreSubmenu(VSystemCategory.Consoles, CoreNames.VirtualBoyee, virtualBoyeeSettingsItem);
-			virtualBoyeeSubmenu.DropDownOpened += (_, _) => virtualBoyeeSettingsItem.Enabled = Emulator is VirtualBoyee;
 			items.Add(virtualBoyeeSubmenu);
 
 			// ZXHawk

--- a/src/BizHawk.Client.EmuHawk/config/GenericCoreConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/GenericCoreConfig.cs
@@ -137,6 +137,31 @@ namespace BizHawk.Client.EmuHawk
 			return owner.ShowDialogAsChild(dlg);
 		}
 
+		public static DialogResult DoNymaDialogFor(
+			IDialogParent owner,
+			ISettingsAdapter settable,
+			Emulation.Cores.Waterbox.NymaCore.NymaSettingsInfo settingsInfo,
+			bool isMovieActive)
+		{
+			var desc = new Emulation.Cores.Waterbox.NymaTypeDescriptorProvider(settingsInfo);
+			try
+			{
+				// OH GOD THE HACKS WHY
+				TypeDescriptor.AddProvider(desc, typeof(Emulation.Cores.Waterbox.NymaCore.NymaSettings));
+				TypeDescriptor.AddProvider(desc, typeof(Emulation.Cores.Waterbox.NymaCore.NymaSyncSettings));
+				using GenericCoreConfig dlg = new(settable, isMovieActive, !settingsInfo.HasSettings, !settingsInfo.HasSyncSettings)
+				{
+					Text = "Nyma Core"
+				};
+				return owner.ShowDialogAsChild(dlg);
+			}
+			finally
+			{
+				TypeDescriptor.RemoveProvider(desc, typeof(Emulation.Cores.Waterbox.NymaCore.NymaSettings));
+				TypeDescriptor.RemoveProvider(desc, typeof(Emulation.Cores.Waterbox.NymaCore.NymaSyncSettings));
+			}
+		}
+
 		private void PropertyGrid2_PropertyValueChanged(object s, PropertyValueChangedEventArgs e)
 		{
 			_syncSettingsChanged = true;

--- a/src/BizHawk.Emulation.Cores/Consoles/NEC/PCE/HyperNyma.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/NEC/PCE/HyperNyma.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+
 using BizHawk.BizInvoke;
 using BizHawk.Common;
 using BizHawk.Emulation.Common;
@@ -12,6 +13,25 @@ namespace BizHawk.Emulation.Cores.Consoles.NEC.PCE
 	[PortedCore(CoreNames.HyperNyma, "Mednafen Team", "1.29.0", "https://mednafen.github.io/releases/")]
 	public class HyperNyma : NymaCore, IRegionable, IPceGpuView
 	{
+		private HyperNyma(CoreComm comm)
+			: base(comm, null, null, null, null)
+		{
+		}
+
+		private static NymaSettingsInfo _cachedSettingsInfo;
+
+		public static NymaSettingsInfo CachedSettingsInfo(CoreComm comm)
+		{
+			if (_cachedSettingsInfo is null)
+			{
+				using var n = new HyperNyma(comm);
+				n.InitForSettingsInfo("hyper.wbx");
+				_cachedSettingsInfo = n.SettingsInfo.Clone();
+			}
+
+			return _cachedSettingsInfo;
+		}
+
 		private readonly LibHyperNyma _hyperNyma;
 		private readonly bool _hasCds;
 
@@ -29,6 +49,11 @@ namespace BizHawk.Emulation.Cores.Consoles.NEC.PCE
 			}
 
 			_hyperNyma = DoInit<LibHyperNyma>(lp, "hyper.wbx", firmwares);
+
+			if (_cachedSettingsInfo is null)
+			{
+				_cachedSettingsInfo = SettingsInfo.Clone();
+			}
 		}
 
 		public override string SystemId => IsSgx

--- a/src/BizHawk.Emulation.Cores/Consoles/NEC/PCE/TurboNyma.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/NEC/PCE/TurboNyma.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+
 using BizHawk.BizInvoke;
 using BizHawk.Common;
 using BizHawk.Emulation.Common;
@@ -14,6 +15,25 @@ namespace BizHawk.Emulation.Cores.Consoles.NEC.PCE
 	[PortedCore(CoreNames.TurboNyma, "Mednafen Team", "1.29.0", "https://mednafen.github.io/releases/")]
 	public class TurboNyma : NymaCore, IRegionable, IPceGpuView
 	{
+		private TurboNyma(CoreComm comm)
+			: base(comm, null, null, null, null)
+		{
+		}
+
+		private static NymaSettingsInfo _cachedSettingsInfo;
+
+		public static NymaSettingsInfo CachedSettingsInfo(CoreComm comm)
+		{
+			if (_cachedSettingsInfo is null)
+			{
+				using var n = new TurboNyma(comm);
+				n.InitForSettingsInfo("turbo.wbx");
+				_cachedSettingsInfo = n.SettingsInfo.Clone();
+			}
+
+			return _cachedSettingsInfo;
+		}
+
 		private readonly LibTurboNyma _turboNyma;
 		private readonly bool _hasCds;
 
@@ -40,6 +60,11 @@ namespace BizHawk.Emulation.Cores.Consoles.NEC.PCE
 			}
 
 			_turboNyma = DoInit<LibTurboNyma>(lp, "turbo.wbx", firmwares);
+
+			if (_cachedSettingsInfo is null)
+			{
+				_cachedSettingsInfo = SettingsInfo.Clone();
+			}
 		}
 
 		public override string SystemId => IsSgx

--- a/src/BizHawk.Emulation.Cores/Consoles/NEC/PCFX/Tst.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/NEC/PCFX/Tst.cs
@@ -1,13 +1,33 @@
-﻿using BizHawk.Emulation.Common;
-using BizHawk.Emulation.Cores.Waterbox;
-using System;
+﻿using System;
 using System.Collections.Generic;
+
+using BizHawk.Emulation.Common;
+using BizHawk.Emulation.Cores.Waterbox;
 
 namespace BizHawk.Emulation.Cores.Consoles.NEC.PCFX
 {
 	[PortedCore(CoreNames.TST, "Mednafen Team", "1.29.0", "https://mednafen.github.io/releases/")]
 	public class Tst : NymaCore
 	{
+		private Tst(CoreComm comm)
+			: base(comm, null, null, null, null)
+		{
+		}
+
+		private static NymaSettingsInfo _cachedSettingsInfo;
+
+		public static NymaSettingsInfo CachedSettingsInfo(CoreComm comm)
+		{
+			if (_cachedSettingsInfo is null)
+			{
+				using var n = new Tst(comm);
+				n.InitForSettingsInfo("pcfx.wbx");
+				_cachedSettingsInfo = n.SettingsInfo.Clone();
+			}
+
+			return _cachedSettingsInfo;
+		}
+
 		[CoreConstructor(VSystemID.Raw.PCFX)]
 		public Tst(CoreLoadParameters<NymaSettings, NymaSyncSettings> lp)
 			: base(lp.Comm, VSystemID.Raw.PCFX, "PC-FX Controller", lp.Settings, lp.SyncSettings)
@@ -20,6 +40,11 @@ namespace BizHawk.Emulation.Cores.Consoles.NEC.PCFX
 			};
 
 			DoInit<LibNymaCore>(lp, "pcfx.wbx", firmwares);
+
+			if (_cachedSettingsInfo is null)
+			{
+				_cachedSettingsInfo = SettingsInfo.Clone();
+			}
 		}
 
 		protected override IDictionary<string, SettingOverride> SettingOverrides { get; } = new Dictionary<string, SettingOverride>

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Faust/Faust.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Faust/Faust.cs
@@ -7,6 +7,25 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.Faust
 	[PortedCore(CoreNames.Faust, "Mednafen Team", "1.29.0", "https://mednafen.github.io/releases/")]
 	public class Faust : NymaCore, IRegionable
 	{
+		private Faust(CoreComm comm)
+			: base(comm, null, null, null, null)
+		{
+		}
+
+		private static NymaSettingsInfo _cachedSettingsInfo;
+
+		public static NymaSettingsInfo CachedSettingsInfo(CoreComm comm)
+		{
+			if (_cachedSettingsInfo is null)
+			{
+				using var n = new Faust(comm);
+				n.InitForSettingsInfo("faust.wbx");
+				_cachedSettingsInfo = n.SettingsInfo.Clone();
+			}
+
+			return _cachedSettingsInfo;
+		}
+
 		[CoreConstructor(VSystemID.Raw.SNES)]
 		public Faust(GameInfo game, byte[] rom, CoreComm comm, string extension,
 			NymaSettings settings, NymaSyncSettings syncSettings, bool deterministic)
@@ -17,6 +36,11 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.Faust
 				SettingOverrides.Add("snes_faust.renderer", new() { Hide = true, Default = "0" });
 
 			DoInit<LibNymaCore>(game, rom, null, "faust.wbx", extension, deterministic);
+
+			if (_cachedSettingsInfo is null)
+			{
+				_cachedSettingsInfo = SettingsInfo.Clone();
+			}
 		}
 
 		protected override HashSet<string> ComputeHiddenPorts()

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/VB/VirtualBoyee.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/VB/VirtualBoyee.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.Waterbox;
@@ -9,11 +8,35 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.VB
 	[PortedCore(CoreNames.VirtualBoyee, "Mednafen Team", "1.29.0", "https://mednafen.github.io/releases/")]
 	public class VirtualBoyee : NymaCore
 	{
+		private VirtualBoyee(CoreComm comm)
+			: base(comm, null, null, null, null)
+		{
+		}
+
+		private static NymaSettingsInfo _cachedSettingsInfo;
+
+		public static NymaSettingsInfo CachedSettingsInfo(CoreComm comm)
+		{
+			if (_cachedSettingsInfo is null)
+			{
+				using var n = new VirtualBoyee(comm);
+				n.InitForSettingsInfo("vb.wbx");
+				_cachedSettingsInfo = n.SettingsInfo.Clone();
+			}
+
+			return _cachedSettingsInfo;
+		}
+
 		[CoreConstructor(VSystemID.Raw.VB)]
 		public VirtualBoyee(CoreLoadParameters<NymaSettings, NymaSyncSettings> lp)
 			: base(lp.Comm, VSystemID.Raw.VB, "VirtualBoy Controller", lp.Settings, lp.SyncSettings)
 		{
 			DoInit<LibNymaCore>(lp, "vb.wbx");
+
+			if (_cachedSettingsInfo is null)
+			{
+				_cachedSettingsInfo = SettingsInfo.Clone();
+			}
 		}
 
 		protected override IDictionary<string, SettingOverride> SettingOverrides { get; } = new Dictionary<string, SettingOverride>

--- a/src/BizHawk.Emulation.Cores/Consoles/SNK/NeoGeoPort.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/SNK/NeoGeoPort.cs
@@ -1,7 +1,8 @@
-﻿using BizHawk.Emulation.Common;
-using BizHawk.Emulation.Cores.Waterbox;
-using System;
+﻿using System;
 using System.Collections.Generic;
+
+using BizHawk.Emulation.Common;
+using BizHawk.Emulation.Cores.Waterbox;
 
 namespace BizHawk.Emulation.Cores.Consoles.SNK
 {
@@ -9,6 +10,25 @@ namespace BizHawk.Emulation.Cores.Consoles.SNK
 	public class NeoGeoPort : NymaCore,
 		ISaveRam // NGP provides its own saveram interface
 	{
+		private NeoGeoPort(CoreComm comm)
+			: base(comm, null, null, null, null)
+		{
+		}
+
+		private static NymaSettingsInfo _cachedSettingsInfo;
+
+		public static NymaSettingsInfo CachedSettingsInfo(CoreComm comm)
+		{
+			if (_cachedSettingsInfo is null)
+			{
+				using var n = new NeoGeoPort(comm);
+				n.InitForSettingsInfo("ngp.wbx");
+				_cachedSettingsInfo = n.SettingsInfo.Clone();
+			}
+
+			return _cachedSettingsInfo;
+		}
+
 		private readonly LibNeoGeoPort _neopop;
 
 		[CoreConstructor(VSystemID.Raw.NGP)]
@@ -17,6 +37,11 @@ namespace BizHawk.Emulation.Cores.Consoles.SNK
 			: base(comm, VSystemID.Raw.NGP, "NeoGeo Portable Controller", settings, syncSettings)
 		{
 			_neopop = DoInit<LibNeoGeoPort>(game, rom, null, "ngp.wbx", extension, deterministic);
+
+			if (_cachedSettingsInfo is null)
+			{
+				_cachedSettingsInfo = SettingsInfo.Clone();
+			}
 		}
 
 		public new bool SaveRamModified

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/Saturn/Saturnus.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/Saturn/Saturnus.cs
@@ -1,13 +1,33 @@
-﻿using BizHawk.Emulation.Common;
-using BizHawk.Emulation.Cores.Waterbox;
-using System;
+﻿using System;
 using System.Collections.Generic;
+
+using BizHawk.Emulation.Common;
+using BizHawk.Emulation.Cores.Waterbox;
 
 namespace BizHawk.Emulation.Cores.Consoles.Sega.Saturn
 {
 	[PortedCore(CoreNames.Saturnus, "Mednafen Team", "1.29.0", "https://mednafen.github.io/releases/")]
 	public class Saturnus : NymaCore, IRegionable
 	{
+		private Saturnus(CoreComm comm)
+			: base(comm, null, null, null, null)
+		{
+		}
+
+		private static NymaSettingsInfo _cachedSettingsInfo;
+
+		public static NymaSettingsInfo CachedSettingsInfo(CoreComm comm)
+		{
+			if (_cachedSettingsInfo is null)
+			{
+				using var n = new Saturnus(comm);
+				n.InitForSettingsInfo("ss.wbx");
+				_cachedSettingsInfo = n.SettingsInfo.Clone();
+			}
+
+			return _cachedSettingsInfo;
+		}
+
 		[CoreConstructor(VSystemID.Raw.SAT)]
 		public Saturnus(CoreLoadParameters<NymaSettings, NymaSyncSettings> lp)
 			: base(lp.Comm, VSystemID.Raw.SAT, "Saturn Controller", lp.Settings, lp.SyncSettings)
@@ -23,6 +43,11 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.Saturn
 				// { "FIRMWARE:$SATAR", new("SAT", "AR") }, // action replay garbage
 			};
 			DoInit<LibNymaCore>(lp, "ss.wbx", firmwares);
+
+			if (_cachedSettingsInfo is null)
+			{
+				_cachedSettingsInfo = SettingsInfo.Clone();
+			}
 		}
 
 		protected override IDictionary<string, SettingOverride> SettingOverrides { get; } = new Dictionary<string, SettingOverride>

--- a/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Nymashock.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Nymashock.cs
@@ -9,6 +9,25 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 	[PortedCore(CoreNames.Nymashock, "Mednafen Team", "1.29.0", "https://mednafen.github.io/releases/")]
 	public class Nymashock : NymaCore, IRegionable, ICycleTiming
 	{
+		private Nymashock(CoreComm comm)
+			: base(comm, null, null, null, null)
+		{
+		}
+
+		private static NymaSettingsInfo _cachedSettingsInfo;
+
+		public static NymaSettingsInfo CachedSettingsInfo(CoreComm comm)
+		{
+			if (_cachedSettingsInfo is null)
+			{
+				using var n = new Nymashock(comm);
+				n.InitForSettingsInfo("shock.wbx");
+				_cachedSettingsInfo = n.SettingsInfo.Clone();
+			}
+
+			return _cachedSettingsInfo;
+		}
+
 		[CoreConstructor(VSystemID.Raw.PSX)]
 		public Nymashock(CoreLoadParameters<NymaSettings, NymaSyncSettings> lp)
 			: base(lp.Comm, VSystemID.Raw.PSX, "PSX Front Panel", lp.Settings, lp.SyncSettings)
@@ -22,6 +41,11 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 				{ "FIRMWARE:$E", new("PSX", "E") },
 			};
 			DoInit<LibNymaCore>(lp, "shock.wbx", firmwares);
+
+			if (_cachedSettingsInfo is null)
+			{
+				_cachedSettingsInfo = SettingsInfo.Clone();
+			}
 		}
 
 		protected override IDictionary<string, SettingOverride> SettingOverrides { get; } = new Dictionary<string, SettingOverride>

--- a/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.Settings.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.Settings.cs
@@ -263,6 +263,18 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			/// </summary>
 			public bool HasSyncSettings => Ports.Count > 0
 				|| AllSettings.Select(s => AllOverrides[s.SettingsKey]).Any(o => !o.Hide && !o.NonSync);
+
+			public NymaSettingsInfo Clone()
+			{
+				return new NymaSettingsInfo
+				{
+					LayerNames = new(LayerNames ?? new()),
+					Ports = new(Ports ?? new()),
+					AllSettings = new(AllSettings ?? new()),
+					AllSettingsByKey = new(AllSettingsByKey ?? new()),
+					AllOverrides = new(AllOverrides ?? new())
+				};
+			}
 		}
 		private void InitAllSettingsInfo(List<NPortInfoT> allPorts)
 		{

--- a/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.cs
@@ -185,6 +185,31 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			return t;
 		}
 
+		// inits only to get settings info
+		// should only ever be called if no SettingsInfo cache exists statically within the core
+		protected void InitForSettingsInfo(string wbxFilename)
+		{
+			_nyma = PreInit<LibNymaCore>(new WaterboxOptions
+			{
+				Filename = wbxFilename,
+				// todo: maybe make these smaller? not much is going to occur within this core instance...
+				SbrkHeapSizeKB = 1024 * 16,
+				SealedHeapSizeKB = 1024 * 48,
+				InvisibleHeapSizeKB = 1024 * 48,
+				PlainHeapSizeKB = 1024 * 48,
+				MmapHeapSizeKB = 1024 * 48,
+				SkipCoreConsistencyCheck = CoreComm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = CoreComm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
+			});
+
+			using (_exe.EnterExit())
+			{
+				_nyma.PreInit();
+				var portData = GetInputPortsData();
+				InitAllSettingsInfo(portData);
+			}
+		}
+
 		protected override void SaveStateBinaryInternal(BinaryWriter writer)
 		{
 			_controllerAdapter.SaveStateBinary(writer);

--- a/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.cs
@@ -26,6 +26,22 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			_controllerDeckName = controllerDeckName;
 		}
 
+		private WaterboxOptions NymaWaterboxOptions(string wbxFilename)
+		{
+			return new WaterboxOptions
+			{
+				Filename = wbxFilename,
+				// WaterboxHost only saves parts of memory that have changed, so not much to be gained by making these precisely sized
+				SbrkHeapSizeKB = 1024 * 16,
+				SealedHeapSizeKB = 1024 * 48,
+				InvisibleHeapSizeKB = 1024 * 48,
+				PlainHeapSizeKB = 1024 * 48,
+				MmapHeapSizeKB = 1024 * 48,
+				SkipCoreConsistencyCheck = CoreComm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = CoreComm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
+			};
+		}
+
 		private LibNymaCore _nyma;
 		protected T DoInit<T>(
 			CoreLoadParameters<NymaSettings, NymaSyncSettings> lp,
@@ -68,18 +84,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				}
 			});
 
-			var t = PreInit<T>(new WaterboxOptions
-			{
-				Filename = wbxFilename,
-				// WaterboxHost only saves parts of memory that have changed, so not much to be gained by making these precisely sized
-				SbrkHeapSizeKB = 1024 * 16,
-				SealedHeapSizeKB = 1024 * 48,
-				InvisibleHeapSizeKB = 1024 * 48,
-				PlainHeapSizeKB = 1024 * 48,
-				MmapHeapSizeKB = 1024 * 48,
-				SkipCoreConsistencyCheck = CoreComm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = CoreComm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
-			}, new Delegate[] { _settingsQueryDelegate, _cdTocCallback, _cdSectorCallback, firmwareDelegate });
+			var t = PreInit<T>(NymaWaterboxOptions(wbxFilename), new Delegate[] { _settingsQueryDelegate, _cdTocCallback, _cdSectorCallback, firmwareDelegate });
 			_nyma = t;
 
 			using (_exe.EnterExit())
@@ -189,18 +194,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 		// should only ever be called if no SettingsInfo cache exists statically within the core
 		protected void InitForSettingsInfo(string wbxFilename)
 		{
-			_nyma = PreInit<LibNymaCore>(new WaterboxOptions
-			{
-				Filename = wbxFilename,
-				// todo: maybe make these smaller? not much is going to occur within this core instance...
-				SbrkHeapSizeKB = 1024 * 16,
-				SealedHeapSizeKB = 1024 * 48,
-				InvisibleHeapSizeKB = 1024 * 48,
-				PlainHeapSizeKB = 1024 * 48,
-				MmapHeapSizeKB = 1024 * 48,
-				SkipCoreConsistencyCheck = CoreComm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = CoreComm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
-			});
+			_nyma = PreInit<LibNymaCore>(NymaWaterboxOptions(wbxFilename));
 
 			using (_exe.EnterExit())
 			{


### PR DESCRIPTION
The details are icky here. Info on the settings is stored in the unmanaged core. So no matter what a core instance is needed at some point.

Now settings info here should be constant for a given core, so we can cache settings info after the core has been loaded and use that.

If in the case the user wants to edit the settings but the core has never been loaded, a minimal load will be done to obtain the settings (and cache them) and quickly dispose thereafter.

This code could probably be cleaner, but not sure how to do so.