### PR TITLE
Stop moving exe PDBs to dll folder

### DIFF
--- a/src/MainSlnExecutable.props
+++ b/src/MainSlnExecutable.props
@@ -18,7 +18,7 @@
 		<ItemGroup>
 			<NotExecFilesFromExecProj Include="$(OutputPath)*.deps.json" />
 			<NotExecFilesFromExecProj Include="$(OutputPath)*.dll" />
-			<NotExecFilesFromExecProj Include="$(OutputPath)*.pdb" />
+			<NotExecFilesFromExecProj Include="$(OutputPath)*.pdb" Exclude="$(OutputPath)EmuHawk.pdb;$(OutputPath)DiscoHawk.pdb" />
 			<NotExecFilesFromExecProj Include="$(OutputPath)*.xml" />
 		</ItemGroup>
 		<Move Condition=" $(IsTargetingNetFramework) " SourceFiles="@(NotExecFilesFromExecProj)" DestinationFolder="$(OutputPath)dll/" />


### PR DESCRIPTION
This PR modifies the build target that moves files into the `dll` subdirectory to exclude the PDBs for `EmuHawk.exe` and `DiscoHawk.exe`.

This allows VS to find those PDBs automatically, which improves the debugger experience when profiling or debugging release builds, without having to manually load those PDBs or fiddle with the symbol source locations.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
