### PR TITLE
Add `--userdata` CLI flag

### DIFF
--- a/src/BizHawk.Client.Common/ArgParser.cs
+++ b/src/BizHawk.Client.Common/ArgParser.cs
@@ -42,6 +42,7 @@ namespace BizHawk.Client.Common
 			string? urlPost = null;
 			bool? audiosync = null;
 			string? openExtToolDll = null;
+			List<(string Key, string Value)>? userdataUnparsedPairs = null;
 			string? cmdRom = null;
 
 			for (var i = 0; i < args.Length; i++)
@@ -157,6 +158,16 @@ namespace BizHawk.Client.Common
 					// - dll path matches given string; or dll filename matches given string with or without `.dll`
 					openExtToolDll = arg.Substring(20);
 				}
+				else if (argDowncased.StartsWith("--userdata="))
+				{
+					userdataUnparsedPairs = new();
+					foreach (var s in arg.Substring(11).Split(';'))
+					{
+						var iColon = s.IndexOf(':');
+						if (iColon is -1) throw new ArgParserException("malformed userdata (';' without ':')");
+						userdataUnparsedPairs.Add((s.Substring(startIndex: 0, length: iColon), s.Substring(iColon + 1)));
+					}
+				}
 				else
 				{
 					cmdRom = arg;
@@ -200,6 +211,7 @@ namespace BizHawk.Client.Common
 				httpAddresses: httpAddresses,
 				audiosync: audiosync,
 				openExtToolDll: openExtToolDll,
+				userdataUnparsedPairs: userdataUnparsedPairs,
 				cmdRom: cmdRom
 			);
 		}

--- a/src/BizHawk.Client.Common/ParsedCLIFlags.cs
+++ b/src/BizHawk.Client.Common/ParsedCLIFlags.cs
@@ -36,6 +36,8 @@ namespace BizHawk.Client.Common
 
 		public readonly (string IP, int Port)? SocketAddress;
 
+		public readonly IReadOnlyList<(string Key, string Value)>? UserdataUnparsedPairs;
+
 		public readonly string? MMFFilename;
 
 		public readonly (string? UrlGet, string? UrlPost)? HTTPAddresses;
@@ -66,6 +68,7 @@ namespace BizHawk.Client.Common
 			(string? UrlGet, string? UrlPost)? httpAddresses,
 			bool? audiosync,
 			string? openExtToolDll,
+			IReadOnlyList<(string Key, string Value)>? userdataUnparsedPairs,
 			string? cmdRom)
 		{
 			this.cmdLoadSlot = cmdLoadSlot;
@@ -87,6 +90,7 @@ namespace BizHawk.Client.Common
 			HTTPAddresses = httpAddresses;
 			this.audiosync = audiosync;
 			this.openExtToolDll = openExtToolDll;
+			UserdataUnparsedPairs = userdataUnparsedPairs;
 			this.cmdRom = cmdRom;
 		}
 	}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -690,6 +690,18 @@ namespace BizHawk.Client.EmuHawk
 				}
 			}
 
+			if (_argParser.UserdataUnparsedPairs is {} pairs) foreach (var (k, v) in pairs)
+			{
+				MovieSession.UserBag[k] = v switch
+				{
+					"true" => true,
+					"false" => false,
+					_ when int.TryParse(v, out var i) => i,
+					_ when double.TryParse(v, out var d) => d,
+					_ => v
+				};
+			}
+
 			//start Lua Console if requested in the command line arguments
 			if (_argParser.luaConsole)
 			{


### PR DESCRIPTION
As an example, `./EmuHawkMono.sh '--userdata=a:1;b:.5;c:1b;d:00;e:true;f:TRUE'` (quoted because ';' is a special char in BASH) sets these userdata entries:
key | type | value
--:|:--|:--
`a` | int | `1`
`b` | double | `0.5`
`c` | string | `"1b"`
`d` | int | `0`
`e` | bool | `true`
`f` | string | `"TRUE"`