### PR TITLE
Fix bugs with entries in patternsform

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/PatternsForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/PatternsForm.cs
@@ -130,18 +130,18 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 
-			// repeating zero times is not allowed
-			if ((int)CountNum.Value == 0)
-			{
-				CountNum.Value = 1;
-			}
-
 			if (PatternList.SelectedIndex == _counts.Count)
 			{
 				_loopAt = (int)CountNum.Value;
 			}
 			else
 			{
+				// repeating zero times is not allowed
+				if ((int)CountNum.Value == 0)
+				{
+					CountNum.Value = 1;
+				}
+
 				_counts[PatternList.SelectedIndex] = (int)CountNum.Value;
 			}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/PatternsForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/PatternsForm.cs
@@ -88,6 +88,10 @@ namespace BizHawk.Client.EmuHawk
 
 		private void DeleteButton_Click(object sender, EventArgs e)
 		{
+			if (PatternList.SelectedIndex >= _counts.Count)
+			{
+				return;
+			}
 			_counts.RemoveAt(PatternList.SelectedIndex);
 			_values.RemoveAt(PatternList.SelectedIndex);
 			UpdatePattern();


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

This changeset addresses two issues with TAStudio/PatternsForm:
- Fixes bug introduced by 883d74d preventing the user from changing the destination of the loop to entry 0
- Fixes #3368 by adding the recommended special case

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
