### PR TITLE
Added support for Tools.GeneralUpdate() in MainForm

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3281,6 +3281,10 @@ namespace BizHawk.Client.EmuHawk
 				// Tools will want to be updated after rewind (load state), but we only need to manually do this if we did not frame advance.
 				UpdateToolsAfter();
 			}
+			else
+			{
+				Tools.GeneralUpdate();
+			}
 
 			Sound.UpdateSound(atten, DisableSecondaryThrottling);
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -753,6 +753,17 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		public void GeneralUpdate()
+		{
+			foreach (var tool in _tools)
+			{
+				if (tool.IsActive)
+				{
+					tool.UpdateValues(ToolFormUpdateType.General);
+				}
+			}
+		}
+
 		private static readonly IList<string> PossibleToolTypeNames = EmuHawk.ReflectionCache.Types.Select(t => t.AssemblyQualifiedName).ToList();
 
 		public bool IsAvailable(Type tool)


### PR DESCRIPTION
Currently, `ToolManager` does not have `GeneralUpdate()` exposed in the `MainForm` class. I added very minimal changes and added the `GeneralUpdate()` function, so that when BizHawk is running, the emulation is paused, TAStudio is opened, and an external tool is loaded and opened, the external tool can finally be able to update by overriding `ToolFormBase.GeneralUpdate()` and do things in the background without the requirements of having to frame advance or unpause the emulation.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites (The test suite is an integration test, with me verifying that the external tool can be invoked by `GeneralUpdate()` when correctly implemented).
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant

Should be able to close #3626 .
