### PR TITLE
LuaConsole fixes

### DIFF
--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -256,7 +256,6 @@ namespace BizHawk.Client.Common
 		// Lua
 		public RecentFiles RecentLua { get; set; } = new RecentFiles(8);
 		public RecentFiles RecentLuaSession { get; set; } = new RecentFiles(8);
-		public bool DisableLuaScriptsOnLoad { get; set; }
 
 		// luaconsole-refactor TODO: move this to LuaConsole settings
 		public bool RunLuaDuringTurbo { get; set; } = true;

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -373,7 +373,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (!item.IsSeparator)
 			{
-				LuaImp.RegisteredFunctions.RemoveForFile(item, Emulator);
+				DisableLuaScript(item);
 				RemoveFileWatcher(item);
 			}
 			LuaImp.ScriptList.Remove(item);

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -341,36 +341,6 @@ namespace BizHawk.Client.EmuHawk
 			UpdateRegisteredFunctionsDialog();
 		}
 
-		private void RunLuaScripts()
-		{
-			foreach (var file in LuaImp.ScriptList.Where(s => !s.IsSeparator))
-			{
-				if (!file.Enabled && file.Thread is null)
-				{
-					try
-					{
-						LuaSandbox.Sandbox(null, () =>
-						{
-							string pathToLoad = ProcessPath(file.Path);
-							LuaImp.SpawnAndSetFileThread(file.Path, file);
-							LuaSandbox.CreateSandbox(file.Thread, Path.GetDirectoryName(pathToLoad));
-						}, () =>
-						{
-							file.State = LuaFile.RunState.Disabled;
-						});
-					}
-					catch (Exception e)
-					{
-						DialogController.ShowMessageBox(e.ToString());
-					}
-				}
-				else
-				{
-					file.Stop();
-				}
-			}
-		}
-
 		private void SessionChangedCallback()
 		{
 			OutputMessages.Text =

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -203,9 +203,7 @@ namespace BizHawk.Client.EmuHawk
 				// we don't use runningScripts here as the other scripts need to be stopped too
 				foreach (var file in luaLibsImpl.ScriptList)
 				{
-					if (file.Enabled) luaLibsImpl.CallExitEvent(file);
-					luaLibsImpl.RegisteredFunctions.RemoveForFile(file, Emulator);
-					file.Stop();
+					DisableLuaScript(file);
 				}
 			}
 
@@ -1509,11 +1507,24 @@ namespace BizHawk.Client.EmuHawk
 			}
 			else if (!file.Enabled && file.Thread is not null)
 			{
+				DisableLuaScript(file);
+				// there used to be a call here which did a redraw of the Gui/OSD, which included a call to `Tools.UpdateToolsAfter` --yoshi
+			}
+		}
+
+		private void DisableLuaScript(LuaFile file)
+		{
+			if (LuaImp is not Win32LuaLibraries luaLibsImpl) return;
+
+			if (file.IsSeparator) return;
+
+			file.State = LuaFile.RunState.Disabled;
+
+			if (file.Thread is not null)
+			{
 				luaLibsImpl.CallExitEvent(file);
 				luaLibsImpl.RegisteredFunctions.RemoveForFile(file, Emulator);
-				luaLibsImpl.CallExitEvent(file);
 				file.Stop();
-				// there used to be a call here which did a redraw of the Gui/OSD, which included a call to `Tools.UpdateToolsAfter` --yoshi
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -909,6 +909,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 			catch (IOException)
 			{
+				item.State = LuaFile.RunState.Disabled;
 				WriteLine($"Unable to access file {item.Path}");
 			}
 			catch (Exception ex)

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -299,23 +299,13 @@ namespace BizHawk.Client.EmuHawk
 
 			var processedPath = Config.PathEntries.TryMakeRelative(path);
 
-			var alreadyInSession = luaLibsImpl.ScriptList.Any(t => processedPath == t.Path);
-			if (alreadyInSession)
+			var alreadyLoadedFile = luaLibsImpl.ScriptList.FirstOrDefault(t => processedPath == t.Path);
+			if (alreadyLoadedFile is not null)
 			{
-				foreach (var file in luaLibsImpl.ScriptList
-					.Where(file => processedPath == file.Path
-						&& file.Enabled == false
-						&& !Settings.DisableLuaScriptsOnLoad))
+				if (!alreadyLoadedFile.Enabled && !Settings.DisableLuaScriptsOnLoad)
 				{
-					if (file.Thread is not null)
-					{
-						file.Toggle();
-					}
-
-					break;
+					ToggleLuaScript(alreadyLoadedFile);
 				}
-
-				RunLuaScripts();
 			}
 			else
 			{

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -687,13 +687,9 @@ namespace BizHawk.Client.EmuHawk
 			var file = GetSaveFileFromUser();
 			if (file != null)
 			{
-				var path = Config.PathEntries
-					.AbsolutePathFor(file.FullName, "")
-					.MakeRelativeTo(Path.GetDirectoryName(file.FullName));
-				LuaImp.ScriptList.Save(path);
-
-				Config.RecentLuaSession.Add(file.FullName); // TODO: should path be used here?
-				OutputMessages.Text = $"{Path.GetFileName(LuaImp.ScriptList.Filename)} saved.";
+				LuaImp.ScriptList.Save(file.FullName);
+				Config.RecentLuaSession.Add(file.FullName);
+				OutputMessages.Text = $"{file.Name} saved.";
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -305,7 +305,7 @@ namespace BizHawk.Client.EmuHawk
 				foreach (var file in luaLibsImpl.ScriptList
 					.Where(file => processedPath == file.Path
 						&& file.Enabled == false
-						&& !Config.DisableLuaScriptsOnLoad))
+						&& !Settings.DisableLuaScriptsOnLoad))
 				{
 					if (file.Thread is not null)
 					{
@@ -325,7 +325,7 @@ namespace BizHawk.Client.EmuHawk
 				LuaListView.RowCount = luaLibsImpl.ScriptList.Count;
 				Config.RecentLua.Add(processedPath);
 
-				if (!Config.DisableLuaScriptsOnLoad)
+				if (!Settings.DisableLuaScriptsOnLoad)
 				{
 					luaFile.State = LuaFile.RunState.Running;
 					EnableLuaFile(luaFile);
@@ -1079,14 +1079,14 @@ namespace BizHawk.Client.EmuHawk
 
 		private void OptionsSubMenu_DropDownOpened(object sender, EventArgs e)
 		{
-			DisableScriptsOnLoadMenuItem.Checked = Config.DisableLuaScriptsOnLoad;
+			DisableScriptsOnLoadMenuItem.Checked = Settings.DisableLuaScriptsOnLoad;
 			ReturnAllIfNoneSelectedMenuItem.Checked = Settings.ToggleAllIfNoneSelected;
 			ReloadWhenScriptFileChangesMenuItem.Checked = Settings.ReloadOnScriptFileChange;
 		}
 
 		private void DisableScriptsOnLoadMenuItem_Click(object sender, EventArgs e)
 		{
-			Config.DisableLuaScriptsOnLoad ^= true;
+			Settings.DisableLuaScriptsOnLoad ^= true;
 		}
 
 		private void ToggleAllIfNoneSelectedMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -736,11 +736,13 @@ namespace BizHawk.Client.EmuHawk
 			return true;
 		}
 
-		private static void UpdateRegisteredFunctionsDialog()
+		private void UpdateRegisteredFunctionsDialog()
 		{
+			if (LuaImp is null) return;
+
 			foreach (var form in Application.OpenForms.OfType<LuaRegisteredFunctionsList>().ToList())
 			{
-				form.UpdateValues();
+				form.UpdateValues(LuaImp.RegisteredFunctions);
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -334,6 +334,26 @@ namespace BizHawk.Client.EmuHawk
 			UpdateDialog();
 		}
 
+		public void RemoveLuaFile(string path)
+		{
+			if (LuaImp is not Win32LuaLibraries luaLibsImpl) return;
+
+			var processedPath = Config.PathEntries.TryMakeRelative(path);
+
+			var luaFile = luaLibsImpl.ScriptList.FirstOrDefault(t => processedPath == t.Path);
+			if (luaFile is not null)
+			{
+				RemoveLuaFile(luaFile);
+				UpdateDialog();
+			}
+		}
+
+		private void RemoveLuaFile(LuaFile item)
+		{
+			LuaImp.RegisteredFunctions.RemoveForFile(item, Emulator);
+			LuaImp.ScriptList.Remove(item);
+		}
+
 		private void UpdateDialog()
 		{
 			LuaListView.RowCount = LuaImp.ScriptList.Count;
@@ -902,8 +922,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				foreach (var item in items)
 				{
-					LuaImp.RegisteredFunctions.RemoveForFile(item, Emulator);
-					LuaImp.ScriptList.Remove(item);
+					RemoveLuaFile(item);
 				}
 
 				UpdateDialog();

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -501,15 +501,23 @@ namespace BizHawk.Client.EmuHawk
 		{
 			var result = LuaImp.ScriptList.Load(path, Settings.DisableLuaScriptsOnLoad);
 
-			RunLuaScripts();
-			UpdateDialog();
-			LuaImp.ScriptList.Changes = false;
-
-			Config.RecentLuaSession.Add(path);
 			foreach (var script in LuaImp.ScriptList)
 			{
-				Config.RecentLua.Add(script.Path);
+				if (!script.IsSeparator)
+				{
+					if (script.Enabled)
+					{
+						EnableLuaFile(script);
+					}
+
+					Config.RecentLua.Add(script.Path);
+				}
 			}
+
+			LuaImp.ScriptList.Changes = false;
+			Config.RecentLuaSession.Add(path);
+			UpdateDialog();
+			AddFileWatches();
 
 			ClearOutputWindow();
 			return result;
@@ -678,8 +686,6 @@ namespace BizHawk.Client.EmuHawk
 					Config.RecentLuaSession.HandleLoadError(MainForm, path);
 				}
 			}
-
-			AddFileWatches();
 		}
 
 		public override bool AskSaveChanges()

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -1058,7 +1058,10 @@ namespace BizHawk.Client.EmuHawk
 
 		private void StopAllScriptsMenuItem_Click(object sender, EventArgs e)
 		{
-			LuaImp.ScriptList.StopAllScripts();
+			foreach (var file in LuaImp.ScriptList)
+			{
+				DisableLuaScript(file);
+			}
 			UpdateDialog();
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -279,6 +279,11 @@ namespace BizHawk.Client.EmuHawk
 				return;
 
 			var (dir, file) = item.Path.MakeProgramRelativePath().SplitPathToDirAndFile();
+
+			// prevent error when (auto)loading session referencing scripts in deleted/renamed directories
+			if (!Directory.Exists(dir))
+				return;
+
 			var watcher = new FileSystemWatcher
 			{
 				Path = dir,

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -285,7 +285,8 @@ namespace BizHawk.Client.EmuHawk
 				Path = dir,
 				Filter = file,
 				NotifyFilter = NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName,
-				EnableRaisingEvents = true
+				EnableRaisingEvents = true,
+				SynchronizingObject = this, // invoke event handlers on GUI thread
 			};
 
 			// TODO, Deleted and Renamed events
@@ -308,7 +309,10 @@ namespace BizHawk.Client.EmuHawk
 		private void OnChanged(object source, FileSystemEventArgs e)
 		{
 			var script = LuaImp.ScriptList.FirstOrDefault(s => s.Path == e.FullPath && s.Enabled);
-			if (script != null) Invoke((MethodInvoker) (() => RefreshLuaScript(script)));
+			if (script is not null)
+			{
+				RefreshLuaScript(script);
+			}
 		}
 
 		public void LoadLuaFile(string path)

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -209,6 +209,7 @@ namespace BizHawk.Client.EmuHawk
 
 			LuaFileList newScripts = new(LuaImp?.ScriptList, onChanged: SessionChangedCallback);
 			LuaFunctionList registeredFuncList = new(onChanged: UpdateRegisteredFunctionsDialog);
+			(LuaImp as Win32LuaLibraries)?.Close();
 			LuaImp = new Win32LuaLibraries(
 				newScripts,
 				registeredFuncList,

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -354,6 +354,14 @@ namespace BizHawk.Client.EmuHawk
 			LuaImp.ScriptList.Remove(item);
 		}
 
+		private void RemoveAllLuaFiles()
+		{
+			while (LuaImp.ScriptList.Count > 0)
+			{
+				RemoveLuaFile(LuaImp.ScriptList[LuaImp.ScriptList.Count - 1]);
+			}
+		}
+
 		private void UpdateDialog()
 		{
 			LuaListView.RowCount = LuaImp.ScriptList.Count;
@@ -489,6 +497,8 @@ namespace BizHawk.Client.EmuHawk
 
 		public bool LoadLuaSession(string path)
 		{
+			RemoveAllLuaFiles();
+
 			var result = LuaImp.ScriptList.Load(path, Settings.DisableLuaScriptsOnLoad);
 
 			foreach (var script in LuaImp.ScriptList)
@@ -743,6 +753,7 @@ namespace BizHawk.Client.EmuHawk
 
 			if (result)
 			{
+				RemoveAllLuaFiles();
 				LuaImp.ScriptList.Clear();
 				ClearOutputWindow();
 				UpdateDialog();

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaRegisteredFunctionsList.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaRegisteredFunctionsList.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Client.EmuHawk
 	{
 		private readonly IMainFormForApi _mainForm;
 
-		private readonly LuaFunctionList _registeredFunctions;
+		private LuaFunctionList _registeredFunctions;
 
 		public LuaRegisteredFunctionsList(IMainFormForApi mainForm, LuaFunctionList registeredFunctions)
 		{
@@ -22,8 +22,9 @@ namespace BizHawk.Client.EmuHawk
 
 		public Point StartLocation { get; set; } = new Point(0, 0);
 
-		public void UpdateValues()
+		public void UpdateValues(LuaFunctionList registeredFunctions)
 		{
+			_registeredFunctions = registeredFunctions;
 			PopulateListView();
 		}
 


### PR DESCRIPTION
This PR fixes a number of issues in `LuaConsole`, mostly related to script loading/unloading

# Changes

1. Change references to `Config.DisableLuaScriptsOnLoad` to `Settings.DisableLuaScriptsOnLoad`
This was inconsistently done in an old commit, leading to some functions obeying this setting and others ignoring it.
This will effectively reset the setting

2. `Close()` existing `Win32LuaLibraries` during `Restart()`.
Before, only closing the `LuaConsole` would call close on the current `LuaImp`, causing possible memory and file handle leaks, and leaving behind 'zombie' forms still referencing the old libraries after loading a rom/restarting the core

3. Dispose `FileSystemWatcher` when no longer needed, avoid relying on path string comparisons, prevent crash in case of missing directory, and prevent some cross-thread risks

4. Remove buggy `RunLuaScripts` and replace it with calls to ` EnableLuaFile`/`ToggleLuaScript` in the two places it was used
This resolves scripts not starting correctly when loading a session, and all scripts being stopped when loading a script that already exists in the list.

5. Remove existing scripts before loading a session or creating a new session, to run cleanup code
Previously, registered functions would hang around

6. Refactor removing and disabling scripts into methods to reduce some code duplication

7. Update registered functions dialog after instantiating a new `LuaImp`

8. Fix luases files always being saved in the exe directory regardless of selected save location
I don't really understand what the intent of the existing code was, seems like a refactor gone wrong? 

9. Stop converting script paths between relative paths and absolute paths all over the place, stick with absolute paths
Again, I'm not sure why it worked this way, but the existing code has a number of issues:
   1. `PathEntries.TryMakeRelative` doesn't handle paths containing dot notation or inconsistent forward/backward slashes on Windows
   2. Paths were made relative to the configured base path, but converted back to absolute to the exe directory, which can be different
   3. Relative paths in a .luases were interpreted as relative to the .luases, which can be different again
   4. FileSystemWatcher code didn't recognize differently formatted paths (resolved by 3.)

# Open questions

1. Should removing a script call `LuaFile.Stop()` and call the exit event like disabling a script does? I would think so, but it didn't before. Also goes for scripts cleared when loading a session/creating a new session.

2. Should "Stop all scripts" behave the same as disabling scripts? Currently it only changes the `State` flag.

3. Should the relative path conversion when loading lua scripts be fixed instead of removed? If so, what is the intended behavior?
No other file loading code behaves like this from what I've seen (roms, lua session files, cheats, watches, etc.) 

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
