### PR TITLE
Fixed code logic error in BasicBot

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
@@ -936,7 +936,7 @@ namespace BizHawk.Client.EmuHawk
 
 					if (current.TieBreak2 == comparison.TieBreak2)
 					{
-						if (!TestValue(Tie3ComparisonType, current.TieBreak3, current.TieBreak3))
+						if (!TestValue(Tie3ComparisonType, current.TieBreak3, comparison.TieBreak3))
 						{
 							return false;
 						}


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

It was comparing with itself when it's comparing the Tie Breaker 3 value.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
