### PR TITLE
fix noise audio channel on SMS VDP (LFSR is 16 bit wide)

### DIFF
--- a/src/BizHawk.Emulation.Cores/Sound/SN76489sms.cs
+++ b/src/BizHawk.Emulation.Cores/Sound/SN76489sms.cs
@@ -193,7 +193,7 @@ namespace BizHawk.Emulation.Cores.Components
 					noise_bit = noise.Bit(0);
 					if (noise_type)
 					{
-						noise = (((noise & 1) ^ ((noise >> 1) & 1)) << 15) | (noise >> 1);						
+						noise = (((noise & 1) ^ ((noise >> 3) & 1)) << 15) | (noise >> 1);						
 					}
 					else
 					{

--- a/src/BizHawk.Emulation.Cores/Sound/SN76489sms.cs
+++ b/src/BizHawk.Emulation.Cores/Sound/SN76489sms.cs
@@ -24,8 +24,6 @@ namespace BizHawk.Emulation.Cores.Components
 		public int noise_rate;
 		public bool noise_bit;
 
-		public ushort tone_low;
-
 		public bool A_L, B_L, C_L, noise_L;
 		public bool A_R, B_R, C_R, noise_R;
 
@@ -90,8 +88,6 @@ namespace BizHawk.Emulation.Cores.Components
 			ser.Sync(nameof(noise_clock), ref noise_clock);
 			ser.Sync(nameof(noise_bit), ref noise_bit);
 
-			ser.Sync(nameof(tone_low), ref tone_low);
-
 			ser.Sync(nameof(psg_clock), ref psg_clock);
 
 			ser.Sync(nameof(A_up), ref A_up);
@@ -137,7 +133,8 @@ namespace BizHawk.Emulation.Cores.Components
 				{
 					if (chan_sel < 3)
 					{
-						tone_low = (ushort)(value & 0xF);
+						Chan_tone[chan_sel] &= 0x3F0;
+						Chan_tone[chan_sel] |= (ushort)(value & 0xF);
 					}
 					else
 					{
@@ -159,7 +156,8 @@ namespace BizHawk.Emulation.Cores.Components
 				{
 					if (chan_sel < 3)
 					{
-						Chan_tone[chan_sel] = (ushort)(((value & 0x3F) << 4) | tone_low);
+						Chan_tone[chan_sel] &= 0xF;
+						Chan_tone[chan_sel] |= (ushort)((value & 0x3F) << 4);
 					}
 					else
 					{
@@ -224,21 +222,18 @@ namespace BizHawk.Emulation.Cores.Components
 				{
 					A_up = !A_up;
 					clock_A = Chan_tone[0] + 1;
-					if (clock_A == 1) { A_up = !A_up; }
 				}
 
 				if (clock_B == 0)
 				{
 					B_up = !B_up;
 					clock_B = Chan_tone[1] + 1;
-					if (clock_B == 1) { B_up = !B_up; }
 				}
 
 				if (clock_C == 0)
 				{
 					C_up = !C_up;
 					clock_C = Chan_tone[2] + 1;
-					if (clock_C == 1) { C_up = !C_up; }
 				}
 
 				// now calculate the volume of each channel and add them together

--- a/src/BizHawk.Emulation.Cores/Sound/SN76489sms.cs
+++ b/src/BizHawk.Emulation.Cores/Sound/SN76489sms.cs
@@ -193,11 +193,11 @@ namespace BizHawk.Emulation.Cores.Components
 					noise_bit = noise.Bit(0);
 					if (noise_type)
 					{
-						noise = (((noise & 1) ^ ((noise >> 1) & 1)) << 14) | (noise >> 1);						
+						noise = (((noise & 1) ^ ((noise >> 1) & 1)) << 15) | (noise >> 1);						
 					}
 					else
 					{
-						noise = ((noise & 1) << 14) | (noise >> 1);
+						noise = ((noise & 1) << 15) | (noise >> 1);
 					}
 
 					if (noise_rate == 0)


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

On the SMS/GG VDP, the noise channel of the integrated SN76489 is a 16-bit LFSR instead of a 15-bit one, this PR should fix that. Also, white noise is generated by XORing bits 0 and 3, not 0 and 1.
Finally, reverting commit 7b857e7 nonsense.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
