### PR TITLE
update PR license agreement to clarify licensing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,4 @@
 [//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
 Check if completed:
 - [ ] I have run any relevant test suites
-- [ ] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
+- [ ] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2023-08-16) and am compliant

--- a/contributing.md
+++ b/contributing.md
@@ -288,6 +288,7 @@ See [Waterbox readme](https://github.com/TASEmulators/BizHawk/tree/master/waterb
 [//]: # "Changing this section? Don't forget to update the modification date in the PR template!"
 
 By contributing, you declare that any additions or changes either:
-- were authored by you (and you are willing to transfer your copyrights to us); or
-- were copied from a publicly-licensed source and are properly attributed, including licensing info.
+- were authored by you and you are willing to license your contributions to us under the [project's license](https://github.com/TASEmulators/BizHawk/tree/master/LICENSE); or
+- were copied from a compatibly open-source, publicly-licensed source and are properly attributed, including licensing info.
+> **Important**
 > We will **not** accept any contributions "authored" by GitHub Copilot or similar ML tools.


### PR DESCRIPTION
* make the GitHub Copilot note more prominent

[Rendered](https://github.com/RetroEdit/BizHawk/blob/contributor-agreement-change/contributing.md#copyrights-and-licensing)

I thought the phrasing for the contributor's licensing agreement could be improved, since it was created since the last time I contributed and I didn't review it at that point in time.

Check if completed:
- [x] I have run any relevant test suites: **(not applicable)**
- [ ] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
