### PR TITLE
`Span`-based bulk peeks (the boring kind)

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/MemoryApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/MemoryApi.cs
@@ -260,6 +260,26 @@ namespace BizHawk.Client.Common
 			return newBytes;
 		}
 
+		public bool ReadByteRange(ulong srcStartOffset, Span<byte> dstBuffer, string domain = null)
+		{
+			var d = NamedDomainOrCurrent(domain);
+			if (srcStartOffset >= (ulong) d.Size)
+			{
+				LogCallback($"Warning: attempted read of {srcStartOffset} outside the memory size of {d.Size}");
+				return false;
+			}
+			try
+			{
+				d.BulkPeekByte(srcStartOffset, dstBuffer);
+				return true;
+			}
+			catch (Exception e)
+			{
+				LogCallback($"bulk-peek threw {e.GetType().Name}: {e.Message}");
+				return false;
+			}
+		}
+
 		public void WriteByteRange(long addr, IReadOnlyList<byte> memoryblock, string domain = null)
 		{
 			var d = NamedDomainOrCurrent(domain);

--- a/src/BizHawk.Client.Common/Api/Classes/MemoryApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/MemoryApi.cs
@@ -252,7 +252,7 @@ namespace BizHawk.Client.Common
 			var iSrc = Math.Min(Math.Max(0L, addr), d.Size);
 			var iDst = iSrc - addr;
 			var bytes = new byte[indexAfterLast - iSrc];
-			if (iSrc < indexAfterLast) using (d.EnterExit()) d.BulkPeekByte(iSrc.RangeToExclusive(indexAfterLast), bytes);
+			if (iSrc < indexAfterLast) using (d.EnterExit()) d.BulkPeekByte(unchecked((ulong) iSrc), bytes);
 			if (lastReqAddr >= d.Size) LogCallback($"Warning: Attempted reads on addresses {d.Size}..{lastReqAddr} outside range of domain {d.Name} in {nameof(ReadByteRange)}()");
 			if (bytes.Length == length) return bytes;
 			var newBytes = new byte[length];

--- a/src/BizHawk.Client.Common/Api/Interfaces/IMemoryApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IMemoryApi.cs
@@ -17,6 +17,15 @@ namespace BizHawk.Client.Common
 
 		uint ReadByte(long addr, string domain = null);
 		IReadOnlyList<byte> ReadByteRange(long addr, int length, string domain = null);
+
+		/// <summary>copies a region of memory into <paramref name="dstBuffer"/>, starting at <paramref name="srcStartOffset"/> and taking as many bytes as will fit in the buffer</summary>
+		/// <returns>
+		/// <see langword="false"/> iff the internal API call threw an exception (for example, if you request bytes beyond the end of the domain).<br/>
+		/// If this happens, the state of <paramref name="dstBuffer"/> is undefined. Anywhere from <c>0</c> bytes to all of them could have been copied.
+		/// The exception is when <paramref name="srcStartOffset"/> falls outside the domain, as that is checked first and results in a no-op.
+		/// </returns>
+		bool ReadByteRange(ulong srcStartOffset, Span<byte> dstBuffer, string domain = null);
+
 		float ReadFloat(long addr, string domain = null);
 
 		int ReadS8(long addr, string domain = null);

--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Memory.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Memory.cs
@@ -151,9 +151,8 @@ namespace BizHawk.Client.EmuHawk
 
 					if (_addressMangler == 0)
 					{
-						var ret = new byte[length];
-						_domain.BulkPeekByte(((long)addr).RangeToExclusive(end), ret);
-						Marshal.Copy(ret, 0, buffer, (int)length);
+						var ret = _domain.BulkPeekByte(((long) addr).RangeToExclusive(end));
+						Marshal.Copy(ret, 0, buffer, (int) length); //TODO create a Span over buffer and pass that to BulkPeekByte
 					}
 					else
 					{

--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Memory.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Memory.cs
@@ -151,8 +151,7 @@ namespace BizHawk.Client.EmuHawk
 
 					if (_addressMangler == 0)
 					{
-						var ret = _domain.BulkPeekByte(((long) addr).RangeToExclusive(end));
-						Marshal.Copy(ret, 0, buffer, (int) length); //TODO create a Span over buffer and pass that to BulkPeekByte
+						_domain.BulkPeekByte(addr, Util.UnsafeSpanFromPointer(ptr: buffer, length: (int) length));
 					}
 					else
 					{

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -639,8 +639,7 @@ namespace BizHawk.Client.EmuHawk
 				default:
 				case 1:
 				{
-					var vals = new byte[end - start];
-					_domain.BulkPeekByte(range, vals);
+					var vals = _domain.BulkPeekByte(range);
 					int i = 0;
 					for (var addr = start; addr < end; addr += dataSize)
 						dict.Add(addr, vals[i++]);

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -96,6 +96,13 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
+		public virtual byte[] BulkPeekByte(Range<long> addresses)
+		{
+			var buf = new byte[addresses.Count()];
+			BulkPeekByte(addresses, buf);
+			return buf;
+		}
+
 		public virtual void BulkPeekByte(Range<long> addresses, byte[] values)
 		{
 			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -11,6 +11,10 @@ namespace BizHawk.Emulation.Common
 	/// <seealso cref="IMemoryDomains" />
 	public abstract class MemoryDomain : IMonitor
 	{
+		private const string ERR_MSG_DEST_WRONG_LEN = "Invalid length of values array";
+
+		private const string ERR_MSG_NOT_ALIGNED = "The API contract doesn't define what to do for unaligned reads and writes!";
+
 		public enum Endian
 		{
 			Big,
@@ -97,9 +101,9 @@ namespace BizHawk.Emulation.Common
 			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 			if (values is null) throw new ArgumentNullException(paramName: nameof(values));
 
-			if ((long)addresses.Count() != values.Length)
+			if ((ulong) values.Length != addresses.Count())
 			{
-				throw new InvalidOperationException("Invalid length of values array");
+				throw new InvalidOperationException(ERR_MSG_DEST_WRONG_LEN);
 			}
 
 			using (this.EnterExit())
@@ -119,13 +123,12 @@ namespace BizHawk.Emulation.Common
 			var start = addresses.Start;
 			var end = addresses.EndInclusive + 1;
 
-			if ((start & 1) != 0 || (end & 1) != 0)
-				throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");
+			if (start % 2 is not 0 || end % 2 is not 0) throw new InvalidOperationException(ERR_MSG_NOT_ALIGNED);
 
-			if (values.LongLength * 2 != end - start)
+			if (checked((ulong) values.Length * 2UL) != addresses.Count())
 			{
 				// a longer array could be valid, but nothing needs that so don't support it for now
-				throw new InvalidOperationException("Invalid length of values array");
+				throw new InvalidOperationException(ERR_MSG_DEST_WRONG_LEN);
 			}
 
 			using (this.EnterExit())
@@ -143,13 +146,12 @@ namespace BizHawk.Emulation.Common
 			var start = addresses.Start;
 			var end = addresses.EndInclusive + 1;
 
-			if ((start & 3) != 0 || (end & 3) != 0)
-				throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");
+			if (start % 4 is not 0 || end % 4 is not 0) throw new InvalidOperationException(ERR_MSG_NOT_ALIGNED);
 
-			if (values.LongLength * 4 != end - start)
+			if (checked((ulong) values.Length * 4UL) != addresses.Count())
 			{
 				// a longer array could be valid, but nothing needs that so don't support it for now
-				throw new InvalidOperationException("Invalid length of values array");
+				throw new InvalidOperationException(ERR_MSG_DEST_WRONG_LEN);
 			}
 
 			using (this.EnterExit())

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -15,6 +15,8 @@ namespace BizHawk.Emulation.Common
 
 		private const string ERR_MSG_NOT_ALIGNED = "The API contract doesn't define what to do for unaligned reads and writes!";
 
+		protected const string ERR_MSG_TOO_MANY_BYTES_REQ = "too many bytes requested, would read beyond bounds of domain";
+
 		public enum Endian
 		{
 			Big,
@@ -99,8 +101,17 @@ namespace BizHawk.Emulation.Common
 		public virtual byte[] BulkPeekByte(Range<long> addresses)
 		{
 			var buf = new byte[addresses.Count()];
-			BulkPeekByte(addresses, buf);
+			BulkPeekByte((ulong) addresses.Start, buf);
 			return buf;
+		}
+
+		public virtual void BulkPeekByte(ulong srcStartOffset, Span<byte> dstBuffer)
+		{
+			using var handle = this.EnterExit();
+			var iSrc = (long) srcStartOffset;
+			var endExcl = (long) srcStartOffset + dstBuffer.Length;
+			var iDst = 0;
+			while (iSrc != endExcl) dstBuffer[iDst++] = PeekByte(iSrc++);
 		}
 
 		public virtual void BulkPeekByte(Range<long> addresses, byte[] values)

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
@@ -80,6 +80,7 @@ namespace BizHawk.Emulation.Common
 			Func<long, byte> peek,
 			Action<long, byte> poke,
 			int wordSize,
+			//TODO bulkPeekByteSpan, though none of the cores using this actually pass any of the bulk peek callbacks at the moment
 			Action<Range<long>, byte[]> bulkPeekByte = null,
 			Action<Range<long>, bool, ushort[]> bulkPeekUshort = null,
 			Action<Range<long>, bool, uint[]> bulkPeekUint = null)
@@ -208,6 +209,14 @@ namespace BizHawk.Emulation.Common
 					throw new ArgumentOutOfRangeException(nameof(addr));
 				}
 			}
+		}
+
+		public override void BulkPeekByte(ulong srcStartOffset, Span<byte> dstBuffer)
+		{
+			if ((ulong) Size <= srcStartOffset) throw new ArgumentOutOfRangeException(paramName: nameof(srcStartOffset));
+			if ((ulong) Size < srcStartOffset + (ulong) dstBuffer.Length) throw new ArgumentException(paramName: nameof(dstBuffer), message: ERR_MSG_TOO_MANY_BYTES_REQ);
+			Util.UnsafeSpanFromPointer(ptr: (IntPtr) ((ulong) Data + srcStartOffset), length: dstBuffer.Length)
+				.CopyTo(dstBuffer);
 		}
 
 		public override void BulkPeekByte(Range<long> addresses, byte[] values)

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainStream.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainStream.cs
@@ -1,7 +1,6 @@
 #nullable disable
 
 using System.IO;
-using BizHawk.Common;
 
 namespace BizHawk.Emulation.Common
 {
@@ -58,11 +57,7 @@ namespace BizHawk.Emulation.Common
 			count = (int)Math.Min(count, Length - Position);
 			if (count == 0)
 				return 0;
-			// TODO: Memory domain doesn't have the overload we need :(
-			var poop = new byte[count];
-			// TODO: Range has the wrong end value
-			_d.BulkPeekByte(Position.RangeToExclusive(Position + count), poop);
-			Array.Copy(poop, 0, buffer, offset, count);
+			_d.BulkPeekByte((ulong) Position, buffer.AsSpan(start: offset, length: count));
 			Position += count;
 			return count;
 		}


### PR DESCRIPTION
This isn't the switching to `ReadOnlySpan` to let the frontend and APIs read memory without copying. This still copies, but into a `Span` instead of an array, which probably makes no difference for internal use, and is slightly more convenient for ext. tools.
I could have exposed the overload which takes an array reference and writes into it, but I figured this way would mitigate user error. The use of an unsigned integer for the start offset, especially.

I'd appreciate if someone could double-check my pointer arithmetic is correct, i.e. it matches the arithmetic in the other overload's implementation.
edit: Rebased, would still like that second opinion, and I think this should wait for #3965.