### PR TITLE
Return success bool from `OpenRom` APIs

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
@@ -142,7 +142,7 @@ namespace BizHawk.Client.Common
 
 		public void OnStateSaved(object sender, string stateName) => StateSaved?.Invoke(sender, new StateSavedEventArgs(stateName));
 
-		public void OpenRom(string path) => _mainForm.LoadRom(path, new LoadRomArgs { OpenAdvanced = OpenAdvancedSerializer.ParseWithLegacy(path) });
+		public bool OpenRom(string path) => _mainForm.LoadRom(path, new LoadRomArgs { OpenAdvanced = OpenAdvancedSerializer.ParseWithLegacy(path) });
 
 		public void Pause() => _mainForm.PauseEmulator();
 

--- a/src/BizHawk.Client.Common/Api/Interfaces/IEmuClientApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IEmuClientApi.cs
@@ -125,7 +125,7 @@ namespace BizHawk.Client.Common
 		/// <param name="stateName">User friendly name for saved state</param>
 		void OnStateSaved(object sender, string stateName);
 
-		void OpenRom(string path);
+		bool OpenRom(string path);
 
 		void Pause();
 

--- a/src/BizHawk.Client.Common/lua/CommonLibs/ClientLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/ClientLuaLibrary.cs
@@ -196,13 +196,14 @@ namespace BizHawk.Client.Common
 		public void OpenRamSearch()
 			=> APIs.Tool.OpenRamSearch();
 
-		[LuaMethodExample("client.openrom( \"C:\\\" );")]
-		[LuaMethod("openrom", "opens the Open ROM dialog")]
-		public void OpenRom(string path)
+		[LuaMethodExample("client.openrom( \"C:\\rom.bin\" );")]
+		[LuaMethod("openrom", "Loads a ROM from the given path. Returns true if the ROM was successfully loaded, otherwise false.")]
+		public bool OpenRom(string path)
 		{
 			_luaLibsImpl.IsRebootingCore = true;
-			APIs.EmuClient.OpenRom(path);
+			var success = APIs.EmuClient.OpenRom(path);
 			_luaLibsImpl.IsRebootingCore = false;
+			return success;
 		}
 
 		[LuaMethodExample("client.opentasstudio( );")]


### PR DESCRIPTION
- Change `OpenRom` methods on `IEmuClientApi` and `ClientLuaLibrary` to pass on return value from `MainForm.LoadRom`.
- Change Lua doc to better reflect the actual function of `client.openrom`.

In line with ec6fe5fcf18b48f85b81ed80b00220392290537b. This API change will break binary compatibility, but since the other commit does that anyway this seems like as good a time as any.

Check if completed:
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
