### PR TITLE
Prevent the BasicBot from loading invalid addresses into the Tiebreaker text boxes.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
@@ -643,10 +643,18 @@ namespace BizHawk.Client.EmuHawk
 				control.Probability = p;
 			}
 
-			MaximizeAddress = botData.Maximize;
-			TieBreaker1Address = botData.TieBreaker1;
-			TieBreaker2Address = botData.TieBreaker2;
-			TieBreaker3Address = botData.TieBreaker3;
+			MaximizeAddressBox.ResetText();
+			TieBreaker1Box.ResetText();
+			TieBreaker2Box.ResetText();
+			TieBreaker3Box.ResetText();
+			if (botData.Maximize != int.MinValue)
+				MaximizeAddress = botData.Maximize;
+			if (botData.TieBreaker1 != int.MinValue)
+				TieBreaker1Address = botData.TieBreaker1;
+			if (botData.TieBreaker2 != int.MinValue)
+				TieBreaker2Address = botData.TieBreaker2;
+			if (botData.TieBreaker3 != int.MinValue)
+				TieBreaker3Address = botData.TieBreaker3;
 			try
 			{
 				MainComparisonType = botData.ComparisonTypeMain;
@@ -723,10 +731,10 @@ namespace BizHawk.Client.EmuHawk
 			{
 				Best = _bestBotAttempt,
 				ControlProbabilities = ControlProbabilities,
-				Maximize = MaximizeAddress,
-				TieBreaker1 = TieBreaker1Address,
-				TieBreaker2 = TieBreaker2Address,
-				TieBreaker3 = TieBreaker3Address,
+				Maximize = MaximizeAddressBox.Text.Length > 0 ? MaximizeAddress : int.MinValue,
+				TieBreaker1 = TieBreaker1Box.Text.Length > 0 ? TieBreaker1Address : int.MinValue,
+				TieBreaker2 = TieBreaker2Box.Text.Length > 0 ? TieBreaker2Address : int.MinValue,
+				TieBreaker3 = TieBreaker3Box.Text.Length > 0 ? TieBreaker3Address : int.MinValue,
 				ComparisonTypeMain = MainComparisonType,
 				ComparisonTypeTie1 = Tie1ComparisonType,
 				ComparisonTypeTie2 = Tie2ComparisonType,


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

Before this change, when the Basic Bot is saving the bot parameters the user made, if the user did not set any address values to the address boxes (including Main Value address box), by default, it will store `0` as the value in the produced .BOT file. When Basic Bot is loading a .BOT file (a file that's produced by Basic Bot itself when saving the bot parameters), if the address boxes' values are `0` in the .BOT file, it will populate it with `0000`. Because it's assuming the user entered in `0000` when the user really didn't do this.

With this change, what I did is to prevent the Basic Bot from saving an empty address box as `0`, so that when it's loading the .BOT file, it won't produce the address value `0000`. I used `int.MinValue` to indicate this, because I'm pretty sure any emulators won't be using some address value located around 2.1 billion places away.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
