### PR TITLE
Dispose disks in Nyma cores

### DIFF
--- a/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.cs
@@ -334,5 +334,17 @@ namespace BizHawk.Emulation.Cores.Waterbox
 
 		private IntPtr _frameThreadPtr;
 		private Action _frameThreadStart;
+
+		public override void Dispose()
+		{
+			if (_disks != null)
+			{
+				foreach (var disk in _disks)
+				{
+					disk.Dispose();
+				}
+			}
+			base.Dispose();
+		}
 	}
 }


### PR DESCRIPTION
Override `Dispose` in `NymaCore` and dispose opened disks like other cores do. Affects Nymashock, Saturnus and possibly others

This should resolve #3750 

Check if completed:
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
