### PR TITLE
Added NOT operator to Basic Bot.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
@@ -606,7 +606,8 @@ namespace BizHawk.Client.EmuHawk
 			">=",
 			"=",
 			"<=",
-			"<"});
+			"<",
+			"!="});
 			this.MainOperator.Location = new System.Drawing.Point(208, 3);
 			this.MainOperator.Name = "MainOperator";
 			this.MainOperator.Size = new System.Drawing.Size(40, 21);

--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
@@ -252,25 +252,25 @@ namespace BizHawk.Client.EmuHawk
 		public byte MainComparisonType
 		{
 			get => (byte)MainOperator.SelectedIndex;
-			set => MainOperator.SelectedIndex = value < 5 ? value : 0;
+			set => MainOperator.SelectedIndex = value < 6 ? value : 0;
 		}
 
 		public byte Tie1ComparisonType
 		{
 			get => (byte)Tiebreak1Operator.SelectedIndex;
-			set => Tiebreak1Operator.SelectedIndex = value < 5 ? value : 0;
+			set => Tiebreak1Operator.SelectedIndex = value < 6 ? value : 0;
 		}
 
 		public byte Tie2ComparisonType
 		{
 			get => (byte)Tiebreak2Operator.SelectedIndex;
-			set => Tiebreak2Operator.SelectedIndex = value < 5 ? value : 0;
+			set => Tiebreak2Operator.SelectedIndex = value < 6 ? value : 0;
 		}
 
 		public byte Tie3ComparisonType
 		{
 			get => (byte)Tiebreak3Operator.SelectedIndex;
-			set => Tiebreak3Operator.SelectedIndex = value < 5 ? value : 0;
+			set => Tiebreak3Operator.SelectedIndex = value < 6 ? value : 0;
 		}
 
 		public string FromSlot
@@ -956,6 +956,7 @@ namespace BizHawk.Client.EmuHawk
 				2 => (currentValue == bestValue),
 				3 => (currentValue <= bestValue),
 				4 => (currentValue < bestValue),
+				5 => (currentValue != bestValue),
 				_ => false
 			};
 		}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6444116/179145408-6e6b427b-cd48-47ce-a35d-2dd8ff047333.png)

Gave the Basic Bot a NOT operator.

This is useful for cases where we are checking for volatile RAM address values, and we don't want it to be specific to a certain value.