### PR TITLE
Fixed Basic Bot anchor points and one label misalignment

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
@@ -308,8 +308,9 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// BestGroupBox
 			// 
-			this.BestGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-			| System.Windows.Forms.AnchorStyles.Right)));
+			this.BestGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
 			this.BestGroupBox.Controls.Add(this.btnCopyBestInput);
 			this.BestGroupBox.Controls.Add(this.PlayBestButton);
 			this.BestGroupBox.Controls.Add(this.ClearBestButton);
@@ -464,7 +465,7 @@ namespace BizHawk.Client.EmuHawk
 			// label13
 			// 
 			this.label13.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.label13.Location = new System.Drawing.Point(104, 16);
+			this.label13.Location = new System.Drawing.Point(96, 16);
 			this.label13.Name = "label13";
 			this.label13.Text = "Main Value:";
 			// 
@@ -962,7 +963,8 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ControlGroupBox
 			// 
-			this.ControlGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.ControlGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
 			this.ControlGroupBox.Controls.Add(this.InvisibleEmulationCheckBox);
 			this.ControlGroupBox.Controls.Add(this.panel2);
 			this.ControlGroupBox.Controls.Add(this.StopBtn);


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

Fixed UI:

![image](https://user-images.githubusercontent.com/6444116/179320834-1b4fc6d1-f1fb-4d3c-8f0c-35dd4313f455.png)

* When Basic Bot window is maximized, the UI panels are now properly aligned to take up space.
* Fixed a label, "Main Value:", being misaligned slightly towards the text box, making the label stand out among the other labels below it. The label is located on the right-most side of the window.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
