### PR TITLE
Sanitize text pasted into hex text boxes

### DIFF
--- a/src/BizHawk.Client.EmuHawk/CustomControls/ClipboardEventTextBox.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/ClipboardEventTextBox.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace BizHawk.Client.EmuHawk.CustomControls
+{
+	public class ClipboardEventTextBox : TextBox
+	{
+		protected override void WndProc(ref Message m)
+		{
+			const int WM_PASTE = 0x302;
+
+			if (m.Msg == WM_PASTE)
+			{
+				bool containsText;
+				string text;
+
+				try
+				{
+					containsText = Clipboard.ContainsText();
+					text = containsText ? Clipboard.GetText() : "";
+				}
+				catch (Exception)
+				{
+					// Clipboard is busy? No idea if this ever happens in practice
+					return;
+				}
+
+				var args = new PasteEventArgs(containsText, text);
+				OnPaste(args);
+
+				if (args.Handled)
+					return;
+			}
+
+			base.WndProc(ref m);
+		}
+
+		protected virtual void OnPaste(PasteEventArgs e)
+		{ }
+
+		/// <summary>
+		/// Paste <paramref name="text"/> at selected position without exceeding the <see cref="TextBoxBase.MaxLength"/> limit.
+		/// The pasted string will be truncated if necessary.
+		/// </summary>
+		/// <remarks>
+		/// Does not raise <see cref="OnPaste"/>.
+		/// </remarks>
+		public void PasteWithMaxLength(string text)
+		{
+			if (MaxLength > 0)
+			{
+				int availableLength = MaxLength - TextLength + SelectionLength;
+				if (text.Length > availableLength)
+				{
+					text = text.Substring(0, availableLength);
+				}
+			}
+			Paste(text);
+		}
+
+		protected class PasteEventArgs : EventArgs
+		{
+			public bool ContainsText { get; }
+			public string Text { get; }
+			/// <summary>Prevents regular paste handling if set to <see langword="true"/>.</summary>
+			public bool Handled { get; set; }
+
+			public PasteEventArgs(bool containsText, string text)
+			{
+				ContainsText = containsText;
+				Text = text;
+			}
+		}
+	}
+}

--- a/src/BizHawk.Client.EmuHawk/CustomControls/ClipboardEventTextBox.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/ClipboardEventTextBox.cs
@@ -8,6 +8,7 @@ namespace BizHawk.Client.EmuHawk.CustomControls
 	{
 		protected override void WndProc(ref Message m)
 		{
+			// WM_PASTE is also sent when pasting through the OS context menu, but doesn't work on Mono 
 			const int WM_PASTE = 0x302;
 
 			if (m.Msg is WM_PASTE && !OSTailoredCode.IsUnixHost)
@@ -31,6 +32,7 @@ namespace BizHawk.Client.EmuHawk.CustomControls
 			return base.ProcessCmdKey(ref m, keyData);
 		}
 
+		/// <returns><see langword="true"/> if regular paste handling should be prevented.</returns>
 		private bool OnPasteInternal()
 		{
 			bool containsText;

--- a/src/BizHawk.Client.EmuHawk/CustomControls/ClipboardEventTextBox.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/ClipboardEventTextBox.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Client.EmuHawk.CustomControls
 		{
 			const int WM_PASTE = 0x302;
 
-			if (m.Msg == WM_PASTE && !OSTailoredCode.IsUnixHost)
+			if (m.Msg is WM_PASTE && !OSTailoredCode.IsUnixHost)
 			{
 				if (OnPasteInternal())
 				{
@@ -23,7 +23,7 @@ namespace BizHawk.Client.EmuHawk.CustomControls
 
 		protected override bool ProcessCmdKey(ref Message m, Keys keyData)
 		{
-			if (OSTailoredCode.IsUnixHost && keyData is (Keys.Control | Keys.V) or (Keys.Shift | Keys.Insert) && !ReadOnly)
+			if (!ReadOnly && OSTailoredCode.IsUnixHost && keyData is (Keys.Control | Keys.V) or (Keys.Shift | Keys.Insert))
 			{
 				return OnPasteInternal();
 			}
@@ -39,7 +39,7 @@ namespace BizHawk.Client.EmuHawk.CustomControls
 			try
 			{
 				containsText = Clipboard.ContainsText();
-				text = containsText ? Clipboard.GetText() : "";
+				text = containsText ? Clipboard.GetText() : string.Empty;
 			}
 			catch (Exception)
 			{
@@ -66,16 +66,16 @@ namespace BizHawk.Client.EmuHawk.CustomControls
 		{
 			if (MaxLength > 0)
 			{
-				int availableLength = MaxLength - TextLength + SelectionLength;
+				var availableLength = MaxLength - TextLength + SelectionLength;
 				if (text.Length > availableLength)
 				{
-					text = text.Substring(0, availableLength);
+					text = text.Substring(startIndex: 0, length: availableLength);
 				}
 			}
 			Paste(text);
 		}
 
-		protected class PasteEventArgs : EventArgs
+		protected sealed class PasteEventArgs : EventArgs
 		{
 			public bool ContainsText { get; }
 			public string Text { get; }

--- a/src/BizHawk.Client.EmuHawk/CustomControls/HexTextBox.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/HexTextBox.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Forms;
-
+using BizHawk.Client.EmuHawk.CustomControls;
 using BizHawk.Common.StringExtensions;
 using BizHawk.Common.NumberExtensions;
 
@@ -15,7 +15,7 @@ namespace BizHawk.Client.EmuHawk
 		void SetFromRawInt(int? rawInt);
 	}
 
-	public class HexTextBox : TextBox, INumberBox
+	public class HexTextBox : ClipboardEventTextBox, INumberBox
 	{
 		private string _addressFormatStr = "";
 		private long? _maxSize;
@@ -133,6 +133,21 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			base.OnTextChanged(e);
+		}
+
+		protected override void OnPaste(PasteEventArgs e)
+		{
+			if (e.ContainsText)
+			{
+				string text = e.Text.Trim().RemovePrefix("0x").RemovePrefix('$');
+				if (text.IsHex())
+				{
+					PasteWithMaxLength(text);
+				}
+				e.Handled = true;
+			}
+
+			base.OnPaste(e);
 		}
 
 		public int? ToRawInt()

--- a/src/BizHawk.Client.EmuHawk/CustomControls/HexTextBox.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/HexTextBox.cs
@@ -140,10 +140,7 @@ namespace BizHawk.Client.EmuHawk
 			if (e.ContainsText)
 			{
 				string text = e.Text.CleanHex();
-				if (text.IsHex())
-				{
-					PasteWithMaxLength(text);
-				}
+				PasteWithMaxLength(text);
 				e.Handled = true;
 			}
 

--- a/src/BizHawk.Client.EmuHawk/CustomControls/HexTextBox.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/HexTextBox.cs
@@ -139,7 +139,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (e.ContainsText)
 			{
-				string text = e.Text.Trim().RemovePrefix("0x").RemovePrefix('$');
+				string text = e.Text.CleanHex();
 				if (text.IsHex())
 				{
 					PasteWithMaxLength(text);

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/WatchValueBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/WatchValueBox.cs
@@ -3,11 +3,13 @@ using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
 using BizHawk.Client.Common;
+using BizHawk.Client.EmuHawk.CustomControls;
 using BizHawk.Common.NumberExtensions;
+using BizHawk.Common.StringExtensions;
 
 namespace BizHawk.Client.EmuHawk
 {
-	public class WatchValueBox : TextBox, INumberBox
+	public class WatchValueBox : ClipboardEventTextBox, INumberBox
 	{
 		private WatchSize _size = WatchSize.Byte;
 		private WatchDisplayType _type = WatchDisplayType.Hex;
@@ -429,6 +431,21 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			base.OnTextChanged(e);
+		}
+
+		protected override void OnPaste(PasteEventArgs e)
+		{
+			if (Type == WatchDisplayType.Hex && e.ContainsText)
+			{
+				string text = e.Text.Trim().RemovePrefix("0x").RemovePrefix('$');
+				if (text.IsHex())
+				{
+					PasteWithMaxLength(text);
+				}
+				e.Handled = true;
+			}
+
+			base.OnPaste(e);
 		}
 
 		public int? ToRawInt()

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/WatchValueBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/WatchValueBox.cs
@@ -438,10 +438,7 @@ namespace BizHawk.Client.EmuHawk
 			if (Type is WatchDisplayType.Hex && e.ContainsText)
 			{
 				string text = e.Text.CleanHex();
-				if (text.IsHex())
-				{
-					PasteWithMaxLength(text);
-				}
+				PasteWithMaxLength(text);
 				e.Handled = true;
 			}
 

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/WatchValueBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/WatchValueBox.cs
@@ -437,7 +437,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (Type == WatchDisplayType.Hex && e.ContainsText)
 			{
-				string text = e.Text.Trim().RemovePrefix("0x").RemovePrefix('$');
+				string text = e.Text.CleanHex();
 				if (text.IsHex())
 				{
 					PasteWithMaxLength(text);

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/WatchValueBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/WatchValueBox.cs
@@ -435,7 +435,7 @@ namespace BizHawk.Client.EmuHawk
 
 		protected override void OnPaste(PasteEventArgs e)
 		{
-			if (Type == WatchDisplayType.Hex && e.ContainsText)
+			if (Type is WatchDisplayType.Hex && e.ContainsText)
 			{
 				string text = e.Text.CleanHex();
 				if (text.IsHex())

--- a/src/BizHawk.Common/Extensions/NumericStringExtensions.cs
+++ b/src/BizHawk.Common/Extensions/NumericStringExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace BizHawk.Common.StringExtensions
 {
@@ -32,6 +33,11 @@ namespace BizHawk.Common.StringExtensions
 		/// That is, all chars of the copy will be hex digits (<c>[0-9A-F]</c>).
 		/// </returns>
 		public static string OnlyHex(this string? raw) => string.IsNullOrWhiteSpace(raw) ? string.Empty : string.Concat(raw.Where(IsHex)).ToUpperInvariant();
+
+		/// <returns>
+		/// A copy of <paramref name="raw"/> after removing <c>0x</c>/<c>$</c> prefixes and all whitespace.
+		/// </returns>
+		public static string CleanHex(this string? raw) => raw is null ? string.Empty : Regex.Replace(raw, @"^\s*(0x|\$)|\s+?", "");
 
 #if NET7_0_OR_GREATER
 		public static ushort ParseU16FromHex(ReadOnlySpan<char> str)

--- a/src/BizHawk.Common/Extensions/NumericStringExtensions.cs
+++ b/src/BizHawk.Common/Extensions/NumericStringExtensions.cs
@@ -35,9 +35,21 @@ namespace BizHawk.Common.StringExtensions
 		public static string OnlyHex(this string? raw) => string.IsNullOrWhiteSpace(raw) ? string.Empty : string.Concat(raw.Where(IsHex)).ToUpperInvariant();
 
 		/// <returns>
-		/// A copy of <paramref name="raw"/> after removing <c>0x</c>/<c>$</c> prefixes and all whitespace.
+		/// A copy of <paramref name="raw"/> in uppercase after removing <c>0x</c>/<c>$</c> prefixes and all whitespace, or
+		/// <see cref="string.Empty"/> if <paramref name="raw"/> contains other non-hex characters.
 		/// </returns>
-		public static string CleanHex(this string? raw) => raw is null ? string.Empty : Regex.Replace(raw, @"^\s*(0x|\$)|\s+?", "");
+		public static string CleanHex(this string? raw)
+		{
+			if (raw is not null && CleanHexRegex.Match(raw) is { Success: true} match)
+			{
+				return match.Groups["hex"].Value.OnlyHex();
+			}
+			else
+			{
+				return string.Empty;
+			}
+		}
+		private static readonly Regex CleanHexRegex = new(@"^\s*(?:0x|\$)?(?<hex>[0-9A-Fa-f\s]+)\s*$");
 
 #if NET7_0_OR_GREATER
 		public static ushort ParseU16FromHex(ReadOnlySpan<char> str)

--- a/src/BizHawk.Tests/Common/StringExtensions/NumericStringExtensionTests.cs
+++ b/src/BizHawk.Tests/Common/StringExtensions/NumericStringExtensionTests.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BizHawk.Common.StringExtensions;
+
+namespace BizHawk.Tests.Common.StringExtensions
+{
+	[TestClass]
+	public class NumericStringExtensionTests
+	{
+		[TestMethod]
+		public void TesCleanHex()
+		{
+			Assert.AreEqual("0123456789ABCDEFABCDEF", "0123456789ABCDEFabcdef".CleanHex());
+			Assert.AreEqual("ABCDEF", "0xABCDEF".CleanHex());
+			Assert.AreEqual("ABCDEF", "$ABCDEF".CleanHex());
+			Assert.AreEqual("ABCDEF", " AB CD\nEF ".CleanHex());
+			Assert.AreEqual("ABCDEF", " 0xABCDEF ".CleanHex());
+
+			Assert.AreEqual("", (null as string).CleanHex());
+			Assert.AreEqual("", "".CleanHex());
+			Assert.AreEqual("", "0x$ABCDEF".CleanHex());
+			Assert.AreEqual("", "$0xABCDEF".CleanHex());
+			Assert.AreEqual("", "$$ABCDEF".CleanHex());
+			Assert.AreEqual("", "ABCDEF$".CleanHex());
+			Assert.AreEqual("", "A!B.C(DE)F".CleanHex());
+		}
+	}
+}

--- a/src/BizHawk.Tests/Common/StringExtensions/NumericStringExtensionTests.cs
+++ b/src/BizHawk.Tests/Common/StringExtensions/NumericStringExtensionTests.cs
@@ -16,7 +16,7 @@ namespace BizHawk.Tests.Common.StringExtensions
 			Assert.AreEqual("ABCDEF", " 0xABCDEF ".CleanHex());
 
 			Assert.AreEqual(string.Empty, (null as string).CleanHex());
-			Assert.AreEqual(string.Empty, "".CleanHex());
+			Assert.AreEqual(string.Empty, string.Empty.CleanHex());
 			Assert.AreEqual(string.Empty, "0x$ABCDEF".CleanHex());
 			Assert.AreEqual(string.Empty, "$0xABCDEF".CleanHex());
 			Assert.AreEqual(string.Empty, "$$ABCDEF".CleanHex());

--- a/src/BizHawk.Tests/Common/StringExtensions/NumericStringExtensionTests.cs
+++ b/src/BizHawk.Tests/Common/StringExtensions/NumericStringExtensionTests.cs
@@ -15,13 +15,13 @@ namespace BizHawk.Tests.Common.StringExtensions
 			Assert.AreEqual("ABCDEF", " AB CD\nEF ".CleanHex());
 			Assert.AreEqual("ABCDEF", " 0xABCDEF ".CleanHex());
 
-			Assert.AreEqual("", (null as string).CleanHex());
-			Assert.AreEqual("", "".CleanHex());
-			Assert.AreEqual("", "0x$ABCDEF".CleanHex());
-			Assert.AreEqual("", "$0xABCDEF".CleanHex());
-			Assert.AreEqual("", "$$ABCDEF".CleanHex());
-			Assert.AreEqual("", "ABCDEF$".CleanHex());
-			Assert.AreEqual("", "A!B.C(DE)F".CleanHex());
+			Assert.AreEqual(string.Empty, (null as string).CleanHex());
+			Assert.AreEqual(string.Empty, "".CleanHex());
+			Assert.AreEqual(string.Empty, "0x$ABCDEF".CleanHex());
+			Assert.AreEqual(string.Empty, "$0xABCDEF".CleanHex());
+			Assert.AreEqual(string.Empty, "$$ABCDEF".CleanHex());
+			Assert.AreEqual(string.Empty, "ABCDEF$".CleanHex());
+			Assert.AreEqual(string.Empty, "A!B.C(DE)F".CleanHex());
 		}
 	}
 }


### PR DESCRIPTION
- Add `ClipboardEventTextBox` control with an `OnPaste` method and make  `HexTextBox` and `WatchValueBox` inherit from that

- Override normal paste behavior to trim `0x`/`$`/whitespace from pasted text

- Prevent pasting of non-hex text

Resolves  #3682

- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
