### PR TITLE
Added soft and hard reset event hooks for apis.

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
@@ -31,6 +31,10 @@ namespace BizHawk.Client.Common
 
 		public event StateSavedEventHandler StateSaved;
 
+		public event HardResetEventHandler HardReset;
+
+		public event SoftResetEventHandler SoftReset;
+
 		public EmuClientApi(Action<string> logCallback, IMainFormForApi mainForm, DisplayManagerBase displayManager, Config config, IEmulator emulator, IGameInfo game)
 		{
 			_config = config;
@@ -139,6 +143,10 @@ namespace BizHawk.Client.Common
 		public void OnStateLoaded(object sender, string stateName) => StateLoaded?.Invoke(sender, new StateLoadedEventArgs(stateName));
 
 		public void OnStateSaved(object sender, string stateName) => StateSaved?.Invoke(sender, new StateSavedEventArgs(stateName));
+
+		public void OnHardReset(object sender) => HardReset?.Invoke(sender, new HardResetEventArgs());
+
+		public void OnSoftReset(object sender) => SoftReset?.Invoke(sender, new SoftResetEventArgs());
 
 		public bool OpenRom(string path)
 			=> _mainForm.LoadRom(path, new LoadRomArgs { OpenAdvanced = OpenAdvancedSerializer.ParseWithLegacy(path) });

--- a/src/BizHawk.Client.Common/Api/Interfaces/IEmuClientApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IEmuClientApi.cs
@@ -32,6 +32,16 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		event StateSavedEventHandler StateSaved;
 
+		/// <summary>
+		/// Occurs when a hard reset is initiated
+		/// </summary>
+		event HardResetEventHandler HardReset;
+
+		/// <summary>
+		/// Occurs when a soft reset is initiated
+		/// </summary>
+		event SoftResetEventHandler SoftReset;
+
 		int BorderHeight();
 
 		int BorderWidth();

--- a/src/BizHawk.Client.Common/EventTypes.cs
+++ b/src/BizHawk.Client.Common/EventTypes.cs
@@ -98,6 +98,32 @@ namespace BizHawk.Client.Common
 	}
 
 	/// <summary>
+	/// This class holds event data for HardReset event
+	/// </summary>
+	public sealed class HardResetEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Initialize a new instance of <see cref="HardResetEventArgs"/>
+		/// </summary>
+		public HardResetEventArgs()
+		{
+		}
+	}
+
+	/// <summary>
+	/// This class holds event data for SoftReset event
+	/// </summary>
+	public sealed class SoftResetEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Initialize a new instance of <see cref="SoftResetEventArgs"/>
+		/// </summary>
+		public SoftResetEventArgs()
+		{
+		}
+	}
+
+	/// <summary>
 	/// Represent a method that will handle the event raised before a quickload is done
 	/// </summary>
 	/// <param name="sender">Object that raised the event</param>
@@ -124,4 +150,18 @@ namespace BizHawk.Client.Common
 	/// <param name="sender">Object that raised the event</param>
 	/// <param name="e">Event arguments</param>
 	public delegate void StateSavedEventHandler(object sender, StateSavedEventArgs e);
+
+	/// <summary>
+	/// Represent a method that will handle the event raised when a hard reset is performed
+	/// </summary>
+	/// <param name="sender">Object that raised the event</param>
+	/// <param name="e">Event arguments</param>
+	public delegate void HardResetEventHandler(object sender, HardResetEventArgs e);
+
+	/// <summary>
+	/// Represent a method that will handle the event raised when a soft reset is performed
+	/// </summary>
+	/// <param name="sender">Object that raised the event</param>
+	/// <param name="e">Event arguments</param>
+	public delegate void SoftResetEventHandler(object sender, SoftResetEventArgs e);
 }

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2628,6 +2628,8 @@ namespace BizHawk.Client.EmuHawk
 			{
 				InputManager.ClickyVirtualPadController.Click("Reset");
 				AddOnScreenMessage("Reset button pressed.");
+
+				EmuClient.OnSoftReset(this);
 			}
 		}
 
@@ -2639,6 +2641,8 @@ namespace BizHawk.Client.EmuHawk
 			{
 				InputManager.ClickyVirtualPadController.Click("Power");
 				AddOnScreenMessage("Power button pressed.");
+
+				EmuClient.OnHardReset(this);
 			}
 		}
 


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

Adds api hooks: HardReset and SoftReset inside of IEmuClientApi interface, which allows consumers of APIHawk to detect when Soft Resets and Hard Resets are triggered via EmuHawk UX. This is potentially useful for HUD interfaces counting resets without needing to infer based on specific points in game code and would allow for uniform handling of Hard Resets which won't go through the Reset handler code in the Game Rom for certain systems such as GB and NES.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [X] I have run any relevant test suites
- [X] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
