### PR TITLE
Update virtualpads immediate when the movie status changes, huge impr…

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.Movie.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Movie.cs
@@ -84,6 +84,7 @@ namespace BizHawk.Client.EmuHawk
 
 			UpdateWindowTitle();
 			UpdateStatusSlots();
+			Tools.UpdateValues<VirtualpadTool>();
 		}
 
 		public void StopMovie(bool saveChanges = true)

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.cs
@@ -147,6 +147,8 @@ namespace BizHawk.Client.EmuHawk
 			CreatePads();
 		}
 
+		protected override void GeneralUpdate() => UpdateAfter();
+
 		protected override void UpdateAfter()
 		{
 			if (!IsHandleCreated || IsDisposed)


### PR DESCRIPTION
…ovement when using tastudio and virtualpad together as the record checkbox toggle now changes the readonly status of the pad
