### PR TITLE
A simple boolean check.

### DIFF
--- a/src/BizHawk.Client.Common/BreakpointList.cs
+++ b/src/BizHawk.Client.Common/BreakpointList.cs
@@ -11,7 +11,10 @@ namespace BizHawk.Client.Common
 
 		public void Add(IDebuggable core, string scope, uint address, uint mask, MemoryCallbackType type)
 		{
-			Add(new Breakpoint(core, scope, Callback, address, mask, type));
+			if (!Exists(x => x.Address == address))
+			{
+				Add(new Breakpoint(core, scope, Callback, address, mask, type));
+			}
 		}
 
 		public new void Clear()


### PR DESCRIPTION
Added a simple boolean check to see if an existing breakpoint contains the same address as the one we wanted to add. If none, we go ahead and add the new breakpoint.

Fixes #3287.