### PR TITLE
Fix hex editor domain issues with MAME

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -645,7 +645,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void SetMemoryDomain(string name)
 		{
-			if (!(MainForm.CurrentlyOpenRomArgs.OpenAdvanced is OpenAdvanced_MAME) && name == _romDomain.Name)
+			if (_romDomain is not null && name == _romDomain.Name)
 			{
 				_domain = _romDomain;
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -215,6 +215,10 @@ namespace BizHawk.Client.EmuHawk
 					_domain = _romDomain;
 				}
 			}
+			else
+			{
+				_romDomain = null;
+			}
 			
 			_domain = MemoryDomains.Any(x => x.Name == _domain.Name)
 				? MemoryDomains[_domain.Name]


### PR DESCRIPTION
- Replace `OpenAdvanced_MAME` check with `_romDomain` `null` check
Fix `NullReferenceException` when changing memory domains on MAME, now that MAME roms can be opened without using the Open Advanced dialog (related to bae71326bf21a392cb360db807214d4132ecb288) 

- Clear `_romDomain` reference when loading MAME rom
Previously, when loading a MAME rom after a non-MAME rom, the "File on Disk" domain would still appear with the contents of the previous rom

For context: `_romDomain` is the "File on Disk" pseudo memory domain in the hex editor, which is not initialized for MAME roms.

Check if completed:
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
