### PR TITLE
Nes.Core now updates the DataBus in WriteMemory()

### DIFF
--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -1149,8 +1149,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				uint flags = (uint)(MemoryCallbackFlags.CPUZero | MemoryCallbackFlags.AccessWrite | MemoryCallbackFlags.SizeByte);
 				MemoryCallbacks.CallMemoryCallbacks(addr, value, flags, "System Bus");
 			}
-			DB = value;
 
+			DB = value;
 		}
 
 		// the palette for each VS game needs to be chosen explicitly since there are 6 different ones.

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -1149,6 +1149,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				uint flags = (uint)(MemoryCallbackFlags.CPUZero | MemoryCallbackFlags.AccessWrite | MemoryCallbackFlags.SizeByte);
 				MemoryCallbacks.CallMemoryCallbacks(addr, value, flags, "System Bus");
 			}
+			DB = value;
+
 		}
 
 		// the palette for each VS game needs to be chosen explicitly since there are 6 different ones.


### PR DESCRIPTION
This will correct open bus execution following write instructions.

[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

Here's an example: 

Address $0056 has a value of $CC. Before this fix, an LSR instruction would leave $CC on the open bus:

![image](https://user-images.githubusercontent.com/23084831/232244852-7d7333f0-8049-4d54-96db-3a5a5107b6c7.png)

However, when the LSR instruction writes the result to memory, the new result will be on the bus. Here's the result with the changes I made:

![image](https://user-images.githubusercontent.com/23084831/232244832-dffbf3e2-bd31-47f9-a0dd-5f48a7992798.png)

This corrected behavior is also demonstrated on Visual6502:

![image](https://user-images.githubusercontent.com/23084831/232245342-283bda67-de87-45f0-9a0a-4c74b5d013fe.png)


This issue was relevant for the verification of a recent TAS involving open bus execution. In the most recent version of Bizhawk, the tracelog looks like this:

![image](https://user-images.githubusercontent.com/23084831/232245071-dc38774d-2591-403f-a9c2-a4bd5dcf9687.png)

However, the actual result should be this:

![image](https://user-images.githubusercontent.com/23084831/232245105-30ff03a1-6ef3-4fce-bf62-ce5a7028c480.png)

This run was console verified with help from Alyosha, despite failing in the emulator: [https://www.youtube.com/watch?v=_Qs0G_gLEyk](url)

- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
