### PR TITLE
Update `MovieSession` props when making blank `.tasproj`

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -600,8 +600,9 @@ namespace BizHawk.Client.EmuHawk
 				Config.DefaultAuthor);
 
 			SetTasMovieCallbacks(tasMovie);
-			tasMovie.ClearChanges(); // Don't ask to save changes here.
-			tasMovie.Save();
+			// QueueNewMovie will write to disk because Changes == true, and RunQueuedMovie will update MovieSession props
+			MovieSession.QueueNewMovie(tasMovie, record: false, Emulator.SystemId, Config.PreferredCores);
+			MovieSession.RunQueuedMovie(recordMode: false, Emulator); //TODO is anything besides setting MovieController (first line in impl.) required?
 			if (HandleMovieLoadStuff(tasMovie))
 			{
 			}


### PR DESCRIPTION
fixes #3417

Replaced `TasMovie.Save` call with [`MainForm.StartNewMovie`](https://github.com/TASEmulators/BizHawk/blob/b81728b2dc35f5a75748e1373f879f414b647640/src/BizHawk.Client.EmuHawk/MainForm.Movie.cs#L12) (which saves), then inlined that and removed the unnecessary bits, which was most of it.