### PR TITLE
Fix KeyLog not being respected in TAStudio

### DIFF
--- a/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
+++ b/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
@@ -21,6 +21,7 @@ namespace BizHawk.Client.Common
 			string newFilename = ConvertFileNameToTasMovie(old.Filename);
 			var tas = (ITasMovie)old.Session.Get(newFilename);
 			tas.CopyLog(old.GetLogEntries());
+			tas.LogKey = old.LogKey;
 
 			old.Truncate(0); // Trying to minimize ram usage
 
@@ -56,6 +57,7 @@ namespace BizHawk.Client.Common
 		{
 			var bk2 = old.Session.Get(old.Filename.Replace(old.PreferredExtension, Bk2Movie.Extension));
 			bk2.CopyLog(old.GetLogEntries());
+			bk2.LogKey = old.LogKey;
 
 			bk2.HeaderEntries.Clear();
 			foreach (var (k, v) in old.HeaderEntries) bk2.HeaderEntries[k] = v;
@@ -95,6 +97,7 @@ namespace BizHawk.Client.Common
 			var entries = old.GetLogEntries();
 
 			tas.CopyLog(entries.Skip(frame));
+			tas.LogKey = old.LogKey;
 			tas.CopyVerificationLog(old.VerificationLog);
 			tas.CopyVerificationLog(entries.Take(frame));
 

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.InputLog.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.InputLog.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-
 using BizHawk.Common;
 
 namespace BizHawk.Client.Common
@@ -8,14 +7,20 @@ namespace BizHawk.Client.Common
 	public partial class Bk2Movie
 	{
 		protected IStringLog Log { get; set; } = StringLogUtil.MakeStringLog();
-		protected string LogKey { get; set; } = "";
+		public string LogKey { get; set; }
 
 		public void WriteInputLog(TextWriter writer)
 		{
 			writer.WriteLine("[Input]");
-
-			var lg = LogGeneratorInstance(Session.MovieController);
-			writer.WriteLine(lg.GenerateLogKey());
+			if (string.IsNullOrEmpty(LogKey))
+			{
+				var lg = LogGeneratorInstance(Session.MovieController);
+				writer.WriteLine(lg.GenerateLogKey());
+			}
+			else
+			{
+				writer.WriteLine($"LogKey:{LogKey}");
+			}
 
 			foreach (var record in Log)
 			{

--- a/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
+++ b/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
@@ -100,6 +100,7 @@ namespace BizHawk.Client.Common
 		string OriginalEmulatorVersion { get; set; }
 		string FirmwareHash { get; set; }
 		string BoardName { get; set; }
+		string LogKey { get; set; }
 
 		/// <summary>
 		/// Loads from the HawkFile the minimal amount of information needed to determine Header info and Movie length.


### PR DESCRIPTION
See: #2843, #2567.

Before, loading a bk2 with a specific `KeyLog` set in TAStudio would just discard it, effectively mis-matching all inputs.
It was possible to craft a .tasproj with a different `KeyLog` by manually editing the `InputLog` file, but on saving the same issue would occur.

I have fixed the `KeyLog` getting discarded in the cases of bk2 -> tasproj, tasproj -> bk2 and saving a tasproj in general.

Here are two files (one .bk2, one .tasproj) that should show the difference in the `InputLog` and what is displayed in TAStudio when loading them:
[Movies.zip](https://github.com/TASEmulators/BizHawk/files/8904678/Movies.zip)

I have tested this and I believe this to work fine, however I would like to get some feedback on whether I may have missed something (or there is a better way of handling the `KeyLog`).