### PR TITLE
Fixed issue where the Copy button in Basic Bot is not toggled on/off properly.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
@@ -958,6 +958,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 				BestAttemptLogLabel.Text = sb.ToString();
 				PlayBestButton.Enabled = true;
+				btnCopyBestInput.Enabled = true;
 			}
 			else
 			{
@@ -969,6 +970,7 @@ namespace BizHawk.Client.EmuHawk
 				BestTieBreak3Box.Text = "";
 				BestAttemptLogLabel.Text = "";
 				PlayBestButton.Enabled = false;
+				btnCopyBestInput.Enabled = false;
 			}
 		}
 


### PR DESCRIPTION
If the Copy button is enabled, but there is no best attempt recorded, it will crash BasicBot / EmuHawk if it attempts to copy a null Log of the best attempt.

[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
