### PR TITLE
Set inputdisplay correctly on LoadState

### DIFF
--- a/src/BizHawk.Client.Common/movie/MovieSession.cs
+++ b/src/BizHawk.Client.Common/movie/MovieSession.cs
@@ -154,7 +154,8 @@ namespace BizHawk.Client.Common
 				}
 				else if (Movie.IsPlayingOrFinished())
 				{
-					LatchInputToLog();
+					int previousFrame = Movie.Emulator.Frame - 1;
+					Movie.Session.MovieController.SetFrom(Movie.GetInputState(previousFrame));
 				}
 				else if (Movie.IsFinished())
 				{

--- a/src/BizHawk.Client.Common/movie/MovieSession.cs
+++ b/src/BizHawk.Client.Common/movie/MovieSession.cs
@@ -154,6 +154,7 @@ namespace BizHawk.Client.Common
 				}
 				else if (Movie.IsPlayingOrFinished())
 				{
+					// set the controller state to the previous frame for input display purposes
 					int previousFrame = Movie.Emulator.Frame - 1;
 					Movie.Session.MovieController.SetFrom(Movie.GetInputState(previousFrame));
 				}

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.cs
@@ -92,10 +92,10 @@ namespace BizHawk.Client.Common
 
 		public IMovieController GetInputState(int frame)
 		{
-			if (frame < FrameCount && frame >= 0)
+			if (frame < FrameCount && frame >= -1)
 			{
 				_adapter ??= new Bk2Controller(LogKey, Session.MovieController.Definition);
-				_adapter.SetFromMnemonic(Log[frame]);
+				_adapter.SetFromMnemonic(frame >= 0 ? Log[frame] : Session.Movie.LogGeneratorInstance(Session.MovieController).EmptyEntry);
 				return _adapter;
 			}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -219,6 +219,9 @@ namespace BizHawk.Client.EmuHawk
 
 			Movie.LoadBranch(branch);
 			Tastudio.LoadState(new(branch.Frame, new MemoryStream(branch.CoreData, false)));
+			int previousFrame = Movie.Emulator.Frame - 1;
+			Tastudio.MovieSession.MovieController.SetFrom(Movie.GetInputState(previousFrame));
+
 			Movie.TasStateManager.Capture(Tastudio.Emulator.Frame, Tastudio.Emulator.AsStatable());
 			QuickBmpFile.Copy(new BitmapBufferVideoProvider(branch.CoreFrameBuffer), Tastudio.VideoProvider);
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -219,6 +219,7 @@ namespace BizHawk.Client.EmuHawk
 
 			Movie.LoadBranch(branch);
 			Tastudio.LoadState(new(branch.Frame, new MemoryStream(branch.CoreData, false)));
+			// set the controller state to the previous frame for input display purposes
 			int previousFrame = Movie.Emulator.Frame - 1;
 			Tastudio.MovieSession.MovieController.SetFrom(Movie.GetInputState(previousFrame));
 


### PR DESCRIPTION
Resolves #3741.

Previously loading a state would either not update the input display (in case of TAStudio) or make the input display display the current frame's inputs, not the inputs of the previous frame (outside of TAStudio).

I'm honestly unsure if this can break anything so I'm making a PR instead of pushing to master directly.