### PR TITLE
Add missing `UpdateDialog` call in `LuaConsole`

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -310,6 +310,10 @@ namespace BizHawk.Client.EmuHawk
 			if (item.Enabled && LuaImp.ScriptList.Contains(item) == true)
 			{
 				RefreshLuaScript(item);
+				if (!item.Enabled)
+				{
+					UpdateDialog();
+				}
 			}
 		}
 


### PR DESCRIPTION
Call `UpdateDialog` after the script is refreshed, in case the script was disabled by a new syntax error etc.

- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
