### PR TITLE
Replace `SortedSet` with `SortedList<T>` in `InputRoll`

### DIFF
--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/Cell.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/Cell.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 
 using BizHawk.Common;
+using BizHawk.Common.CollectionExtensions;
 
 namespace BizHawk.Client.EmuHawk
 {
@@ -105,6 +106,21 @@ namespace BizHawk.Client.EmuHawk
 			}
 			_list.Insert(~i, item);
 		}
+
+		public bool IncludesRow(int rowIndex)
+#if false
+			=> _list.Exists(cell => cell.RowIndex == rowIndex);
+#elif false
+		{
+			var i = _list.BinarySearch(new() { RowIndex = rowIndex, Column = null });
+			return i >= 0 || (~i < _list.Count && _list[~i].RowIndex == rowIndex);
+		}
+#else
+		{
+			var i = _list.LowerBoundBinarySearch(static c => c.RowIndex ?? -1, rowIndex);
+			return i >= 0 && _list[i].RowIndex == rowIndex;
+		}
+#endif
 	}
 
 	public static class CellExtensions

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -22,7 +22,8 @@ namespace BizHawk.Client.EmuHawk
 	public partial class InputRoll : Control
 	{
 		private readonly IControlRenderer _renderer;
-		private readonly SortedSet<Cell> _selectedItems = new SortedSet<Cell>(new SortCell());
+
+		private readonly CellList _selectedItems = new();
 
 		// scrollbar location(s) are calculated later (e.g. on resize)
 		private readonly VScrollBar _vBar = new VScrollBar { Visible = false };
@@ -265,13 +266,10 @@ namespace BizHawk.Client.EmuHawk
 
 					_rowCount = value;
 
+					//TODO replace this with a binary search + truncate
 					if (_selectedItems.Max(s => s.RowIndex) >= _rowCount)
 					{
-#if NETFRAMEWORK
 						_selectedItems.RemoveAll(i => i.RowIndex >= _rowCount);
-#else
-						_selectedItems.RemoveWhere(i => i.RowIndex >= _rowCount);
-#endif
 					}
 
 					RecalculateScrollBars();
@@ -576,7 +574,8 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					_selectedItems.RemoveWhere(cell => cell.RowIndex == index);
+					IEnumerable<Cell> items = _selectedItems.Where(cell => cell.RowIndex == index);
+					_selectedItems.RemoveAll(items.Contains);
 					_lastSelectedRow = _selectedItems.LastOrDefault()?.RowIndex;
 				}
 			}
@@ -612,7 +611,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public void TruncateSelection(int index)
 		{
-			_selectedItems.RemoveWhere(cell => cell.RowIndex > index);
+			_selectedItems.RemoveAll(cell => cell.RowIndex > index);
 			_lastSelectedRow = _selectedItems.LastOrDefault()?.RowIndex;
 		}
 
@@ -1788,7 +1787,7 @@ namespace BizHawk.Client.EmuHawk
 
 				if (FullRowSelect)
 				{
-					if (toggle && (_selectedItems.RemoveWhere(x => x.RowIndex == row) is not 0))
+					if (toggle && (_selectedItems.RemoveAll(x => x.RowIndex == row) is not 0))
 					{
 						_lastSelectedRow = _selectedItems.LastOrDefault()?.RowIndex;
 					}

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -969,7 +969,7 @@ namespace BizHawk.Client.EmuHawk
 			=> SelectedRowsWithDuplicates.First();
 
 		public bool IsRowSelected(int rowIndex)
-			=> _selectedItems.Any(cell => cell.RowIndex == rowIndex);
+			=> _selectedItems.IncludesRow(rowIndex);
 
 		public IEnumerable<ToolStripItem> GenerateContextMenuItems()
 		{
@@ -1159,12 +1159,12 @@ namespace BizHawk.Client.EmuHawk
 					}
 					else if (ModifierKeys == Keys.Shift && CurrentCell.Column.Type == ColumnType.Text)
 					{
-						if (_selectedItems.Any())
+						if (_selectedItems.Count is not 0)
 						{
 							if (FullRowSelect)
 							{
 								var targetRow = CurrentCell.RowIndex.Value;
-								if (!_selectedItems.Any(c => c.RowIndex == targetRow))
+								if (!_selectedItems.IncludesRow(targetRow))
 								{
 									int additionStart, additionEndExcl;
 									SortedList<int> rowIndices = new(SelectedRows);
@@ -1465,8 +1465,8 @@ namespace BizHawk.Client.EmuHawk
 				{
 					if (MultiSelect && _lastSelectedRow > 0)
 					{
-						if (_selectedItems.Any(i => i.RowIndex == _lastSelectedRow.Value)
-							&& _selectedItems.Any(i => i.RowIndex == _lastSelectedRow - 1)) // Unhighlight if already highlighted
+						if (_selectedItems.IncludesRow(_lastSelectedRow.Value)
+							&& _selectedItems.IncludesRow(_lastSelectedRow.Value - 1)) // Unhighlight if already highlighted
 						{
 							SelectRow(_lastSelectedRow.Value, false);
 						}
@@ -1482,8 +1482,8 @@ namespace BizHawk.Client.EmuHawk
 				{
 					if (MultiSelect && _lastSelectedRow < RowCount - 1)
 					{
-						if (_selectedItems.Any(i => i.RowIndex == _lastSelectedRow.Value)
-							&& _selectedItems.Any(i => i.RowIndex == _lastSelectedRow + 1)) // Unhighlight if already highlighted
+						if (_selectedItems.IncludesRow(_lastSelectedRow.Value)
+							&& _selectedItems.IncludesRow(_lastSelectedRow.Value + 1)) // Unhighlight if already highlighted
 						{
 							var origIndex = _lastSelectedRow.Value;
 							SelectRow(origIndex, false);
@@ -1787,8 +1787,9 @@ namespace BizHawk.Client.EmuHawk
 
 				if (FullRowSelect)
 				{
-					if (toggle && (_selectedItems.RemoveAll(x => x.RowIndex == row) is not 0))
+					if (toggle && _selectedItems.IncludesRow(row))
 					{
+						_selectedItems.RemoveAll(x => x.RowIndex == row);
 						_lastSelectedRow = _selectedItems.LastOrDefault()?.RowIndex;
 					}
 					else
@@ -1803,7 +1804,7 @@ namespace BizHawk.Client.EmuHawk
 				else
 				{
 					_lastSelectedRow = null; // TODO: tracking this by cell is a lot more work
-					if (toggle && _selectedItems.Any(x => x.RowIndex == row))
+					if (toggle && _selectedItems.IncludesRow(row))
 					{
 						var item = _selectedItems
 							.FirstOrDefault(x => x.Equals(cell));

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -10,6 +10,7 @@ using BizHawk.Client.Common;
 using BizHawk.Client.EmuHawk.CustomControls;
 using BizHawk.Common;
 using BizHawk.Common.CollectionExtensions;
+using CollectionExtensions = BizHawk.Common.CollectionExtensions.CollectionExtensions;
 
 // TODO: There are some bad interactions between ScrollToIndex and MakeIndexVisible that are preventing things from working as intended.
 //       But, the current behaviour is ok for now for what it is used for.
@@ -267,7 +268,7 @@ namespace BizHawk.Client.EmuHawk
 					_rowCount = value;
 
 					//TODO replace this with a binary search + truncate
-					if (_selectedItems.Max(s => s.RowIndex) >= _rowCount)
+					if (_selectedItems.LastOrDefault()?.RowIndex >= _rowCount)
 					{
 						_selectedItems.RemoveAll(i => i.RowIndex >= _rowCount);
 					}
@@ -623,13 +624,13 @@ namespace BizHawk.Client.EmuHawk
 		[Browsable(false)]
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		public int? SelectionStartIndex
-			=> AnyRowsSelected ? SelectedRowsWithDuplicates.Min() : null;
+			=> AnyRowsSelected ? SelectedRowsWithDuplicates.First() : null;
 
 		/// <returns>the <see cref="Cell.RowIndex"/> of the selected row with the latest index, or <see langword="null"/> if no rows are selected</returns>
 		[Browsable(false)]
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		public int? SelectionEndIndex
-			=> AnyRowsSelected ? SelectedRowsWithDuplicates.Max() : null;
+			=> AnyRowsSelected ? SelectedRowsWithDuplicates.Last() : null;
 
 		/// <summary>
 		/// Gets or sets the current Cell that the mouse was in.

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -10,7 +10,6 @@ using BizHawk.Client.Common;
 using BizHawk.Client.EmuHawk.CustomControls;
 using BizHawk.Common;
 using BizHawk.Common.CollectionExtensions;
-using CollectionExtensions = BizHawk.Common.CollectionExtensions.CollectionExtensions;
 
 // TODO: There are some bad interactions between ScrollToIndex and MakeIndexVisible that are preventing things from working as intended.
 //       But, the current behaviour is ok for now for what it is used for.

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -619,6 +619,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 
 				CurrentTasMovie.RemoveFrames(TasView.SelectedRows.ToArray());
+				SetTasViewRowCount();
 				SetSplicer();
 
 				if (needsToRollback)

--- a/src/BizHawk.Common/CustomCollections.cs
+++ b/src/BizHawk.Common/CustomCollections.cs
@@ -71,6 +71,9 @@ namespace BizHawk.Common
 
 		public virtual void CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
 
+		public T FirstOrDefault()
+			=> _list.Count is 0 ? default! : _list[0];
+
 		public virtual IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
 
 		/// <remarks>throws if list is empty</remarks>
@@ -86,6 +89,9 @@ namespace BizHawk.Common
 			var i = _list.BinarySearch(item);
 			return i < 0 ? -1 : i;
 		}
+
+		public T LastOrDefault()
+			=> _list.Count is 0 ? default! : _list[_list.Count - 1];
 
 		public virtual bool Remove(T item)
 		{


### PR DESCRIPTION
Following up on https://github.com/TASEmulators/BizHawk/commit/6d40c08c3c1404a217617c0bd237ba58f1ada76c#r139706953. Turns out I'd [already had that idea](https://github.com/TASEmulators/BizHawk/commit/67ba0e4f238a323a90a94dd3d25f7e9a08331830) some years ago (time flies) but never finished it.

I've tested this by trying a few of TAStudio's features and the assertion was never hit, but it deserves more scrutiny, and the `RemoveAll` call that was the impetus for all this will need reprofiling.