### PR TITLE
Increased Basic Bot max frames from 999 to 9999.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
@@ -520,7 +520,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.FrameLengthNumeric.Location = new System.Drawing.Point(60, 25);
 			this.FrameLengthNumeric.Maximum = new decimal(new int[] {
-			999,
+			9999,
 			0,
 			0,
 			0});


### PR DESCRIPTION
Some games, such as River City Ransom EX for the GBA, has an RNG counter period 0x270 to 0x1, which has an average of around 1200 frames to be able to see potential RNG routes to take. "999" is too small for this. I also don't see any issues with increasing the max limit from 999 to 9999.