### PR TITLE
Add setting to control what happens when double-clicking RAM watch 

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.Designer.cs
@@ -668,7 +668,7 @@ namespace BizHawk.Client.EmuHawk
             this.DoubleClickActionSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.DoubleClickToEditMenuItem,
             this.DoubleClickToPokeMenuItem});
-            this.DoubleClickActionSubMenu.Text = "Double-Click Action";
+            this.DoubleClickActionSubMenu.Text = "On Double-Clicking a Watch";
             this.DoubleClickActionSubMenu.DropDownOpening += new System.EventHandler(this.DoubleClickActionSubMenu_DropDownOpening);
             // 
             // DoubleClickToEditMenuItem

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.Designer.cs
@@ -107,6 +107,9 @@ namespace BizHawk.Client.EmuHawk
             this.OriginalMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.WatchesOnScreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.WatchListView = new InputRoll();
+            this.DoubleClickActionSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DoubleClickToEditMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DoubleClickToPokeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.ListViewContextMenu.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
@@ -600,7 +603,8 @@ namespace BizHawk.Client.EmuHawk
             // 
             this.OptionsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.DefinePreviousValueSubMenu,
-            this.WatchesOnScreenMenuItem});
+            this.WatchesOnScreenMenuItem,
+            this.DoubleClickActionSubMenu});
             this.OptionsSubMenu.Text = "&Settings";
             this.OptionsSubMenu.DropDownOpened += new System.EventHandler(this.SettingsSubMenu_DropDownOpened);
             // 
@@ -658,6 +662,24 @@ namespace BizHawk.Client.EmuHawk
             this.WatchListView.DragEnter += new System.Windows.Forms.DragEventHandler(this.DragEnterWrapper);
             this.WatchListView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.WatchListView_KeyDown);
             this.WatchListView.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.WatchListView_MouseDoubleClick);
+            // 
+            // DoubleClickActionSubMenu
+            // 
+            this.DoubleClickActionSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.DoubleClickToEditMenuItem,
+            this.DoubleClickToPokeMenuItem});
+            this.DoubleClickActionSubMenu.Text = "Double-Click Action";
+            this.DoubleClickActionSubMenu.DropDownOpening += new System.EventHandler(this.DoubleClickActionSubMenu_DropDownOpening);
+            // 
+            // DoubleClickToEditMenuItem
+            // 
+            this.DoubleClickToEditMenuItem.Text = "Edit Watch";
+            this.DoubleClickToEditMenuItem.Click += new System.EventHandler(this.DoubleClickToEditMenuItem_Click);
+            // 
+            // DoubleClickToPokeMenuItem
+            // 
+            this.DoubleClickToPokeMenuItem.Text = "Poke Address";
+            this.DoubleClickToPokeMenuItem.Click += new System.EventHandler(this.DoubleClickToPokeMenuItem_Click);
             // 
             // RamWatch
             // 
@@ -765,5 +787,8 @@ namespace BizHawk.Client.EmuHawk
         private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveBottomMenuItem;
         private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveTopContextMenuItem;
         private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveBottomContextMenuItem;
+        private ToolStripMenuItemEx DoubleClickActionSubMenu;
+        private ToolStripMenuItemEx DoubleClickToEditMenuItem;
+        private ToolStripMenuItemEx DoubleClickToPokeMenuItem;
     }
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -435,6 +435,17 @@ namespace BizHawk.Client.EmuHawk
 			GeneralUpdate();
 		}
 
+		/// <summary>
+		/// Open Edit or Poke window for selected watch depending on user setting
+		/// </summary>
+		private void OpenWatch()
+		{
+			if (Settings.DoubleClickToPoke)
+				PokeAddress();
+			else
+				EditWatch();
+		}
+
 		private void EditWatch(bool duplicate = false)
 		{
 			var indexes = SelectedIndices.ToList();
@@ -1227,7 +1238,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 			else if (e.IsPressed(Keys.Enter))
 			{
-				EditWatch();
+				OpenWatch();
 			}
 		}
 
@@ -1240,10 +1251,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void WatchListView_MouseDoubleClick(object sender, MouseEventArgs e)
 		{
-			if (Settings.DoubleClickToPoke)
-				PokeAddress();
-			else
-				EditWatch();
+			OpenWatch();
 		}
 
 		private void WatchListView_ColumnClick(object sender, InputRoll.ColumnClickEventArgs e)

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -441,9 +441,13 @@ namespace BizHawk.Client.EmuHawk
 		private void OpenWatch()
 		{
 			if (Settings.DoubleClickToPoke)
+			{
 				PokeAddress();
+			}
 			else
+			{
 				EditWatch();
+			}
 		}
 
 		private void EditWatch(bool duplicate = false)

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -179,6 +179,8 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			public List<RollColumn> Columns { get; set; }
+
+			public bool DoubleClickToPoke { get; set; }
 		}
 
 		private IEnumerable<int> SelectedIndices => WatchListView.SelectedRows;
@@ -491,6 +493,22 @@ namespace BizHawk.Client.EmuHawk
 				}
 
 				GeneralUpdate();
+			}
+		}
+
+		private void PokeAddress()
+		{
+			if (SelectedWatches.Any())
+			{
+				var poke = new RamPoke(DialogController, SelectedWatches, MainForm.CheatList)
+				{
+					InitialLocation = this.ChildPointToScreen(WatchListView)
+				};
+
+				if (this.ShowDialogWithTempMute(poke).IsOk())
+				{
+					GeneralUpdate();
+				}
 			}
 		}
 
@@ -836,18 +854,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void PokeAddressMenuItem_Click(object sender, EventArgs e)
 		{
-			if (SelectedWatches.Any())
-			{
-				var poke = new RamPoke(DialogController, SelectedWatches, MainForm.CheatList)
-				{
-					InitialLocation = this.ChildPointToScreen(WatchListView)
-				};
-
-				if (this.ShowDialogWithTempMute(poke).IsOk())
-				{
-					GeneralUpdate();
-				}
-			}
+			PokeAddress();
 		}
 
 		private void FreezeAddressMenuItem_Click(object sender, EventArgs e)
@@ -1036,6 +1043,22 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		private void DoubleClickActionSubMenu_DropDownOpening(object sender, EventArgs e)
+		{
+			DoubleClickToEditMenuItem.Checked = !Settings.DoubleClickToPoke;
+			DoubleClickToPokeMenuItem.Checked = Settings.DoubleClickToPoke;
+		}
+
+		private void DoubleClickToEditMenuItem_Click(object sender, EventArgs e)
+		{
+			Settings.DoubleClickToPoke = false;
+		}
+
+		private void DoubleClickToPokeMenuItem_Click(object sender, EventArgs e)
+		{
+			Settings.DoubleClickToPoke = true;
+		}
+
 		[RestoreDefaults]
 		private void RestoreDefaultsMenuItem()
 		{
@@ -1217,7 +1240,10 @@ namespace BizHawk.Client.EmuHawk
 
 		private void WatchListView_MouseDoubleClick(object sender, MouseEventArgs e)
 		{
-			EditWatch();
+			if (Settings.DoubleClickToPoke)
+				PokeAddress();
+			else
+				EditWatch();
 		}
 
 		private void WatchListView_ColumnClick(object sender, InputRoll.ColumnClickEventArgs e)

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -180,7 +180,7 @@ namespace BizHawk.Client.EmuHawk
 
 			public List<RollColumn> Columns { get; set; }
 
-			public bool DoubleClickToPoke { get; set; }
+			public bool DoubleClickToPoke { get; set; } = true;
 		}
 
 		private IEnumerable<int> SelectedIndices => WatchListView.SelectedRows;

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -511,22 +511,6 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private void PokeAddress()
-		{
-			if (SelectedWatches.Any())
-			{
-				var poke = new RamPoke(DialogController, SelectedWatches, MainForm.CheatList)
-				{
-					InitialLocation = this.ChildPointToScreen(WatchListView)
-				};
-
-				if (this.ShowDialogWithTempMute(poke).IsOk())
-				{
-					GeneralUpdate();
-				}
-			}
-		}
-
 		private string ComputeDisplayType(Watch w)
 		{
 			string s = w.Size == WatchSize.Byte ? "1" : (w.Size == WatchSize.Word ? "2" : "4");
@@ -870,6 +854,22 @@ namespace BizHawk.Client.EmuHawk
 		private void PokeAddressMenuItem_Click(object sender, EventArgs e)
 		{
 			PokeAddress();
+		}
+
+		private void PokeAddress()
+		{
+			if (SelectedWatches.Any())
+			{
+				var poke = new RamPoke(DialogController, SelectedWatches, MainForm.CheatList)
+				{
+					InitialLocation = this.ChildPointToScreen(WatchListView)
+				};
+
+				if (this.ShowDialogWithTempMute(poke).IsOk())
+				{
+					GeneralUpdate();
+				}
+			}
 		}
 
 		private void FreezeAddressMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
- Add a new setting to the `RamWatch` dialog menu that changes whether double-clicking a watch in the list will open the Edit or the Poke dialog. 
- Setting defaults to poke (previous behavior was edit)
- Pressing enter also obeys this setting 

Resolves #3688

Check if completed:
- [ ] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
