### PR TITLE
Improve `DisplaySurface` performance

### DIFF
--- a/src/BizHawk.Client.Common/DisplayManager/DisplaySurface.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/DisplaySurface.cs
@@ -1,99 +1,34 @@
+using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.Runtime.InteropServices;
-
-using BizHawk.Common;
 
 namespace BizHawk.Client.Common
 {
 	/// <summary>
-	/// This is a wrapper for a Bitmap, basically, which can also be a int[].
+	/// This is a wrapper for a Bitmap.
 	/// It should be phased out, in favor of BitmapBuffer and Texture2d's
 	/// </summary>
 	public unsafe class DisplaySurface : IDisplaySurface
 	{
+		private const PixelFormat Format = PixelFormat.Format32bppArgb;
+
 		private Bitmap _bmp;
-		private BitmapData _bmpData;
-		private readonly int[] _pixels;
 
 		public void Clear()
 		{
-			FromBitmap(false);
-			Util.Memset(PixelPtr, 0, Stride * Height);
+			var bmpData = _bmp.LockBits(new(0, 0, Width, Height), ImageLockMode.WriteOnly, Format);
+			new Span<byte>((void*)bmpData.Scan0, bmpData.Stride * bmpData.Height).Clear();
+			_bmp.UnlockBits(bmpData);
 		}
 
 		public Bitmap PeekBitmap()
 		{
-			ToBitmap();
 			return _bmp;
 		}
 
 		public Graphics GetGraphics()
 		{
-			ToBitmap();
 			return Graphics.FromImage(_bmp);
-		}
-
-		public void ToBitmap(bool copy = true)
-		{
-			if (_isBitmap) return;
-			_isBitmap = true;
-
-			if (_bmp == null)
-			{
-				_bmp = new Bitmap(Width, Height, PixelFormat.Format32bppArgb);
-			}
-
-			if (copy)
-			{
-				_bmpData = _bmp.LockBits(new Rectangle(0, 0, Width, Height), ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
-
-				int w = Width;
-				int h = Height;
-				int stride = _bmpData.Stride / 4;
-				int* bmpBuf = (int*)_bmpData.Scan0.ToPointer();
-				for (int y = 0, i = 0; y < h; y++)
-				{
-					for (int x = 0; x < w; x++)
-					{
-						bmpBuf[y * stride + x] = _pixels[i++];
-					}
-				}
-
-				_bmp.UnlockBits(_bmpData);
-			}
-
-		}
-
-		private bool _isBitmap;
-
-		public void FromBitmap(bool copy = true)
-		{
-			if (!_isBitmap)
-			{
-				return;
-			}
-
-			_isBitmap = false;
-
-			if (copy)
-			{
-				_bmpData = _bmp.LockBits(new Rectangle(0, 0, Width, Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
-
-				int w = Width;
-				int h = Height;
-				int stride = _bmpData.Stride / 4;
-				int* bmpBuf = (int*)_bmpData.Scan0.ToPointer();
-				for (int y = 0, i = 0; y < h; y++)
-				{
-					for (int x = 0; x < w; x++)
-					{
-						_pixels[i++] = bmpBuf[y * stride + x];
-					}
-				}
-
-				_bmp.UnlockBits(_bmpData);
-			}
 		}
 
 		public DisplaySurface(int width, int height)
@@ -112,28 +47,7 @@ namespace BizHawk.Client.Common
 			Width = width;
 			Height = height;
 
-			_pixels = new int[width * height];
-			LockPixels();
-		}
-
-		public int* PixelPtr => (int*)_ptr;
-		public int Stride => Width * 4;
-
-		private void* _ptr;
-		private GCHandle _handle;
-		private void LockPixels()
-		{
-			UnlockPixels();
-			_handle = GCHandle.Alloc(_pixels, GCHandleType.Pinned);
-			_ptr = _handle.AddrOfPinnedObject().ToPointer();
-		}
-
-		private void UnlockPixels()
-		{
-			if (_handle.IsAllocated)
-			{
-				_handle.Free();
-			}
+			_bmp = new Bitmap(Width, Height, Format);
 		}
 
 		public int Width { get; }
@@ -143,7 +57,6 @@ namespace BizHawk.Client.Common
 		{
 			_bmp?.Dispose();
 			_bmp = null;
-			UnlockPixels();
 		}
 	}
 


### PR DESCRIPTION
- Replace `DisplaySurface.Clear()` with a significantly faster implementation
- Remove unused `int[]` pixel buffer and superfluous conversion between the array and `Bitmap`

My aim was to improve the performance of drawing on the "client" surface from Lua, which I've always avoided using simply because it causes huge FPS drops compared to drawing on "emucore" regardless of how simple the drawing is, especially at larger window sizes.

Much of the performance drain comes from `DisplaySurface.Clear()`, which uses a fairly slow byte-for-byte loop to clear the `_pixels` array. And then the cleared `_pixels` data is later copied back to the `Bitmap`.

With this PR, `DisplaySurface.Clear()` now clears the `Bitmap` directly (`LockBits`), and uses `Span<byte>.Clear()` which is a lot faster than the custom `Utils.Memset` method. (I also tested `Graphics.Clear(Color)` which surprisingly was also comparatively slow.)

As far as I can tell nothing other than the `Clear()` method actually references the `_pixels` array or the pointer to that array. Drawing functions draw to the bitmap, and rendering reads from the bitmap. So I ended up removing that aspect completely. `DrawingSurface` now doesn't really have functionality other than the `Clear()` method, and there was already a very old comment at the top saying it should be phased out, but the code around it looked fairly daunting and I didn't want to get even deeper into the weeds.

- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
