### PR TITLE
Fix the build?

### DIFF
--- a/src/MainSlnCommon.props
+++ b/src/MainSlnCommon.props
@@ -22,4 +22,7 @@
 	<ItemGroup Condition=" '$(Configuration)' != 'Debug' ">
 		<Compile Remove="$(MSBuildProjectDirectory)/debug/**/*" />
 	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.3.0-3.final" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
I've been unable to build since 65ffa3f.  The primary issue appeared to be code analysis tools no longer succeeding in loading:

```
CSC : warning CS8032: An instance of analyzer BizHawk.Analyzers.FeatureNotImplementedAnalyzer cannot be created from C:\Develop\BizHawk\References\BizHawk.Analyzer.dll : Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.. [C:\Develop\BizHawk\src\BizHawk.Common\BizHawk.Common.csproj]
```

This ultimately resulted in the git hash information not processing correctly.

This change fixes the build, but I'm not sure if we should do it, as the solution is a bit of a hack.


