### PR TITLE
Don't send key release events with modifiers

### DIFF
--- a/src/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/src/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -117,9 +117,7 @@ namespace BizHawk.Client.EmuHawk
 
 			// don't generate events for things like Ctrl+LeftControl
 			var mods = _modifiers;
-			if (!newState)
-				mods = 0;
-			else if (currentModifier is not 0U)
+			if (currentModifier is not 0U)
 				mods &= ~currentModifier;
 
 			var ie = new InputEvent


### PR DESCRIPTION
This would close #3327. As I've written in that issue thread, the main problem seems to be the fact that key release events were sent with their respective modifier, aka when holding e.g. `Ctrl+C` and releasing `C`, a `Release:Ctrl+C` event would be generated which also happned to release the `Ctrl` key, even though that was still pressed.

The comments and code which I've removed seem to imply that this functionality was (more or less) intended and had a use case, although in my testing I couldn't figure out an issue with removing it; @zeromus do you recall the specific reason this code was needed?