### PR TITLE
Add some larger sizes to `View` -> `Window Size` (Fixes #3826)

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -57,6 +57,7 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator21 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.AutoloadLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveSlotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectSlot1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectSlot2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectSlot3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -66,7 +67,6 @@ namespace BizHawk.Client.EmuHawk
 			this.SelectSlot7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectSlot8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectSlot9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PreviousSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.NextSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
@@ -134,7 +134,6 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripMenuItem4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DisplayStatusBarMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DisplayMessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DisplayLogWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ControllersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -206,9 +205,9 @@ namespace BizHawk.Client.EmuHawk
 			this.GameSharkConverterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator29 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.MultiDiskBundlerFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.BatchRunnerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ExternalToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.dummyExternalTool = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BatchRunnerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.StartRetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.NESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -260,14 +259,14 @@ namespace BizHawk.Client.EmuHawk
 			this.ColecoUseSGMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.N64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.N64PluginSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Ares64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Ares64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.N64ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator23 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.N64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Ares64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MupenStyleLagMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.N64ExpansionSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Ares64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Ares64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Ares64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.GBLSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.GBLsettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AppleSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -373,6 +372,7 @@ namespace BizHawk.Client.EmuHawk
 			this.ShowMenuContextMenuSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ShowMenuContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
+			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.MainformMenu.SuspendLayout();
 			this.MainStatusBar.SuspendLayout();
 			this.MainFormContextMenu.SuspendLayout();
@@ -380,7 +380,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// MainformMenu
 			// 
-			this.MainformMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
 			this.MainformMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.FileSubMenu,
 			this.EmulationSubMenu,
@@ -529,6 +528,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// AutosaveLastSlotMenuItem
 			// 
+			this.AutosaveLastSlotMenuItem.Name = "AutosaveLastSlotMenuItem";
 			this.AutosaveLastSlotMenuItem.Text = "Autosave Last Slot";
 			this.AutosaveLastSlotMenuItem.Click += new System.EventHandler(this.AutosaveLastSlotMenuItem_Click);
 			// 
@@ -633,6 +633,11 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveSlotSubMenu.Text = "Save S&lot";
 			this.SaveSlotSubMenu.DropDownOpened += new System.EventHandler(this.SaveSlotSubMenu_DropDownOpened);
 			// 
+			// SelectSlot0MenuItem
+			// 
+			this.SelectSlot0MenuItem.Text = "Select Slot 10";
+			this.SelectSlot0MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
 			// SelectSlot1MenuItem
 			// 
 			this.SelectSlot1MenuItem.Text = "Select Slot 1";
@@ -677,11 +682,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SelectSlot9MenuItem.Text = "Select Slot 9";
 			this.SelectSlot9MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// SelectSlot0MenuItem
-			// 
-			this.SelectSlot0MenuItem.Text = "Select Slot 10";
-			this.SelectSlot0MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// PreviousSlotMenuItem
 			// 
@@ -866,7 +866,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.CaptureLuaMenuItem.CheckOnClick = true;
 			this.CaptureLuaMenuItem.Name = "CaptureLuaMenuItem";
-			this.CaptureLuaMenuItem.Size = new System.Drawing.Size(288, 26);
+			this.CaptureLuaMenuItem.Size = new System.Drawing.Size(225, 22);
 			this.CaptureLuaMenuItem.Text = "Capture Lua";
 			this.CaptureLuaMenuItem.Click += new System.EventHandler(this.CaptureLuaMenuItem_Click);
 			// 
@@ -1399,6 +1399,17 @@ namespace BizHawk.Client.EmuHawk
 			this.BasicBotMenuItem.Text = "Basic Bot";
 			this.BasicBotMenuItem.Click += new System.EventHandler(this.BasicBotMenuItem_Click);
 			// 
+			// RetroAchievementsMenuItem
+			// 
+			this.RetroAchievementsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			StartRetroAchievementsMenuItem});
+			this.RetroAchievementsMenuItem.Text = "&RetroAchievements";
+			// 
+			// StartRetroAchievementsMenuItem
+			// 
+			this.StartRetroAchievementsMenuItem.Text = "&Start RetroAchievements";
+			this.StartRetroAchievementsMenuItem.Click += new System.EventHandler(this.StartRetroAchievementsMenuItem_Click);
+			// 
 			// CheatsMenuItem
 			// 
 			this.CheatsMenuItem.Text = "Cheats";
@@ -1414,12 +1425,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MultiDiskBundlerFileMenuItem.Text = "Multi-disk Bundler";
 			this.MultiDiskBundlerFileMenuItem.Click += new System.EventHandler(this.MultidiskBundlerMenuItem_Click);
 			// 
-			// BatchRunnerMenuItem
-			// 
-			this.BatchRunnerMenuItem.Text = "Batch Runner...";
-			this.BatchRunnerMenuItem.Visible = false;
-			this.BatchRunnerMenuItem.Click += new System.EventHandler(this.BatchRunnerMenuItem_Click);
-			// 
 			// ExternalToolMenuItem
 			// 
 			this.ExternalToolMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -1431,16 +1436,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.dummyExternalTool.Text = "None";
 			// 
-			// RetroAchievementsMenuItem
+			// BatchRunnerMenuItem
 			// 
-			this.RetroAchievementsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.StartRetroAchievementsMenuItem});
-			this.RetroAchievementsMenuItem.Text = "&RetroAchievements";
-			// 
-			// StartRetroAchievementsMenuItem
-			// 
-			this.StartRetroAchievementsMenuItem.Text = "&Start RetroAchievements";
-			this.StartRetroAchievementsMenuItem.Click += new System.EventHandler(this.StartRetroAchievementsMenuItem_Click);
+			this.BatchRunnerMenuItem.Text = "Batch Runner...";
+			this.BatchRunnerMenuItem.Visible = false;
+			this.BatchRunnerMenuItem.Click += new System.EventHandler(this.BatchRunnerMenuItem_Click);
 			// 
 			// NESSubMenu
 			// 
@@ -1971,7 +1971,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// MainStatusBar
 			// 
-			this.MainStatusBar.ImageScalingSize = new System.Drawing.Size(20, 20);
 			this.MainStatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.DumpStatusButton,
 			this.EmuStatus,
@@ -1997,7 +1996,7 @@ namespace BizHawk.Client.EmuHawk
 			this.ProfileFirstBootLabel,
 			this.LinkConnectStatusBarButton,
 			this.UpdateNotification});
-			this.MainStatusBar.Location = new System.Drawing.Point(0, 382);
+			this.MainStatusBar.Location = new System.Drawing.Point(0, 386);
 			this.MainStatusBar.Name = "MainStatusBar";
 			this.MainStatusBar.ShowItemToolTips = true;
 			this.MainStatusBar.SizingGrip = false;
@@ -2009,7 +2008,7 @@ namespace BizHawk.Client.EmuHawk
 			this.DumpStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.DumpStatusButton.Name = "DumpStatusButton";
 			this.DumpStatusButton.ShowDropDownArrow = false;
-			this.DumpStatusButton.Size = new System.Drawing.Size(4, 24);
+			this.DumpStatusButton.Size = new System.Drawing.Size(4, 20);
 			this.DumpStatusButton.Text = "No ROM loaded";
 			this.DumpStatusButton.Click += new System.EventHandler(this.DumpStatusButton_Click);
 			// 
@@ -2019,7 +2018,7 @@ namespace BizHawk.Client.EmuHawk
 			this.PlayRecordStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.PlayRecordStatusButton.Name = "PlayRecordStatusButton";
 			this.PlayRecordStatusButton.ShowDropDownArrow = false;
-			this.PlayRecordStatusButton.Size = new System.Drawing.Size(4, 24);
+			this.PlayRecordStatusButton.Size = new System.Drawing.Size(4, 20);
 			this.PlayRecordStatusButton.Text = "No movie is active";
 			// 
 			// PauseStatusButton
@@ -2029,7 +2028,7 @@ namespace BizHawk.Client.EmuHawk
 			this.PauseStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.PauseStatusButton.Name = "PauseStatusButton";
 			this.PauseStatusButton.ShowDropDownArrow = false;
-			this.PauseStatusButton.Size = new System.Drawing.Size(4, 24);
+			this.PauseStatusButton.Size = new System.Drawing.Size(4, 20);
 			this.PauseStatusButton.Text = "toolStripDropDownButton1";
 			this.PauseStatusButton.ToolTipText = "Emulator is paused";
 			this.PauseStatusButton.Click += new System.EventHandler(this.PauseMenuItem_Click);
@@ -2158,7 +2157,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// MainFormContextMenu
 			// 
-			this.MainFormContextMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
 			this.MainFormContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.OpenRomContextMenuItem,
 			this.LoadLastRomContextMenuItem,
@@ -2186,7 +2184,7 @@ namespace BizHawk.Client.EmuHawk
 			this.ShowMenuContextMenuSeparator,
 			this.ShowMenuContextMenuItem});
 			this.MainFormContextMenu.Name = "contextMenuStrip1";
-			this.MainFormContextMenu.Size = new System.Drawing.Size(257, 532);
+			this.MainFormContextMenu.Size = new System.Drawing.Size(217, 490);
 			this.MainFormContextMenu.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.MainFormContextMenu_Closing);
 			this.MainFormContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.MainFormContextMenu_Opening);
 			// 
@@ -2760,7 +2758,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AmstradCPCNonSyncSettingsToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator8;
 		private System.Windows.Forms.ToolStripMenuItem CaptureLuaMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem AutosaveLastSlotMenuItem;
 		private ToolStripSeparatorEx toolStripSeparator24;
-		private ToolStripMenuItemEx AutosaveLastSlotMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -17,2462 +17,2462 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		private void InitializeComponent()
 		{
-		            this.components = new System.ComponentModel.Container();
-		            this.MainformMenu = new BizHawk.WinForms.Controls.MenuStripEx();
-		            this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.OpenRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.RecentRomSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.OpenAdvancedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.CloseRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.SaveStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.SaveNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator24 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.AutosaveLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.LoadNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator21 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.AutoloadLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveSlotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SelectSlot1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SelectSlot2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SelectSlot3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SelectSlot4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SelectSlot5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SelectSlot6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SelectSlot7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SelectSlot8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SelectSlot9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SelectSlot0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PreviousSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.NextSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.SaveToCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveRAMSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.FlushSaveRAMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.MovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ReadonlyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator15 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.RecentMovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator16 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.RecordMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PlayMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.StopMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PlayFromBeginningMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ImportMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveMovieAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.StopMovieWithoutSavingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator14 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.AutomaticallyBackupMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.FullMovieLoadstatesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MovieEndSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MovieEndFinishMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MovieEndRecordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MovieEndStopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MovieEndPauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AVSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.RecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ConfigAndRecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.StopAVIMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator19 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.CaptureOSDMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.CaptureLuaMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-		            this.SynclessRecordingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ScreenshotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ScreenshotAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ScreenshotClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ScreenshotClientClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator20 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.ScreenshotCaptureOSDMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.EmulationSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.RebootCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.SoftResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.HardResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.EmulatorMenuSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.LoadedCoreNameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ViewSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.WindowSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.x1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.x2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.x3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.x4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.x5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.x6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.x7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.x8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.x9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.mzMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SwitchToFullscreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.DisplayFPSMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.DisplayFrameCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.DisplayLagCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.DisplayInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.DisplayRerecordCountMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.DisplaySubtitlesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.DisplayStatusBarMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.DisplayMessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.DisplayLogWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ControllersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.HotkeysMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.DisplayConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SoundMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PathsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.FirmwaresMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AutofireMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.RewindOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.extensionsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ClientOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ProfilesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator9 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.SpeedSkipSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ClockThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AudioThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.VsyncThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator27 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.VsyncEnabledMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.miUnthrottled = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MinimizeSkippingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.NeverSkipMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem17 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Frameskip1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Frameskip2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Frameskip3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Frameskip4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Frameskip5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Frameskip6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Frameskip7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Frameskip8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Frameskip9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.Speed50MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Speed75MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Speed100MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Speed150MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Speed200MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Speed400MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.KeyPrioritySubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.BothHkAndControllerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.InputOverHkMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.HkOverInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.CoresSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator10 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.SaveConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveConfigAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadConfigFromMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ToolsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ToolBoxMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator12 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.RamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.RamSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LuaConsoleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.TAStudioMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.HexEditorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.TraceLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.DebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.CodeDataLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MacroToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.VirtualPadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.BasicBotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator11 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.CheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.GameSharkConverterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator29 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.MultiDiskBundlerFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.BatchRunnerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ExternalToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.dummyExternalTool = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.RetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.StartRetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.NESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.NESPPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.NESNametableViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MusicRipperMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator17 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.NesControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.NESGraphicSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.NESSoundChannelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.VSSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MovieSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator22 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.FDSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.FdsEjectDiskMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.VSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.VSInsertCoinP1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.VSInsertCoinP2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.VSServiceSwitchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.BarcodeReaderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.TI83SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.KeypadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadTIFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator13 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.paletteToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.A7800SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.A7800ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.A7800FilterSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.GBSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.GBcoreSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SameBoyColorChooserMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator28 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.GBGPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.GBPrinterViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PSXSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PSXControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PSXOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PSXDiscControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PSXHashDiscsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SNESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SNESControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator18 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.SnesGfxDebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SnesOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ColecoSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ColecoControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator35 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.ColecoSkipBiosMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ColecoUseSGMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.N64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.N64PluginSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.N64ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator23 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.N64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MupenStyleLagMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.N64ExpansionSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Ares64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Ares64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.Ares64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.GBLSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.GBLsettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AppleSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AppleDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator31 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.settingsToolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.C64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.C64DisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator36 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.C64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.IntvSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.IntVControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.zXSpectrumToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ZXSpectrumCoreEmulationSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ZXSpectrumControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ZXSpectrumAudioSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ZXSpectrumNonSyncSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ZXSpectrumMediaMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ZXSpectrumTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.zxt1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ZXSpectrumDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.zxt2ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ZXSpectrumExportSnapshotMenuItemMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.GenericCoreSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.amstradCPCToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.amstradCPCCoreEmulationSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AmstradCPCAudioSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AmstradCPCNonSyncSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AmstradCPCMediaToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AmstradCPCTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.cpct1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AmstradCPCDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.cpcd1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.HelpSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.OnlineHelpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ForumsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.FeaturesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AboutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.A7800HawkCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.MainStatusBar = new BizHawk.WinForms.Controls.StatusStripEx();
-		            this.DumpStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-		            this.EmuStatus = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.PlayRecordStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-		            this.PauseStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-		            this.RebootStatusBarIcon = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.AVIStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.LedLightStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.SaveSlotsStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.Slot1StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.Slot2StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.Slot3StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.Slot4StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.Slot5StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.Slot6StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.Slot7StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.Slot8StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.Slot9StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.Slot0StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.CheatStatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.KeyPriorityStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.CoreNameStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.ProfileFirstBootLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.LinkConnectStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.UpdateNotification = new BizHawk.WinForms.Controls.StatusLabelEx();
-		            this.MainFormContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-		            this.OpenRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadLastRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.StopAVContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ContextSeparator_AfterROM = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.RecordMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.PlayMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.RestartMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.StopMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.LoadLastMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.BackupMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.StopNoSaveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ViewSubtitlesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.AddSubtitleContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ViewCommentsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.SaveMovieAsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ContextSeparator_AfterMovie = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.UndoSavestateContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ContextSeparator_AfterUndo = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.ConfigContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem6 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem7 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem8 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem9 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem10 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem11 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem12 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem13 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem14 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem15 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.customizeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripSeparator30 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.toolStripMenuItem66 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.toolStripMenuItem67 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ScreenshotContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.CloseRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ClearSRAMContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.ShowMenuContextMenuSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-		            this.ShowMenuContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-		            this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
-		            this.MainformMenu.SuspendLayout();
-		            this.MainStatusBar.SuspendLayout();
-		            this.MainFormContextMenu.SuspendLayout();
-		            this.SuspendLayout();
-		            // 
-		            // MainformMenu
-		            // 
-		            this.MainformMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
-		            this.MainformMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.FileSubMenu,
-		            this.EmulationSubMenu,
-		            this.ViewSubMenu,
-		            this.ConfigSubMenu,
-		            this.ToolsSubMenu,
-		            this.NESSubMenu,
-		            this.TI83SubMenu,
-		            this.A7800SubMenu,
-		            this.GBSubMenu,
-		            this.PSXSubMenu,
-		            this.SNESSubMenu,
-		            this.ColecoSubMenu,
-		            this.N64SubMenu,
-		            this.Ares64SubMenu,
-		            this.GBLSubMenu,
-		            this.AppleSubMenu,
-		            this.C64SubMenu,
-		            this.IntvSubMenu,
-		            this.zXSpectrumToolStripMenuItem,
-		            this.GenericCoreSubMenu,
-		            this.amstradCPCToolStripMenuItem,
-		            this.HelpSubMenu});
-		            this.MainformMenu.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
-		            this.MainformMenu.TabIndex = 0;
-		            this.MainformMenu.MenuActivate += new System.EventHandler(this.MainformMenu_MenuActivate);
-		            this.MainformMenu.MenuDeactivate += new System.EventHandler(this.MainformMenu_MenuDeactivate);
-		            // 
-		            // FileSubMenu
-		            // 
-		            this.FileSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.OpenRomMenuItem,
-		            this.RecentRomSubMenu,
-		            this.OpenAdvancedMenuItem,
-		            this.CloseRomMenuItem,
-		            this.toolStripMenuItem1,
-		            this.SaveStateSubMenu,
-		            this.LoadStateSubMenu,
-		            this.SaveSlotSubMenu,
-		            this.SaveRAMSubMenu,
-		            this.toolStripMenuItem2,
-		            this.MovieSubMenu,
-		            this.AVSubMenu,
-		            this.ScreenshotSubMenu,
-		            this.toolStripSeparator4,
-		            this.ExitMenuItem});
-		            this.FileSubMenu.Text = "&File";
-		            this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
-		            // 
-		            // OpenRomMenuItem
-		            // 
-		            this.OpenRomMenuItem.Text = "&Open ROM...";
-		            this.OpenRomMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
-		            // 
-		            // RecentRomSubMenu
-		            // 
-		            this.RecentRomSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.toolStripSeparator3});
-		            this.RecentRomSubMenu.Text = "&Recent ROM";
-		            this.RecentRomSubMenu.DropDownOpened += new System.EventHandler(this.RecentRomMenuItem_DropDownOpened);
-		            // 
-		            // OpenAdvancedMenuItem
-		            // 
-		            this.OpenAdvancedMenuItem.Text = "Open Ad&vanced...";
-		            this.OpenAdvancedMenuItem.Click += new System.EventHandler(this.OpenAdvancedMenuItem_Click);
-		            // 
-		            // CloseRomMenuItem
-		            // 
-		            this.CloseRomMenuItem.Text = "&Close ROM";
-		            this.CloseRomMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
-		            // 
-		            // SaveStateSubMenu
-		            // 
-		            this.SaveStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.SaveState1MenuItem,
-		            this.SaveState2MenuItem,
-		            this.SaveState3MenuItem,
-		            this.SaveState4MenuItem,
-		            this.SaveState5MenuItem,
-		            this.SaveState6MenuItem,
-		            this.SaveState7MenuItem,
-		            this.SaveState8MenuItem,
-		            this.SaveState9MenuItem,
-		            this.SaveState0MenuItem,
-		            this.toolStripSeparator6,
-		            this.SaveNamedStateMenuItem,
-		            this.toolStripSeparator24,
-		            this.AutosaveLastSlotMenuItem});
-		            this.SaveStateSubMenu.Text = "&Save State";
-		            this.SaveStateSubMenu.DropDownOpened += new System.EventHandler(this.SaveStateSubMenu_DropDownOpened);
-		            // 
-		            // SaveState1MenuItem
-		            // 
-		            this.SaveState1MenuItem.Text = "1";
-		            this.SaveState1MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-		            // 
-		            // SaveState2MenuItem
-		            // 
-		            this.SaveState2MenuItem.Text = "2";
-		            this.SaveState2MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-		            // 
-		            // SaveState3MenuItem
-		            // 
-		            this.SaveState3MenuItem.Text = "3";
-		            this.SaveState3MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-		            // 
-		            // SaveState4MenuItem
-		            // 
-		            this.SaveState4MenuItem.Text = "4";
-		            this.SaveState4MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-		            // 
-		            // SaveState5MenuItem
-		            // 
-		            this.SaveState5MenuItem.Text = "5";
-		            this.SaveState5MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-		            // 
-		            // SaveState6MenuItem
-		            // 
-		            this.SaveState6MenuItem.Text = "6";
-		            this.SaveState6MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-		            // 
-		            // SaveState7MenuItem
-		            // 
-		            this.SaveState7MenuItem.Text = "7";
-		            this.SaveState7MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-		            // 
-		            // SaveState8MenuItem
-		            // 
-		            this.SaveState8MenuItem.Text = "8";
-		            this.SaveState8MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-		            // 
-		            // SaveState9MenuItem
-		            // 
-		            this.SaveState9MenuItem.Text = "9";
-		            this.SaveState9MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-		            // 
-		            // SaveState0MenuItem
-		            // 
-		            this.SaveState0MenuItem.Text = "10";
-		            this.SaveState0MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-		            // 
-		            // SaveNamedStateMenuItem
-		            // 
-		            this.SaveNamedStateMenuItem.Text = "Save Named State...";
-		            this.SaveNamedStateMenuItem.Click += new System.EventHandler(this.SaveNamedStateMenuItem_Click);
-		            // 
-		            // AutosaveLastSlotMenuItem
-		            // 
-		            this.AutosaveLastSlotMenuItem.Text = "Autosave Last Slot";
-		            this.AutosaveLastSlotMenuItem.Click += new System.EventHandler(this.AutosaveLastSlotMenuItem_Click);
-		            // 
-		            // LoadStateSubMenu
-		            // 
-		            this.LoadStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.LoadState1MenuItem,
-		            this.LoadState2MenuItem,
-		            this.LoadState3MenuItem,
-		            this.LoadState4MenuItem,
-		            this.LoadState5MenuItem,
-		            this.LoadState6MenuItem,
-		            this.LoadState7MenuItem,
-		            this.LoadState8MenuItem,
-		            this.LoadState9MenuItem,
-		            this.LoadState0MenuItem,
-		            this.toolStripSeparator7,
-		            this.LoadNamedStateMenuItem,
-		            this.toolStripSeparator21,
-		            this.AutoloadLastSlotMenuItem});
-		            this.LoadStateSubMenu.Text = "&Load State";
-		            this.LoadStateSubMenu.DropDownOpened += new System.EventHandler(this.LoadStateSubMenu_DropDownOpened);
-		            // 
-		            // LoadState1MenuItem
-		            // 
-		            this.LoadState1MenuItem.Text = "1";
-		            this.LoadState1MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-		            // 
-		            // LoadState2MenuItem
-		            // 
-		            this.LoadState2MenuItem.Text = "2";
-		            this.LoadState2MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-		            // 
-		            // LoadState3MenuItem
-		            // 
-		            this.LoadState3MenuItem.Text = "3";
-		            this.LoadState3MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-		            // 
-		            // LoadState4MenuItem
-		            // 
-		            this.LoadState4MenuItem.Text = "4";
-		            this.LoadState4MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-		            // 
-		            // LoadState5MenuItem
-		            // 
-		            this.LoadState5MenuItem.Text = "5";
-		            this.LoadState5MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-		            // 
-		            // LoadState6MenuItem
-		            // 
-		            this.LoadState6MenuItem.Text = "6";
-		            this.LoadState6MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-		            // 
-		            // LoadState7MenuItem
-		            // 
-		            this.LoadState7MenuItem.Text = "7";
-		            this.LoadState7MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-		            // 
-		            // LoadState8MenuItem
-		            // 
-		            this.LoadState8MenuItem.Text = "8";
-		            this.LoadState8MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-		            // 
-		            // LoadState9MenuItem
-		            // 
-		            this.LoadState9MenuItem.Text = "9";
-		            this.LoadState9MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-		            // 
-		            // LoadState0MenuItem
-		            // 
-		            this.LoadState0MenuItem.Text = "10";
-		            this.LoadState0MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-		            // 
-		            // LoadNamedStateMenuItem
-		            // 
-		            this.LoadNamedStateMenuItem.Text = "Load Named State...";
-		            this.LoadNamedStateMenuItem.Click += new System.EventHandler(this.LoadNamedStateMenuItem_Click);
-		            // 
-		            // AutoloadLastSlotMenuItem
-		            // 
-		            this.AutoloadLastSlotMenuItem.Text = "Autoload Last Slot";
-		            this.AutoloadLastSlotMenuItem.Click += new System.EventHandler(this.AutoloadLastSlotMenuItem_Click);
-		            // 
-		            // SaveSlotSubMenu
-		            // 
-		            this.SaveSlotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.SelectSlot1MenuItem,
-		            this.SelectSlot2MenuItem,
-		            this.SelectSlot3MenuItem,
-		            this.SelectSlot4MenuItem,
-		            this.SelectSlot5MenuItem,
-		            this.SelectSlot6MenuItem,
-		            this.SelectSlot7MenuItem,
-		            this.SelectSlot8MenuItem,
-		            this.SelectSlot9MenuItem,
-		            this.SelectSlot0MenuItem,
-		            this.PreviousSlotMenuItem,
-		            this.NextSlotMenuItem,
-		            this.toolStripSeparator5,
-		            this.SaveToCurrentSlotMenuItem,
-		            this.LoadCurrentSlotMenuItem});
-		            this.SaveSlotSubMenu.Text = "Save S&lot";
-		            this.SaveSlotSubMenu.DropDownOpened += new System.EventHandler(this.SaveSlotSubMenu_DropDownOpened);
-		            // 
-		            // SelectSlot1MenuItem
-		            // 
-		            this.SelectSlot1MenuItem.Text = "Select Slot 1";
-		            this.SelectSlot1MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-		            // 
-		            // SelectSlot2MenuItem
-		            // 
-		            this.SelectSlot2MenuItem.Text = "Select Slot 2";
-		            this.SelectSlot2MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-		            // 
-		            // SelectSlot3MenuItem
-		            // 
-		            this.SelectSlot3MenuItem.Text = "Select Slot 3";
-		            this.SelectSlot3MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-		            // 
-		            // SelectSlot4MenuItem
-		            // 
-		            this.SelectSlot4MenuItem.Text = "Select Slot 4";
-		            this.SelectSlot4MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-		            // 
-		            // SelectSlot5MenuItem
-		            // 
-		            this.SelectSlot5MenuItem.Text = "Select Slot 5";
-		            this.SelectSlot5MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-		            // 
-		            // SelectSlot6MenuItem
-		            // 
-		            this.SelectSlot6MenuItem.Text = "Select Slot 6";
-		            this.SelectSlot6MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-		            // 
-		            // SelectSlot7MenuItem
-		            // 
-		            this.SelectSlot7MenuItem.Text = "Select Slot 7";
-		            this.SelectSlot7MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-		            // 
-		            // SelectSlot8MenuItem
-		            // 
-		            this.SelectSlot8MenuItem.Text = "Select Slot 8";
-		            this.SelectSlot8MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-		            // 
-		            // SelectSlot9MenuItem
-		            // 
-		            this.SelectSlot9MenuItem.Text = "Select Slot 9";
-		            this.SelectSlot9MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-		            // 
-		            // SelectSlot0MenuItem
-		            // 
-		            this.SelectSlot0MenuItem.Text = "Select Slot 10";
-		            this.SelectSlot0MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-		            // 
-		            // PreviousSlotMenuItem
-		            // 
-		            this.PreviousSlotMenuItem.Text = "Previous Slot";
-		            this.PreviousSlotMenuItem.Click += new System.EventHandler(this.PreviousSlotMenuItem_Click);
-		            // 
-		            // NextSlotMenuItem
-		            // 
-		            this.NextSlotMenuItem.Text = "Next Slot";
-		            this.NextSlotMenuItem.Click += new System.EventHandler(this.NextSlotMenuItem_Click);
-		            // 
-		            // SaveToCurrentSlotMenuItem
-		            // 
-		            this.SaveToCurrentSlotMenuItem.Text = "Save to Current Slot";
-		            this.SaveToCurrentSlotMenuItem.Click += new System.EventHandler(this.SaveToCurrentSlotMenuItem_Click);
-		            // 
-		            // LoadCurrentSlotMenuItem
-		            // 
-		            this.LoadCurrentSlotMenuItem.Text = "Load Current Slot";
-		            this.LoadCurrentSlotMenuItem.Click += new System.EventHandler(this.LoadCurrentSlotMenuItem_Click);
-		            // 
-		            // SaveRAMSubMenu
-		            // 
-		            this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.FlushSaveRAMMenuItem});
-		            this.SaveRAMSubMenu.Text = "Save &RAM";
-		            this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
-		            // 
-		            // FlushSaveRAMMenuItem
-		            // 
-		            this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
-		            this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
-		            // 
-		            // MovieSubMenu
-		            // 
-		            this.MovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.ReadonlyMenuItem,
-		            this.toolStripSeparator15,
-		            this.RecentMovieSubMenu,
-		            this.RecordMovieMenuItem,
-		            this.PlayMovieMenuItem,
-		            this.StopMovieMenuItem,
-		            this.PlayFromBeginningMenuItem,
-		            this.ImportMoviesMenuItem,
-		            this.SaveMovieMenuItem,
-		            this.SaveMovieAsMenuItem,
-		            this.StopMovieWithoutSavingMenuItem,
-		            this.toolStripSeparator14,
-		            this.AutomaticallyBackupMoviesMenuItem,
-		            this.FullMovieLoadstatesMenuItem,
-		            this.MovieEndSubMenu});
-		            this.MovieSubMenu.Text = "&Movie";
-		            this.MovieSubMenu.DropDownOpened += new System.EventHandler(this.MovieSubMenu_DropDownOpened);
-		            // 
-		            // ReadonlyMenuItem
-		            // 
-		            this.ReadonlyMenuItem.Text = "Read-only";
-		            this.ReadonlyMenuItem.Click += new System.EventHandler(this.ReadonlyMenuItem_Click);
-		            // 
-		            // RecentMovieSubMenu
-		            // 
-		            this.RecentMovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.toolStripSeparator16});
-		            this.RecentMovieSubMenu.Text = "Recent";
-		            this.RecentMovieSubMenu.DropDownOpened += new System.EventHandler(this.RecentMovieSubMenu_DropDownOpened);
-		            // 
-		            // RecordMovieMenuItem
-		            // 
-		            this.RecordMovieMenuItem.Text = "&Record Movie...";
-		            this.RecordMovieMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
-		            // 
-		            // PlayMovieMenuItem
-		            // 
-		            this.PlayMovieMenuItem.Text = "&Play Movie...";
-		            this.PlayMovieMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
-		            // 
-		            // StopMovieMenuItem
-		            // 
-		            this.StopMovieMenuItem.Text = "Stop Movie";
-		            this.StopMovieMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
-		            // 
-		            // PlayFromBeginningMenuItem
-		            // 
-		            this.PlayFromBeginningMenuItem.Text = "Play from Beginning";
-		            this.PlayFromBeginningMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
-		            // 
-		            // ImportMoviesMenuItem
-		            // 
-		            this.ImportMoviesMenuItem.Text = "Import Movies...";
-		            this.ImportMoviesMenuItem.Click += new System.EventHandler(this.ImportMovieMenuItem_Click);
-		            // 
-		            // SaveMovieMenuItem
-		            // 
-		            this.SaveMovieMenuItem.Text = "&Save Movie";
-		            this.SaveMovieMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
-		            // 
-		            // SaveMovieAsMenuItem
-		            // 
-		            this.SaveMovieAsMenuItem.Text = "Save Movie As...";
-		            this.SaveMovieAsMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
-		            // 
-		            // StopMovieWithoutSavingMenuItem
-		            // 
-		            this.StopMovieWithoutSavingMenuItem.Text = "Stop Movie without Saving";
-		            this.StopMovieWithoutSavingMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
-		            // 
-		            // AutomaticallyBackupMoviesMenuItem
-		            // 
-		            this.AutomaticallyBackupMoviesMenuItem.Text = "Automatically Backup Movies";
-		            this.AutomaticallyBackupMoviesMenuItem.Click += new System.EventHandler(this.AutomaticMovieBackupMenuItem_Click);
-		            // 
-		            // FullMovieLoadstatesMenuItem
-		            // 
-		            this.FullMovieLoadstatesMenuItem.Text = "Full Movie Loadstates";
-		            this.FullMovieLoadstatesMenuItem.Click += new System.EventHandler(this.FullMovieLoadstatesMenuItem_Click);
-		            // 
-		            // MovieEndSubMenu
-		            // 
-		            this.MovieEndSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.MovieEndFinishMenuItem,
-		            this.MovieEndRecordMenuItem,
-		            this.MovieEndStopMenuItem,
-		            this.MovieEndPauseMenuItem});
-		            this.MovieEndSubMenu.Text = "On Movie End";
-		            this.MovieEndSubMenu.DropDownOpened += new System.EventHandler(this.MovieEndSubMenu_DropDownOpened);
-		            // 
-		            // MovieEndFinishMenuItem
-		            // 
-		            this.MovieEndFinishMenuItem.Text = "Switch to Finished";
-		            this.MovieEndFinishMenuItem.Click += new System.EventHandler(this.MovieEndFinishMenuItem_Click);
-		            // 
-		            // MovieEndRecordMenuItem
-		            // 
-		            this.MovieEndRecordMenuItem.Text = "Switch To Record";
-		            this.MovieEndRecordMenuItem.Click += new System.EventHandler(this.MovieEndRecordMenuItem_Click);
-		            // 
-		            // MovieEndStopMenuItem
-		            // 
-		            this.MovieEndStopMenuItem.Text = "Stop";
-		            this.MovieEndStopMenuItem.Click += new System.EventHandler(this.MovieEndStopMenuItem_Click);
-		            // 
-		            // MovieEndPauseMenuItem
-		            // 
-		            this.MovieEndPauseMenuItem.Text = "Pause";
-		            this.MovieEndPauseMenuItem.Click += new System.EventHandler(this.MovieEndPauseMenuItem_Click);
-		            // 
-		            // AVSubMenu
-		            // 
-		            this.AVSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.RecordAVMenuItem,
-		            this.ConfigAndRecordAVMenuItem,
-		            this.StopAVIMenuItem,
-		            this.toolStripSeparator19,
-		            this.CaptureOSDMenuItem,
-		            this.CaptureLuaMenuItem,
-		            this.SynclessRecordingMenuItem});
-		            this.AVSubMenu.Text = "&AVI/WAV";
-		            this.AVSubMenu.DropDownOpened += new System.EventHandler(this.AVSubMenu_DropDownOpened);
-		            // 
-		            // RecordAVMenuItem
-		            // 
-		            this.RecordAVMenuItem.Text = "&Record AVI/WAV";
-		            this.RecordAVMenuItem.Click += new System.EventHandler(this.RecordAVMenuItem_Click);
-		            // 
-		            // ConfigAndRecordAVMenuItem
-		            // 
-		            this.ConfigAndRecordAVMenuItem.Text = "Config and Record AVI/WAV...";
-		            this.ConfigAndRecordAVMenuItem.Click += new System.EventHandler(this.ConfigAndRecordAVMenuItem_Click);
-		            // 
-		            // StopAVIMenuItem
-		            // 
-		            this.StopAVIMenuItem.Text = "&Stop AVI/WAV";
-		            this.StopAVIMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
-		            // 
-		            // CaptureOSDMenuItem
-		            // 
-		            this.CaptureOSDMenuItem.CheckOnClick = true;
-		            this.CaptureOSDMenuItem.Text = "Capture OSD";
-		            this.CaptureOSDMenuItem.Click += new System.EventHandler(this.CaptureOSDMenuItem_Click);
-		            // 
-		            // CaptureLuaMenuItem
-		            // 
-		            this.CaptureLuaMenuItem.CheckOnClick = true;
-		            this.CaptureLuaMenuItem.Name = "CaptureLuaMenuItem";
-		            this.CaptureLuaMenuItem.Size = new System.Drawing.Size(288, 26);
-		            this.CaptureLuaMenuItem.Text = "Capture Lua";
-		            this.CaptureLuaMenuItem.Click += new System.EventHandler(this.CaptureLuaMenuItem_Click);
-		            // 
-		            // SynclessRecordingMenuItem
-		            // 
-		            this.SynclessRecordingMenuItem.Text = "S&yncless Recording Tools";
-		            // 
-		            // ScreenshotSubMenu
-		            // 
-		            this.ScreenshotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.ScreenshotMenuItem,
-		            this.ScreenshotAsMenuItem,
-		            this.ScreenshotClipboardMenuItem,
-		            this.ScreenshotClientClipboardMenuItem,
-		            this.toolStripSeparator20,
-		            this.ScreenshotCaptureOSDMenuItem1});
-		            this.ScreenshotSubMenu.Text = "Scree&nshot";
-		            this.ScreenshotSubMenu.DropDownOpening += new System.EventHandler(this.ScreenshotSubMenu_DropDownOpening);
-		            // 
-		            // ScreenshotMenuItem
-		            // 
-		            this.ScreenshotMenuItem.Text = "Screenshot";
-		            this.ScreenshotMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
-		            // 
-		            // ScreenshotAsMenuItem
-		            // 
-		            this.ScreenshotAsMenuItem.Text = "Screenshot As...";
-		            this.ScreenshotAsMenuItem.Click += new System.EventHandler(this.ScreenshotAsMenuItem_Click);
-		            // 
-		            // ScreenshotClipboardMenuItem
-		            // 
-		            this.ScreenshotClipboardMenuItem.Text = "Screenshot (raw) -> Clipboard";
-		            this.ScreenshotClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClipboardMenuItem_Click);
-		            // 
-		            // ScreenshotClientClipboardMenuItem
-		            // 
-		            this.ScreenshotClientClipboardMenuItem.Text = "Screenshot (client) -> Clipboard";
-		            this.ScreenshotClientClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClientClipboardMenuItem_Click);
-		            // 
-		            // ScreenshotCaptureOSDMenuItem1
-		            // 
-		            this.ScreenshotCaptureOSDMenuItem1.Text = "Capture OSD";
-		            this.ScreenshotCaptureOSDMenuItem1.Click += new System.EventHandler(this.ScreenshotCaptureOSDMenuItem_Click);
-		            // 
-		            // ExitMenuItem
-		            // 
-		            this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-		            this.ExitMenuItem.Text = "E&xit";
-		            this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
-		            // 
-		            // EmulationSubMenu
-		            // 
-		            this.EmulationSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.PauseMenuItem,
-		            this.RebootCoreMenuItem,
-		            this.toolStripSeparator1,
-		            this.SoftResetMenuItem,
-		            this.HardResetMenuItem,
-		            this.EmulatorMenuSeparator2,
-		            this.LoadedCoreNameMenuItem});
-		            this.EmulationSubMenu.Text = "&Emulation";
-		            this.EmulationSubMenu.DropDownOpened += new System.EventHandler(this.EmulationMenuItem_DropDownOpened);
-		            // 
-		            // PauseMenuItem
-		            // 
-		            this.PauseMenuItem.Text = "&Pause";
-		            this.PauseMenuItem.Click += new System.EventHandler(this.PauseMenuItem_Click);
-		            // 
-		            // RebootCoreMenuItem
-		            // 
-		            this.RebootCoreMenuItem.Text = "&Reboot Core";
-		            this.RebootCoreMenuItem.Click += new System.EventHandler(this.PowerMenuItem_Click);
-		            // 
-		            // SoftResetMenuItem
-		            // 
-		            this.SoftResetMenuItem.Text = "&Soft Reset";
-		            this.SoftResetMenuItem.Click += new System.EventHandler(this.SoftResetMenuItem_Click);
-		            // 
-		            // HardResetMenuItem
-		            // 
-		            this.HardResetMenuItem.Text = "&Hard Reset";
-		            this.HardResetMenuItem.Click += new System.EventHandler(this.HardResetMenuItem_Click);
-		            // 
-		            // LoadedCoreNameMenuItem
-		            // 
-		            this.LoadedCoreNameMenuItem.Enabled = false;
-		            this.LoadedCoreNameMenuItem.Text = "Loaded core: <core name> (sysID)";
-		            // 
-		            // ViewSubMenu
-		            // 
-		            this.ViewSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.WindowSizeSubMenu,
-		            this.SwitchToFullscreenMenuItem,
-		            this.toolStripSeparator2,
-		            this.DisplayFPSMenuItem,
-		            this.DisplayFrameCounterMenuItem,
-		            this.DisplayLagCounterMenuItem,
-		            this.DisplayInputMenuItem,
-		            this.DisplayRerecordCountMenuItem,
-		            this.DisplaySubtitlesMenuItem,
-		            this.toolStripMenuItem4,
-		            this.DisplayStatusBarMenuItem,
-		            this.DisplayMessagesMenuItem,
-		            this.toolStripSeparator8,
-		            this.DisplayLogWindowMenuItem});
-		            this.ViewSubMenu.Text = "&View";
-		            this.ViewSubMenu.DropDownOpened += new System.EventHandler(this.ViewSubMenu_DropDownOpened);
-		            // 
-		            // WindowSizeSubMenu
-		            // 
-		            this.WindowSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.x1MenuItem,
-		            this.x2MenuItem,
-		            this.x3MenuItem,
-		            this.x4MenuItem,
-		            this.x5MenuItem,
-		            this.x6MenuItem,
-		            this.x7MenuItem,
-		            this.x8MenuItem,
-		            this.x9MenuItem,
-		            this.mzMenuItem});
-		            this.WindowSizeSubMenu.Text = "&Window Size";
-		            this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
-		            // 
-		            // x1MenuItem
-		            // 
-		            this.x1MenuItem.Text = "&1x";
-		            this.x1MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-		            // 
-		            // x2MenuItem
-		            // 
-		            this.x2MenuItem.Text = "&2x";
-		            this.x2MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-		            // 
-		            // x3MenuItem
-		            // 
-		            this.x3MenuItem.Text = "&3x";
-		            this.x3MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-		            // 
-		            // x4MenuItem
-		            // 
-		            this.x4MenuItem.Text = "&4x";
-		            this.x4MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-		            // 
-		            // x5MenuItem
-		            // 
-		            this.x5MenuItem.Text = "&5x";
-		            this.x5MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-		            // 
-		            // x6MenuItem
-		            // 
-		            this.x6MenuItem.Text = "&6x";
-		            this.x6MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-		            // 
-		            // x7MenuItem
-		            // 
-		            this.x7MenuItem.Text = "&7x";
-		            this.x7MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-		            // 
-		            // x8MenuItem
-		            // 
-		            this.x8MenuItem.Text = "&8x";
-		            this.x8MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-		            // 
-		            // x9MenuItem
-		            // 
-		            this.x9MenuItem.Text = "&9x";
-		            this.x9MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-		            // 
-		            // mzMenuItem
-		            // 
-		            this.mzMenuItem.Text = "1&0x";
-		            this.mzMenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-		            // 
-		            // SwitchToFullscreenMenuItem
-		            // 
-		            this.SwitchToFullscreenMenuItem.Text = "Switch to Fullscreen";
-		            this.SwitchToFullscreenMenuItem.Click += new System.EventHandler(this.SwitchToFullscreenMenuItem_Click);
-		            // 
-		            // DisplayFPSMenuItem
-		            // 
-		            this.DisplayFPSMenuItem.Text = "Display FPS";
-		            this.DisplayFPSMenuItem.Click += new System.EventHandler(this.DisplayFpsMenuItem_Click);
-		            // 
-		            // DisplayFrameCounterMenuItem
-		            // 
-		            this.DisplayFrameCounterMenuItem.Text = "Display Frame Count";
-		            this.DisplayFrameCounterMenuItem.Click += new System.EventHandler(this.DisplayFrameCounterMenuItem_Click);
-		            // 
-		            // DisplayLagCounterMenuItem
-		            // 
-		            this.DisplayLagCounterMenuItem.Text = "Display Lag Frame Count";
-		            this.DisplayLagCounterMenuItem.Click += new System.EventHandler(this.DisplayLagCounterMenuItem_Click);
-		            // 
-		            // DisplayInputMenuItem
-		            // 
-		            this.DisplayInputMenuItem.Text = "Display Input";
-		            this.DisplayInputMenuItem.Click += new System.EventHandler(this.DisplayInputMenuItem_Click);
-		            // 
-		            // DisplayRerecordCountMenuItem
-		            // 
-		            this.DisplayRerecordCountMenuItem.Text = "Display Rerecord Count";
-		            this.DisplayRerecordCountMenuItem.Click += new System.EventHandler(this.DisplayRerecordsMenuItem_Click);
-		            // 
-		            // DisplaySubtitlesMenuItem
-		            // 
-		            this.DisplaySubtitlesMenuItem.Text = "Display Subtitles";
-		            this.DisplaySubtitlesMenuItem.Click += new System.EventHandler(this.DisplaySubtitlesMenuItem_Click);
-		            // 
-		            // DisplayStatusBarMenuItem
-		            // 
-		            this.DisplayStatusBarMenuItem.Text = "Display Status Bar";
-		            this.DisplayStatusBarMenuItem.Click += new System.EventHandler(this.DisplayStatusBarMenuItem_Click);
-		            // 
-		            // DisplayMessagesMenuItem
-		            // 
-		            this.DisplayMessagesMenuItem.Text = "Display Messages";
-		            this.DisplayMessagesMenuItem.Click += new System.EventHandler(this.DisplayMessagesMenuItem_Click);
-		            // 
-		            // DisplayLogWindowMenuItem
-		            // 
-		            this.DisplayLogWindowMenuItem.Text = "Open &Log Window...";
-		            this.DisplayLogWindowMenuItem.Click += new System.EventHandler(this.DisplayLogWindowMenuItem_Click);
-		            // 
-		            // ConfigSubMenu
-		            // 
-		            this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.ControllersMenuItem,
-		            this.HotkeysMenuItem,
-		            this.DisplayConfigMenuItem,
-		            this.SoundMenuItem,
-		            this.PathsMenuItem,
-		            this.FirmwaresMenuItem,
-		            this.MessagesMenuItem,
-		            this.AutofireMenuItem,
-		            this.RewindOptionsMenuItem,
-		            this.extensionsToolStripMenuItem,
-		            this.ClientOptionsMenuItem,
-		            this.ProfilesMenuItem,
-		            this.toolStripSeparator9,
-		            this.SpeedSkipSubMenu,
-		            this.KeyPrioritySubMenu,
-		            this.CoresSubMenu,
-		            this.toolStripSeparator10,
-		            this.SaveConfigMenuItem,
-		            this.SaveConfigAsMenuItem,
-		            this.LoadConfigMenuItem,
-		            this.LoadConfigFromMenuItem});
-		            this.ConfigSubMenu.Text = "&Config";
-		            this.ConfigSubMenu.DropDownOpened += new System.EventHandler(this.ConfigSubMenu_DropDownOpened);
-		            // 
-		            // ControllersMenuItem
-		            // 
-		            this.ControllersMenuItem.Text = "&Controllers...";
-		            this.ControllersMenuItem.Click += new System.EventHandler(this.ControllersMenuItem_Click);
-		            // 
-		            // HotkeysMenuItem
-		            // 
-		            this.HotkeysMenuItem.Text = "&Hotkeys...";
-		            this.HotkeysMenuItem.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
-		            // 
-		            // DisplayConfigMenuItem
-		            // 
-		            this.DisplayConfigMenuItem.Text = "Display...";
-		            this.DisplayConfigMenuItem.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
-		            // 
-		            // SoundMenuItem
-		            // 
-		            this.SoundMenuItem.Text = "&Sound...";
-		            this.SoundMenuItem.Click += new System.EventHandler(this.SoundMenuItem_Click);
-		            // 
-		            // PathsMenuItem
-		            // 
-		            this.PathsMenuItem.Text = "Paths...";
-		            this.PathsMenuItem.Click += new System.EventHandler(this.PathsMenuItem_Click);
-		            // 
-		            // FirmwaresMenuItem
-		            // 
-		            this.FirmwaresMenuItem.Text = "&Firmwares...";
-		            this.FirmwaresMenuItem.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
-		            // 
-		            // MessagesMenuItem
-		            // 
-		            this.MessagesMenuItem.Text = "&Messages...";
-		            this.MessagesMenuItem.Click += new System.EventHandler(this.MessagesMenuItem_Click);
-		            // 
-		            // AutofireMenuItem
-		            // 
-		            this.AutofireMenuItem.Text = "&Autofire...";
-		            this.AutofireMenuItem.Click += new System.EventHandler(this.AutofireMenuItem_Click);
-		            // 
-		            // RewindOptionsMenuItem
-		            // 
-		            this.RewindOptionsMenuItem.Text = "&Rewind && States...";
-		            this.RewindOptionsMenuItem.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
-		            // 
-		            // extensionsToolStripMenuItem
-		            // 
-		            this.extensionsToolStripMenuItem.Text = "File Extensions...";
-		            this.extensionsToolStripMenuItem.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
-		            // 
-		            // ClientOptionsMenuItem
-		            // 
-		            this.ClientOptionsMenuItem.Text = "&Customize...";
-		            this.ClientOptionsMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
-		            // 
-		            // ProfilesMenuItem
-		            // 
-		            this.ProfilesMenuItem.Text = "&Profiles...";
-		            this.ProfilesMenuItem.Click += new System.EventHandler(this.ProfilesMenuItem_Click);
-		            // 
-		            // SpeedSkipSubMenu
-		            // 
-		            this.SpeedSkipSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.ClockThrottleMenuItem,
-		            this.AudioThrottleMenuItem,
-		            this.VsyncThrottleMenuItem,
-		            this.toolStripSeparator27,
-		            this.VsyncEnabledMenuItem,
-		            this.toolStripMenuItem3,
-		            this.miUnthrottled,
-		            this.MinimizeSkippingMenuItem,
-		            this.NeverSkipMenuItem,
-		            this.toolStripMenuItem17,
-		            this.toolStripMenuItem5,
-		            this.Speed50MenuItem,
-		            this.Speed75MenuItem,
-		            this.Speed100MenuItem,
-		            this.Speed150MenuItem,
-		            this.Speed200MenuItem,
-		            this.Speed400MenuItem});
-		            this.SpeedSkipSubMenu.Text = "Speed/Skip";
-		            this.SpeedSkipSubMenu.DropDownOpened += new System.EventHandler(this.FrameSkipMenuItem_DropDownOpened);
-		            // 
-		            // ClockThrottleMenuItem
-		            // 
-		            this.ClockThrottleMenuItem.Text = "Clock Throttle";
-		            this.ClockThrottleMenuItem.Click += new System.EventHandler(this.ClockThrottleMenuItem_Click);
-		            // 
-		            // AudioThrottleMenuItem
-		            // 
-		            this.AudioThrottleMenuItem.Text = "Audio Throttle";
-		            this.AudioThrottleMenuItem.Click += new System.EventHandler(this.AudioThrottleMenuItem_Click);
-		            // 
-		            // VsyncThrottleMenuItem
-		            // 
-		            this.VsyncThrottleMenuItem.Text = "VSync Throttle";
-		            this.VsyncThrottleMenuItem.Click += new System.EventHandler(this.VsyncThrottleMenuItem_Click);
-		            // 
-		            // VsyncEnabledMenuItem
-		            // 
-		            this.VsyncEnabledMenuItem.Text = "VSync Enabled";
-		            this.VsyncEnabledMenuItem.Click += new System.EventHandler(this.VsyncEnabledMenuItem_Click);
-		            // 
-		            // miUnthrottled
-		            // 
-		            this.miUnthrottled.Text = "Unthrottled";
-		            this.miUnthrottled.Click += new System.EventHandler(this.UnthrottledMenuItem_Click);
-		            // 
-		            // MinimizeSkippingMenuItem
-		            // 
-		            this.MinimizeSkippingMenuItem.Text = "Auto-minimize skipping";
-		            this.MinimizeSkippingMenuItem.Click += new System.EventHandler(this.MinimizeSkippingMenuItem_Click);
-		            // 
-		            // NeverSkipMenuItem
-		            // 
-		            this.NeverSkipMenuItem.Text = "Skip 0 (never)";
-		            this.NeverSkipMenuItem.Click += new System.EventHandler(this.NeverSkipMenuItem_Click);
-		            // 
-		            // toolStripMenuItem17
-		            // 
-		            this.toolStripMenuItem17.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.Frameskip1MenuItem,
-		            this.Frameskip2MenuItem,
-		            this.Frameskip3MenuItem,
-		            this.Frameskip4MenuItem,
-		            this.Frameskip5MenuItem,
-		            this.Frameskip6MenuItem,
-		            this.Frameskip7MenuItem,
-		            this.Frameskip8MenuItem,
-		            this.Frameskip9MenuItem});
-		            this.toolStripMenuItem17.Text = "Skip 1..9";
-		            // 
-		            // Frameskip1MenuItem
-		            // 
-		            this.Frameskip1MenuItem.Text = "1";
-		            this.Frameskip1MenuItem.Click += new System.EventHandler(this.Frameskip1MenuItem_Click);
-		            // 
-		            // Frameskip2MenuItem
-		            // 
-		            this.Frameskip2MenuItem.Text = "2";
-		            this.Frameskip2MenuItem.Click += new System.EventHandler(this.Frameskip2MenuItem_Click);
-		            // 
-		            // Frameskip3MenuItem
-		            // 
-		            this.Frameskip3MenuItem.Text = "3";
-		            this.Frameskip3MenuItem.Click += new System.EventHandler(this.Frameskip3MenuItem_Click);
-		            // 
-		            // Frameskip4MenuItem
-		            // 
-		            this.Frameskip4MenuItem.Text = "4";
-		            this.Frameskip4MenuItem.Click += new System.EventHandler(this.Frameskip4MenuItem_Click);
-		            // 
-		            // Frameskip5MenuItem
-		            // 
-		            this.Frameskip5MenuItem.Text = "5";
-		            this.Frameskip5MenuItem.Click += new System.EventHandler(this.Frameskip5MenuItem_Click);
-		            // 
-		            // Frameskip6MenuItem
-		            // 
-		            this.Frameskip6MenuItem.Text = "6";
-		            this.Frameskip6MenuItem.Click += new System.EventHandler(this.Frameskip6MenuItem_Click);
-		            // 
-		            // Frameskip7MenuItem
-		            // 
-		            this.Frameskip7MenuItem.Text = "7";
-		            this.Frameskip7MenuItem.Click += new System.EventHandler(this.Frameskip7MenuItem_Click);
-		            // 
-		            // Frameskip8MenuItem
-		            // 
-		            this.Frameskip8MenuItem.Text = "8";
-		            this.Frameskip8MenuItem.Click += new System.EventHandler(this.Frameskip8MenuItem_Click);
-		            // 
-		            // Frameskip9MenuItem
-		            // 
-		            this.Frameskip9MenuItem.Text = "9";
-		            this.Frameskip9MenuItem.Click += new System.EventHandler(this.Frameskip9MenuItem_Click);
-		            // 
-		            // Speed50MenuItem
-		            // 
-		            this.Speed50MenuItem.Text = "Speed 50%";
-		            this.Speed50MenuItem.Click += new System.EventHandler(this.Speed50MenuItem_Click);
-		            // 
-		            // Speed75MenuItem
-		            // 
-		            this.Speed75MenuItem.Text = "Speed 75%";
-		            this.Speed75MenuItem.Click += new System.EventHandler(this.Speed75MenuItem_Click);
-		            // 
-		            // Speed100MenuItem
-		            // 
-		            this.Speed100MenuItem.Text = "Speed 100%";
-		            this.Speed100MenuItem.Click += new System.EventHandler(this.Speed100MenuItem_Click);
-		            // 
-		            // Speed150MenuItem
-		            // 
-		            this.Speed150MenuItem.Text = "Speed 150%";
-		            this.Speed150MenuItem.Click += new System.EventHandler(this.Speed150MenuItem_Click);
-		            // 
-		            // Speed200MenuItem
-		            // 
-		            this.Speed200MenuItem.Text = "Speed 200%";
-		            this.Speed200MenuItem.Click += new System.EventHandler(this.Speed200MenuItem_Click);
-		            // 
-		            // Speed400MenuItem
-		            // 
-		            this.Speed400MenuItem.Text = "Speed 400%";
-		            this.Speed400MenuItem.Click += new System.EventHandler(this.Speed400MenuItem_Click);
-		            // 
-		            // KeyPrioritySubMenu
-		            // 
-		            this.KeyPrioritySubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.BothHkAndControllerMenuItem,
-		            this.InputOverHkMenuItem,
-		            this.HkOverInputMenuItem});
-		            this.KeyPrioritySubMenu.Text = "Key Priority";
-		            this.KeyPrioritySubMenu.DropDownOpened += new System.EventHandler(this.KeyPriorityMenuItem_DropDownOpened);
-		            // 
-		            // BothHkAndControllerMenuItem
-		            // 
-		            this.BothHkAndControllerMenuItem.Text = "Both Hotkeys and Controllers";
-		            this.BothHkAndControllerMenuItem.Click += new System.EventHandler(this.BothHkAndControllerMenuItem_Click);
-		            // 
-		            // InputOverHkMenuItem
-		            // 
-		            this.InputOverHkMenuItem.Text = "Input overrides Hotkeys";
-		            this.InputOverHkMenuItem.Click += new System.EventHandler(this.InputOverHkMenuItem_Click);
-		            // 
-		            // HkOverInputMenuItem
-		            // 
-		            this.HkOverInputMenuItem.Text = "Hotkeys override Input";
-		            this.HkOverInputMenuItem.Click += new System.EventHandler(this.HkOverInputMenuItem_Click);
-		            // 
-		            // CoresSubMenu
-		            // 
-		            this.CoresSubMenu.Text = "Preferred Cores";
-		            // 
-		            // SaveConfigMenuItem
-		            // 
-		            this.SaveConfigMenuItem.Text = "Save Config";
-		            this.SaveConfigMenuItem.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
-		            // 
-		            // SaveConfigAsMenuItem
-		            // 
-		            this.SaveConfigAsMenuItem.Text = "Save Config As...";
-		            this.SaveConfigAsMenuItem.Click += new System.EventHandler(this.SaveConfigAsMenuItem_Click);
-		            // 
-		            // LoadConfigMenuItem
-		            // 
-		            this.LoadConfigMenuItem.Text = "Load Config";
-		            this.LoadConfigMenuItem.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
-		            // 
-		            // LoadConfigFromMenuItem
-		            // 
-		            this.LoadConfigFromMenuItem.Text = "Load Config From...";
-		            this.LoadConfigFromMenuItem.Click += new System.EventHandler(this.LoadConfigFromMenuItem_Click);
-		            // 
-		            // ToolsSubMenu
-		            // 
-		            this.ToolsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.ToolBoxMenuItem,
-		            this.toolStripSeparator12,
-		            this.RamWatchMenuItem,
-		            this.RamSearchMenuItem,
-		            this.LuaConsoleMenuItem,
-		            this.TAStudioMenuItem,
-		            this.HexEditorMenuItem,
-		            this.TraceLoggerMenuItem,
-		            this.DebuggerMenuItem,
-		            this.CodeDataLoggerMenuItem,
-		            this.MacroToolMenuItem,
-		            this.VirtualPadMenuItem,
-		            this.BasicBotMenuItem,
-		            this.toolStripSeparator11,
-		            this.CheatsMenuItem,
-		            this.GameSharkConverterMenuItem,
-		            this.toolStripSeparator29,
-		            this.MultiDiskBundlerFileMenuItem,
-		            this.BatchRunnerMenuItem,
-		            this.ExternalToolMenuItem,
-		            this.RetroAchievementsMenuItem});
-		            this.ToolsSubMenu.Text = "&Tools";
-		            this.ToolsSubMenu.DropDownOpened += new System.EventHandler(this.ToolsSubMenu_DropDownOpened);
-		            // 
-		            // ToolBoxMenuItem
-		            // 
-		            this.ToolBoxMenuItem.Text = "&Tool Box";
-		            this.ToolBoxMenuItem.Click += new System.EventHandler(this.ToolBoxMenuItem_Click);
-		            // 
-		            // RamWatchMenuItem
-		            // 
-		            this.RamWatchMenuItem.Text = "RAM &Watch";
-		            this.RamWatchMenuItem.Click += new System.EventHandler(this.RamWatchMenuItem_Click);
-		            // 
-		            // RamSearchMenuItem
-		            // 
-		            this.RamSearchMenuItem.Text = "RAM &Search";
-		            this.RamSearchMenuItem.Click += new System.EventHandler(this.RamSearchMenuItem_Click);
-		            // 
-		            // LuaConsoleMenuItem
-		            // 
-		            this.LuaConsoleMenuItem.Text = "Lua Console";
-		            this.LuaConsoleMenuItem.Click += new System.EventHandler(this.LuaConsoleMenuItem_Click);
-		            // 
-		            // TAStudioMenuItem
-		            // 
-		            this.TAStudioMenuItem.Text = "&TAStudio";
-		            this.TAStudioMenuItem.Click += new System.EventHandler(this.TAStudioMenuItem_Click);
-		            // 
-		            // HexEditorMenuItem
-		            // 
-		            this.HexEditorMenuItem.Text = "&Hex Editor";
-		            this.HexEditorMenuItem.Click += new System.EventHandler(this.HexEditorMenuItem_Click);
-		            // 
-		            // TraceLoggerMenuItem
-		            // 
-		            this.TraceLoggerMenuItem.Text = "Trace &Logger";
-		            this.TraceLoggerMenuItem.Click += new System.EventHandler(this.TraceLoggerMenuItem_Click);
-		            // 
-		            // DebuggerMenuItem
-		            // 
-		            this.DebuggerMenuItem.Text = "&Debugger";
-		            this.DebuggerMenuItem.Click += new System.EventHandler(this.DebuggerMenuItem_Click);
-		            // 
-		            // CodeDataLoggerMenuItem
-		            // 
-		            this.CodeDataLoggerMenuItem.Text = "Code-Data Logger";
-		            this.CodeDataLoggerMenuItem.Click += new System.EventHandler(this.CodeDataLoggerMenuItem_Click);
-		            // 
-		            // MacroToolMenuItem
-		            // 
-		            this.MacroToolMenuItem.Text = "&Macro Tool";
-		            this.MacroToolMenuItem.Click += new System.EventHandler(this.MacroToolMenuItem_Click);
-		            // 
-		            // VirtualPadMenuItem
-		            // 
-		            this.VirtualPadMenuItem.Text = "Virtual Pad";
-		            this.VirtualPadMenuItem.Click += new System.EventHandler(this.VirtualPadMenuItem_Click);
-		            // 
-		            // BasicBotMenuItem
-		            // 
-		            this.BasicBotMenuItem.Text = "Basic Bot";
-		            this.BasicBotMenuItem.Click += new System.EventHandler(this.BasicBotMenuItem_Click);
-		            // 
-		            // CheatsMenuItem
-		            // 
-		            this.CheatsMenuItem.Text = "Cheats";
-		            this.CheatsMenuItem.Click += new System.EventHandler(this.CheatsMenuItem_Click);
-		            // 
-		            // GameSharkConverterMenuItem
-		            // 
-		            this.GameSharkConverterMenuItem.Text = "Cheat Code Converter";
-		            this.GameSharkConverterMenuItem.Click += new System.EventHandler(this.CheatCodeConverterMenuItem_Click);
-		            // 
-		            // MultiDiskBundlerFileMenuItem
-		            // 
-		            this.MultiDiskBundlerFileMenuItem.Text = "Multi-disk Bundler";
-		            this.MultiDiskBundlerFileMenuItem.Click += new System.EventHandler(this.MultidiskBundlerMenuItem_Click);
-		            // 
-		            // BatchRunnerMenuItem
-		            // 
-		            this.BatchRunnerMenuItem.Text = "Batch Runner...";
-		            this.BatchRunnerMenuItem.Visible = false;
-		            this.BatchRunnerMenuItem.Click += new System.EventHandler(this.BatchRunnerMenuItem_Click);
-		            // 
-		            // ExternalToolMenuItem
-		            // 
-		            this.ExternalToolMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.dummyExternalTool});
-		            this.ExternalToolMenuItem.Text = "External Tool";
-		            this.ExternalToolMenuItem.DropDownOpening += new System.EventHandler(this.ExternalToolMenuItem_DropDownOpening);
-		            // 
-		            // dummyExternalTool
-		            // 
-		            this.dummyExternalTool.Text = "None";
-		            // 
-		            // RetroAchievementsMenuItem
-		            // 
-		            this.RetroAchievementsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.StartRetroAchievementsMenuItem});
-		            this.RetroAchievementsMenuItem.Text = "&RetroAchievements";
-		            // 
-		            // StartRetroAchievementsMenuItem
-		            // 
-		            this.StartRetroAchievementsMenuItem.Text = "&Start RetroAchievements";
-		            this.StartRetroAchievementsMenuItem.Click += new System.EventHandler(this.StartRetroAchievementsMenuItem_Click);
-		            // 
-		            // NESSubMenu
-		            // 
-		            this.NESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.NESPPUViewerMenuItem,
-		            this.NESNametableViewerMenuItem,
-		            this.MusicRipperMenuItem,
-		            this.toolStripSeparator17,
-		            this.NesControllerSettingsMenuItem,
-		            this.NESGraphicSettingsMenuItem,
-		            this.NESSoundChannelsMenuItem,
-		            this.VSSettingsMenuItem,
-		            this.MovieSettingsMenuItem,
-		            this.toolStripSeparator22,
-		            this.FDSControlsMenuItem,
-		            this.VSControlsMenuItem,
-		            this.BarcodeReaderMenuItem});
-		            this.NESSubMenu.Text = "&NES";
-		            this.NESSubMenu.DropDownOpened += new System.EventHandler(this.NesSubMenu_DropDownOpened);
-		            // 
-		            // NESPPUViewerMenuItem
-		            // 
-		            this.NESPPUViewerMenuItem.Text = "&PPU Viewer";
-		            this.NESPPUViewerMenuItem.Click += new System.EventHandler(this.NesPpuViewerMenuItem_Click);
-		            // 
-		            // NESNametableViewerMenuItem
-		            // 
-		            this.NESNametableViewerMenuItem.Text = "&Nametable Viewer";
-		            this.NESNametableViewerMenuItem.Click += new System.EventHandler(this.NesNametableViewerMenuItem_Click);
-		            // 
-		            // MusicRipperMenuItem
-		            // 
-		            this.MusicRipperMenuItem.Text = "Music Ripper";
-		            this.MusicRipperMenuItem.Click += new System.EventHandler(this.MusicRipperMenuItem_Click);
-		            // 
-		            // NesControllerSettingsMenuItem
-		            // 
-		            this.NesControllerSettingsMenuItem.Text = "Controller Settings...";
-		            this.NesControllerSettingsMenuItem.Click += new System.EventHandler(this.NesControllerSettingsMenuItem_Click);
-		            // 
-		            // NESGraphicSettingsMenuItem
-		            // 
-		            this.NESGraphicSettingsMenuItem.Text = "Graphics Settings...";
-		            this.NESGraphicSettingsMenuItem.Click += new System.EventHandler(this.NesGraphicSettingsMenuItem_Click);
-		            // 
-		            // NESSoundChannelsMenuItem
-		            // 
-		            this.NESSoundChannelsMenuItem.Text = "Sound Channels...";
-		            this.NESSoundChannelsMenuItem.Click += new System.EventHandler(this.NesSoundChannelsMenuItem_Click);
-		            // 
-		            // VSSettingsMenuItem
-		            // 
-		            this.VSSettingsMenuItem.Text = "VS Settings...";
-		            this.VSSettingsMenuItem.Click += new System.EventHandler(this.VsSettingsMenuItem_Click);
-		            // 
-		            // MovieSettingsMenuItem
-		            // 
-		            this.MovieSettingsMenuItem.Text = "Advanced Settings...";
-		            this.MovieSettingsMenuItem.Click += new System.EventHandler(this.MovieSettingsMenuItem_Click);
-		            // 
-		            // FDSControlsMenuItem
-		            // 
-		            this.FDSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.FdsEjectDiskMenuItem});
-		            this.FDSControlsMenuItem.Text = "FDS Controls";
-		            this.FDSControlsMenuItem.DropDownOpened += new System.EventHandler(this.FdsControlsMenuItem_DropDownOpened);
-		            // 
-		            // FdsEjectDiskMenuItem
-		            // 
-		            this.FdsEjectDiskMenuItem.Text = "&Eject Disk";
-		            this.FdsEjectDiskMenuItem.Click += new System.EventHandler(this.FdsEjectDiskMenuItem_Click);
-		            // 
-		            // VSControlsMenuItem
-		            // 
-		            this.VSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.VSInsertCoinP1MenuItem,
-		            this.VSInsertCoinP2MenuItem,
-		            this.VSServiceSwitchMenuItem});
-		            this.VSControlsMenuItem.Text = "VS Controls";
-		            // 
-		            // VSInsertCoinP1MenuItem
-		            // 
-		            this.VSInsertCoinP1MenuItem.Text = "Insert Coin P1";
-		            this.VSInsertCoinP1MenuItem.Click += new System.EventHandler(this.VsInsertCoinP1MenuItem_Click);
-		            // 
-		            // VSInsertCoinP2MenuItem
-		            // 
-		            this.VSInsertCoinP2MenuItem.Text = "Insert Coin P2";
-		            this.VSInsertCoinP2MenuItem.Click += new System.EventHandler(this.VsInsertCoinP2MenuItem_Click);
-		            // 
-		            // VSServiceSwitchMenuItem
-		            // 
-		            this.VSServiceSwitchMenuItem.Text = "Service Switch";
-		            this.VSServiceSwitchMenuItem.Click += new System.EventHandler(this.VsServiceSwitchMenuItem_Click);
-		            // 
-		            // BarcodeReaderMenuItem
-		            // 
-		            this.BarcodeReaderMenuItem.Text = "Barcode Reader";
-		            this.BarcodeReaderMenuItem.Click += new System.EventHandler(this.BarcodeReaderMenuItem_Click);
-		            // 
-		            // TI83SubMenu
-		            // 
-		            this.TI83SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.KeypadMenuItem,
-		            this.LoadTIFileMenuItem,
-		            this.toolStripSeparator13,
-		            this.paletteToolStripMenuItem});
-		            this.TI83SubMenu.Text = "TI83";
-		            // 
-		            // KeypadMenuItem
-		            // 
-		            this.KeypadMenuItem.Text = "Keypad";
-		            this.KeypadMenuItem.Click += new System.EventHandler(this.Ti83KeypadMenuItem_Click);
-		            // 
-		            // LoadTIFileMenuItem
-		            // 
-		            this.LoadTIFileMenuItem.Text = "Load TI-83 File...";
-		            this.LoadTIFileMenuItem.Click += new System.EventHandler(this.Ti83LoadTIFileMenuItem_Click);
-		            // 
-		            // paletteToolStripMenuItem
-		            // 
-		            this.paletteToolStripMenuItem.Text = "Palette...";
-		            this.paletteToolStripMenuItem.Click += new System.EventHandler(this.Ti83PaletteMenuItem_Click);
-		            // 
-		            // A7800SubMenu
-		            // 
-		            this.A7800SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.A7800ControllerSettingsMenuItem,
-		            this.A7800FilterSettingsMenuItem});
-		            this.A7800SubMenu.Text = "&A7800";
-		            this.A7800SubMenu.DropDownOpened += new System.EventHandler(this.A7800SubMenu_DropDownOpened);
-		            // 
-		            // A7800ControllerSettingsMenuItem
-		            // 
-		            this.A7800ControllerSettingsMenuItem.Text = "Controller Settings";
-		            this.A7800ControllerSettingsMenuItem.Click += new System.EventHandler(this.A7800ControllerSettingsMenuItem_Click);
-		            // 
-		            // A7800FilterSettingsMenuItem
-		            // 
-		            this.A7800FilterSettingsMenuItem.Text = "Filter Settings";
-		            this.A7800FilterSettingsMenuItem.Click += new System.EventHandler(this.A7800FilterSettingsMenuItem_Click);
-		            // 
-		            // GBSubMenu
-		            // 
-		            this.GBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.GBcoreSettingsToolStripMenuItem,
-		            this.SameBoyColorChooserMenuItem,
-		            this.toolStripSeparator28,
-		            this.GBGPUViewerMenuItem,
-		            this.GBPrinterViewerMenuItem});
-		            this.GBSubMenu.Text = "&GB";
-		            // 
-		            // GBcoreSettingsToolStripMenuItem
-		            // 
-		            this.GBcoreSettingsToolStripMenuItem.Text = "Settings...";
-		            this.GBcoreSettingsToolStripMenuItem.Click += new System.EventHandler(this.GbCoreSettingsMenuItem_Click);
-		            // 
-		            // SameBoyColorChooserMenuItem
-		            // 
-		            this.SameBoyColorChooserMenuItem.Text = "&Choose Custom Palette...";
-		            this.SameBoyColorChooserMenuItem.Click += new System.EventHandler(this.SameboyColorChooserMenuItem_Click);
-		            // 
-		            // GBGPUViewerMenuItem
-		            // 
-		            this.GBGPUViewerMenuItem.Text = "GPU Viewer";
-		            this.GBGPUViewerMenuItem.Click += new System.EventHandler(this.GbGpuViewerMenuItem_Click);
-		            // 
-		            // GBPrinterViewerMenuItem
-		            // 
-		            this.GBPrinterViewerMenuItem.Text = "&Printer Viewer";
-		            this.GBPrinterViewerMenuItem.Click += new System.EventHandler(this.GbPrinterViewerMenuItem_Click);
-		            // 
-		            // PSXSubMenu
-		            // 
-		            this.PSXSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.PSXControllerSettingsMenuItem,
-		            this.PSXOptionsMenuItem,
-		            this.PSXDiscControlsMenuItem,
-		            this.PSXHashDiscsToolStripMenuItem});
-		            this.PSXSubMenu.Text = "PSX";
-		            this.PSXSubMenu.DropDownOpened += new System.EventHandler(this.PsxSubMenu_DropDownOpened);
-		            // 
-		            // PSXControllerSettingsMenuItem
-		            // 
-		            this.PSXControllerSettingsMenuItem.Text = "Controller / Memcard Settings";
-		            this.PSXControllerSettingsMenuItem.Click += new System.EventHandler(this.PsxControllerSettingsMenuItem_Click);
-		            // 
-		            // PSXOptionsMenuItem
-		            // 
-		            this.PSXOptionsMenuItem.Text = "&Options";
-		            this.PSXOptionsMenuItem.Click += new System.EventHandler(this.PsxOptionsMenuItem_Click);
-		            // 
-		            // PSXDiscControlsMenuItem
-		            // 
-		            this.PSXDiscControlsMenuItem.Text = "&Disc Controls";
-		            this.PSXDiscControlsMenuItem.Click += new System.EventHandler(this.PsxDiscControlsMenuItem_Click);
-		            // 
-		            // PSXHashDiscsToolStripMenuItem
-		            // 
-		            this.PSXHashDiscsToolStripMenuItem.Text = "&Hash Discs";
-		            this.PSXHashDiscsToolStripMenuItem.Click += new System.EventHandler(this.PsxHashDiscsMenuItem_Click);
-		            // 
-		            // SNESSubMenu
-		            // 
-		            this.SNESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.SNESControllerConfigurationMenuItem,
-		            this.toolStripSeparator18,
-		            this.SnesGfxDebuggerMenuItem,
-		            this.SnesOptionsMenuItem});
-		            this.SNESSubMenu.Text = "&SNES";
-		            this.SNESSubMenu.DropDownOpened += new System.EventHandler(this.SnesSubMenu_DropDownOpened);
-		            // 
-		            // SNESControllerConfigurationMenuItem
-		            // 
-		            this.SNESControllerConfigurationMenuItem.Text = "Controller Configuration";
-		            this.SNESControllerConfigurationMenuItem.Click += new System.EventHandler(this.SNESControllerConfigurationMenuItem_Click);
-		            // 
-		            // SnesGfxDebuggerMenuItem
-		            // 
-		            this.SnesGfxDebuggerMenuItem.Text = "Graphics Debugger";
-		            this.SnesGfxDebuggerMenuItem.Click += new System.EventHandler(this.SnesGfxDebuggerMenuItem_Click);
-		            // 
-		            // SnesOptionsMenuItem
-		            // 
-		            this.SnesOptionsMenuItem.Text = "&Options";
-		            this.SnesOptionsMenuItem.Click += new System.EventHandler(this.SnesOptionsMenuItem_Click);
-		            // 
-		            // ColecoSubMenu
-		            // 
-		            this.ColecoSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.ColecoControllerSettingsMenuItem,
-		            this.toolStripSeparator35,
-		            this.ColecoSkipBiosMenuItem,
-		            this.ColecoUseSGMMenuItem});
-		            this.ColecoSubMenu.Text = "&Coleco";
-		            this.ColecoSubMenu.DropDownOpened += new System.EventHandler(this.ColecoSubMenu_DropDownOpened);
-		            // 
-		            // ColecoControllerSettingsMenuItem
-		            // 
-		            this.ColecoControllerSettingsMenuItem.Text = "&Controller Settings...";
-		            this.ColecoControllerSettingsMenuItem.Click += new System.EventHandler(this.ColecoControllerSettingsMenuItem_Click);
-		            // 
-		            // ColecoSkipBiosMenuItem
-		            // 
-		            this.ColecoSkipBiosMenuItem.Text = "&Skip BIOS intro (When Applicable)";
-		            this.ColecoSkipBiosMenuItem.Click += new System.EventHandler(this.ColecoSkipBiosMenuItem_Click);
-		            // 
-		            // ColecoUseSGMMenuItem
-		            // 
-		            this.ColecoUseSGMMenuItem.Text = "&Use the Super Game Module";
-		            this.ColecoUseSGMMenuItem.Click += new System.EventHandler(this.ColecoUseSGMMenuItem_Click);
-		            // 
-		            // N64SubMenu
-		            // 
-		            this.N64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.N64PluginSettingsMenuItem,
-		            this.N64ControllerSettingsMenuItem,
-		            this.toolStripSeparator23,
-		            this.N64CircularAnalogRangeMenuItem,
-		            this.MupenStyleLagMenuItem,
-		            this.N64ExpansionSlotMenuItem});
-		            this.N64SubMenu.Text = "N64";
-		            this.N64SubMenu.DropDownOpened += new System.EventHandler(this.N64SubMenu_DropDownOpened);
-		            // 
-		            // N64PluginSettingsMenuItem
-		            // 
-		            this.N64PluginSettingsMenuItem.Text = "Plugins";
-		            this.N64PluginSettingsMenuItem.Click += new System.EventHandler(this.N64PluginSettingsMenuItem_Click);
-		            // 
-		            // N64ControllerSettingsMenuItem
-		            // 
-		            this.N64ControllerSettingsMenuItem.Text = "Controller Settings...";
-		            this.N64ControllerSettingsMenuItem.Click += new System.EventHandler(this.N64ControllerSettingsMenuItem_Click);
-		            // 
-		            // N64CircularAnalogRangeMenuItem
-		            // 
-		            this.N64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
-		            this.N64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
-		            // 
-		            // MupenStyleLagMenuItem
-		            // 
-		            this.MupenStyleLagMenuItem.Text = "&Mupen Style Lag Frames";
-		            this.MupenStyleLagMenuItem.Click += new System.EventHandler(this.MupenStyleLagMenuItem_Click);
-		            // 
-		            // N64ExpansionSlotMenuItem
-		            // 
-		            this.N64ExpansionSlotMenuItem.Text = "&Use Expansion Slot";
-		            this.N64ExpansionSlotMenuItem.Click += new System.EventHandler(this.N64ExpansionSlotMenuItem_Click);
-		            // 
-		            // Ares64SubMenu
-		            // 
-		            this.Ares64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.Ares64SettingsMenuItem,
-		            this.Ares64CircularAnalogRangeMenuItem});
-		            this.Ares64SubMenu.Text = "N64";
-		            this.Ares64SubMenu.DropDownOpened += new System.EventHandler(this.Ares64SubMenu_DropDownOpened);
-		            // 
-		            // Ares64SettingsMenuItem
-		            // 
-		            this.Ares64SettingsMenuItem.Text = "Settings...";
-		            this.Ares64SettingsMenuItem.Click += new System.EventHandler(this.Ares64SettingsMenuItem_Click);
-		            // 
-		            // Ares64CircularAnalogRangeMenuItem
-		            // 
-		            this.Ares64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
-		            this.Ares64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
-		            // 
-		            // GBLSubMenu
-		            // 
-		            this.GBLSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.GBLsettingsToolStripMenuItem});
-		            this.GBLSubMenu.Text = "&GB Link";
-		            // 
-		            // GBLsettingsToolStripMenuItem
-		            // 
-		            this.GBLsettingsToolStripMenuItem.Text = "Settings...";
-		            this.GBLsettingsToolStripMenuItem.Click += new System.EventHandler(this.GblSettingsMenuItem_Click);
-		            // 
-		            // AppleSubMenu
-		            // 
-		            this.AppleSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.AppleDisksSubMenu,
-		            this.settingsToolStripMenuItem1});
-		            this.AppleSubMenu.Text = "Apple";
-		            this.AppleSubMenu.DropDownOpened += new System.EventHandler(this.AppleSubMenu_DropDownOpened);
-		            // 
-		            // AppleDisksSubMenu
-		            // 
-		            this.AppleDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.toolStripSeparator31});
-		            this.AppleDisksSubMenu.Text = "Disks";
-		            this.AppleDisksSubMenu.DropDownOpened += new System.EventHandler(this.AppleDisksSubMenu_DropDownOpened);
-		            // 
-		            // settingsToolStripMenuItem1
-		            // 
-		            this.settingsToolStripMenuItem1.Text = "&Settings...";
-		            this.settingsToolStripMenuItem1.Click += new System.EventHandler(this.AppleIISettingsMenuItem_Click);
-		            // 
-		            // C64SubMenu
-		            // 
-		            this.C64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.C64DisksSubMenu,
-		            this.C64SettingsMenuItem});
-		            this.C64SubMenu.Text = "&C64";
-		            this.C64SubMenu.DropDownOpened += new System.EventHandler(this.C64SubMenu_DropDownOpened);
-		            // 
-		            // C64DisksSubMenu
-		            // 
-		            this.C64DisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.toolStripSeparator36});
-		            this.C64DisksSubMenu.Text = "Disks";
-		            this.C64DisksSubMenu.DropDownOpened += new System.EventHandler(this.C64DisksSubMenu_DropDownOpened);
-		            // 
-		            // C64SettingsMenuItem
-		            // 
-		            this.C64SettingsMenuItem.Text = "&Settings...";
-		            this.C64SettingsMenuItem.Click += new System.EventHandler(this.C64SettingsMenuItem_Click);
-		            // 
-		            // IntvSubMenu
-		            // 
-		            this.IntvSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.IntVControllerSettingsMenuItem});
-		            this.IntvSubMenu.Text = "&Intv";
-		            this.IntvSubMenu.DropDownOpened += new System.EventHandler(this.IntVSubMenu_DropDownOpened);
-		            // 
-		            // IntVControllerSettingsMenuItem
-		            // 
-		            this.IntVControllerSettingsMenuItem.Text = "Controller Settings...";
-		            this.IntVControllerSettingsMenuItem.Click += new System.EventHandler(this.IntVControllerSettingsMenuItem_Click);
-		            // 
-		            // zXSpectrumToolStripMenuItem
-		            // 
-		            this.zXSpectrumToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.ZXSpectrumCoreEmulationSettingsMenuItem,
-		            this.ZXSpectrumControllerConfigurationMenuItem,
-		            this.ZXSpectrumAudioSettingsMenuItem,
-		            this.ZXSpectrumNonSyncSettingsMenuItem,
-		            this.ZXSpectrumMediaMenuItem});
-		            this.zXSpectrumToolStripMenuItem.Text = "ZX Spectrum";
-		            // 
-		            // ZXSpectrumCoreEmulationSettingsMenuItem
-		            // 
-		            this.ZXSpectrumCoreEmulationSettingsMenuItem.Text = "Core Emulation Settings";
-		            this.ZXSpectrumCoreEmulationSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumCoreEmulationSettingsMenuItem_Click);
-		            // 
-		            // ZXSpectrumControllerConfigurationMenuItem
-		            // 
-		            this.ZXSpectrumControllerConfigurationMenuItem.Text = "Joystick Configuration";
-		            this.ZXSpectrumControllerConfigurationMenuItem.Click += new System.EventHandler(this.ZXSpectrumControllerConfigurationMenuItem_Click);
-		            // 
-		            // ZXSpectrumAudioSettingsMenuItem
-		            // 
-		            this.ZXSpectrumAudioSettingsMenuItem.Text = "Audio Settings";
-		            this.ZXSpectrumAudioSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumAudioSettingsMenuItem_Click);
-		            // 
-		            // ZXSpectrumNonSyncSettingsMenuItem
-		            // 
-		            this.ZXSpectrumNonSyncSettingsMenuItem.Text = "Non-Sync Settings";
-		            this.ZXSpectrumNonSyncSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumNonSyncSettingsMenuItem_Click);
-		            // 
-		            // ZXSpectrumMediaMenuItem
-		            // 
-		            this.ZXSpectrumMediaMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.ZXSpectrumTapesSubMenu,
-		            this.ZXSpectrumDisksSubMenu,
-		            this.ZXSpectrumExportSnapshotMenuItemMenuItem});
-		            this.ZXSpectrumMediaMenuItem.Text = "Media";
-		            this.ZXSpectrumMediaMenuItem.DropDownOpened += new System.EventHandler(this.ZXSpectrumMediaMenuItem_DropDownOpened);
-		            // 
-		            // ZXSpectrumTapesSubMenu
-		            // 
-		            this.ZXSpectrumTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.zxt1ToolStripMenuItem});
-		            this.ZXSpectrumTapesSubMenu.Text = "Tapes";
-		            this.ZXSpectrumTapesSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumTapesSubMenu_DropDownOpened);
-		            // 
-		            // zxt1ToolStripMenuItem
-		            // 
-		            this.zxt1ToolStripMenuItem.Text = "zxt1";
-		            // 
-		            // ZXSpectrumDisksSubMenu
-		            // 
-		            this.ZXSpectrumDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.zxt2ToolStripMenuItem});
-		            this.ZXSpectrumDisksSubMenu.Text = "Disks";
-		            this.ZXSpectrumDisksSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumDisksSubMenu_DropDownOpened);
-		            // 
-		            // zxt2ToolStripMenuItem
-		            // 
-		            this.zxt2ToolStripMenuItem.Text = "zxt2";
-		            // 
-		            // ZXSpectrumExportSnapshotMenuItemMenuItem
-		            // 
-		            this.ZXSpectrumExportSnapshotMenuItemMenuItem.Text = "Export Snapshot";
-		            this.ZXSpectrumExportSnapshotMenuItemMenuItem.Click += new System.EventHandler(this.ZXSpectrumExportSnapshotMenuItemMenuItem_Click);
-		            // 
-		            // GenericCoreSubMenu
-		            // 
-		            this.GenericCoreSubMenu.Text = "&Core";
-		            // 
-		            // amstradCPCToolStripMenuItem
-		            // 
-		            this.amstradCPCToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.amstradCPCCoreEmulationSettingsToolStripMenuItem,
-		            this.AmstradCPCAudioSettingsToolStripMenuItem,
-		            this.AmstradCPCNonSyncSettingsToolStripMenuItem,
-		            this.AmstradCPCMediaToolStripMenuItem});
-		            this.amstradCPCToolStripMenuItem.Text = "Amstrad CPC";
-		            // 
-		            // amstradCPCCoreEmulationSettingsToolStripMenuItem
-		            // 
-		            this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Text = "Core Emulation Settings";
-		            this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcCoreEmulationSettingsMenuItem_Click);
-		            // 
-		            // AmstradCPCAudioSettingsToolStripMenuItem
-		            // 
-		            this.AmstradCPCAudioSettingsToolStripMenuItem.Text = "Audio Settings";
-		            this.AmstradCPCAudioSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcAudioSettingsMenuItem_Click);
-		            // 
-		            // AmstradCPCNonSyncSettingsToolStripMenuItem
-		            // 
-		            this.AmstradCPCNonSyncSettingsToolStripMenuItem.Text = "Non-Sync Settings";
-		            this.AmstradCPCNonSyncSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcNonSyncSettingsMenuItem_Click);
-		            // 
-		            // AmstradCPCMediaToolStripMenuItem
-		            // 
-		            this.AmstradCPCMediaToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.AmstradCPCTapesSubMenu,
-		            this.AmstradCPCDisksSubMenu});
-		            this.AmstradCPCMediaToolStripMenuItem.Text = "Media";
-		            this.AmstradCPCMediaToolStripMenuItem.DropDownOpened += new System.EventHandler(this.AmstradCpcMediaMenuItem_DropDownOpened);
-		            // 
-		            // AmstradCPCTapesSubMenu
-		            // 
-		            this.AmstradCPCTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.cpct1ToolStripMenuItem});
-		            this.AmstradCPCTapesSubMenu.Text = "Tapes";
-		            this.AmstradCPCTapesSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcTapesSubMenu_DropDownOpened);
-		            // 
-		            // cpct1ToolStripMenuItem
-		            // 
-		            this.cpct1ToolStripMenuItem.Text = "cpct1";
-		            // 
-		            // AmstradCPCDisksSubMenu
-		            // 
-		            this.AmstradCPCDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.cpcd1ToolStripMenuItem});
-		            this.AmstradCPCDisksSubMenu.Text = "Disks";
-		            this.AmstradCPCDisksSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcDisksSubMenu_DropDownOpened);
-		            // 
-		            // cpcd1ToolStripMenuItem
-		            // 
-		            this.cpcd1ToolStripMenuItem.Text = "cpcd1";
-		            // 
-		            // HelpSubMenu
-		            // 
-		            this.HelpSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.OnlineHelpMenuItem,
-		            this.ForumsMenuItem,
-		            this.FeaturesMenuItem,
-		            this.AboutMenuItem});
-		            this.HelpSubMenu.Text = "&Help";
-		            this.HelpSubMenu.DropDownOpened += new System.EventHandler(this.HelpSubMenu_DropDownOpened);
-		            // 
-		            // OnlineHelpMenuItem
-		            // 
-		            this.OnlineHelpMenuItem.Text = "Open TASVideos Wiki in Browser";
-		            this.OnlineHelpMenuItem.Click += new System.EventHandler(this.OnlineHelpMenuItem_Click);
-		            // 
-		            // ForumsMenuItem
-		            // 
-		            this.ForumsMenuItem.Text = "Open Forums in Browser";
-		            this.ForumsMenuItem.Click += new System.EventHandler(this.ForumsMenuItem_Click);
-		            // 
-		            // FeaturesMenuItem
-		            // 
-		            this.FeaturesMenuItem.Text = "&Features";
-		            this.FeaturesMenuItem.Click += new System.EventHandler(this.FeaturesMenuItem_Click);
-		            // 
-		            // AboutMenuItem
-		            // 
-		            this.AboutMenuItem.Text = "&About...";
-		            this.AboutMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
-		            // 
-		            // A7800HawkCoreMenuItem
-		            // 
-		            this.A7800HawkCoreMenuItem.Text = "A7800Hawk";
-		            // 
-		            // MainStatusBar
-		            // 
-		            this.MainStatusBar.ImageScalingSize = new System.Drawing.Size(20, 20);
-		            this.MainStatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.DumpStatusButton,
-		            this.EmuStatus,
-		            this.PlayRecordStatusButton,
-		            this.PauseStatusButton,
-		            this.RebootStatusBarIcon,
-		            this.AVIStatusLabel,
-		            this.LedLightStatusLabel,
-		            this.SaveSlotsStatusLabel,
-		            this.Slot1StatusButton,
-		            this.Slot2StatusButton,
-		            this.Slot3StatusButton,
-		            this.Slot4StatusButton,
-		            this.Slot5StatusButton,
-		            this.Slot6StatusButton,
-		            this.Slot7StatusButton,
-		            this.Slot8StatusButton,
-		            this.Slot9StatusButton,
-		            this.Slot0StatusButton,
-		            this.CheatStatusButton,
-		            this.KeyPriorityStatusLabel,
-		            this.CoreNameStatusBarButton,
-		            this.ProfileFirstBootLabel,
-		            this.LinkConnectStatusBarButton,
-		            this.UpdateNotification});
-		            this.MainStatusBar.Location = new System.Drawing.Point(0, 382);
-		            this.MainStatusBar.Name = "MainStatusBar";
-		            this.MainStatusBar.ShowItemToolTips = true;
-		            this.MainStatusBar.SizingGrip = false;
-		            this.MainStatusBar.TabIndex = 1;
-		            // 
-		            // DumpStatusButton
-		            // 
-		            this.DumpStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-		            this.DumpStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-		            this.DumpStatusButton.Name = "DumpStatusButton";
-		            this.DumpStatusButton.ShowDropDownArrow = false;
-		            this.DumpStatusButton.Size = new System.Drawing.Size(4, 24);
-		            this.DumpStatusButton.Text = "No ROM loaded";
-		            this.DumpStatusButton.Click += new System.EventHandler(this.DumpStatusButton_Click);
-		            // 
-		            // PlayRecordStatusButton
-		            // 
-		            this.PlayRecordStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-		            this.PlayRecordStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-		            this.PlayRecordStatusButton.Name = "PlayRecordStatusButton";
-		            this.PlayRecordStatusButton.ShowDropDownArrow = false;
-		            this.PlayRecordStatusButton.Size = new System.Drawing.Size(4, 24);
-		            this.PlayRecordStatusButton.Text = "No movie is active";
-		            // 
-		            // PauseStatusButton
-		            // 
-		            this.PauseStatusButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-		            this.PauseStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-		            this.PauseStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-		            this.PauseStatusButton.Name = "PauseStatusButton";
-		            this.PauseStatusButton.ShowDropDownArrow = false;
-		            this.PauseStatusButton.Size = new System.Drawing.Size(4, 24);
-		            this.PauseStatusButton.Text = "toolStripDropDownButton1";
-		            this.PauseStatusButton.ToolTipText = "Emulator is paused";
-		            this.PauseStatusButton.Click += new System.EventHandler(this.PauseMenuItem_Click);
-		            // 
-		            // RebootStatusBarIcon
-		            // 
-		            this.RebootStatusBarIcon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-		            this.RebootStatusBarIcon.RightToLeft = System.Windows.Forms.RightToLeft.No;
-		            this.RebootStatusBarIcon.Text = "Reboot";
-		            this.RebootStatusBarIcon.ToolTipText = "A reboot of the core is needed for a setting change to take effect";
-		            this.RebootStatusBarIcon.Click += new System.EventHandler(this.PowerMenuItem_Click);
-		            // 
-		            // AVIStatusLabel
-		            // 
-		            this.AVIStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-		            this.AVIStatusLabel.Text = "AVI Capture";
-		            // 
-		            // LedLightStatusLabel
-		            // 
-		            this.LedLightStatusLabel.ToolTipText = "Disk Drive LED Light";
-		            // 
-		            // SaveSlotsStatusLabel
-		            // 
-		            this.SaveSlotsStatusLabel.BackColor = System.Drawing.SystemColors.Control;
-		            this.SaveSlotsStatusLabel.Text = "Save slots";
-		            // 
-		            // Slot1StatusButton
-		            // 
-		            this.Slot1StatusButton.Text = "1";
-		            this.Slot1StatusButton.ToolTipText = "Save slot 1";
-		            this.Slot1StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-		            // 
-		            // Slot2StatusButton
-		            // 
-		            this.Slot2StatusButton.Text = "2";
-		            this.Slot2StatusButton.ToolTipText = "Save slot 2";
-		            this.Slot2StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-		            // 
-		            // Slot3StatusButton
-		            // 
-		            this.Slot3StatusButton.Text = "3";
-		            this.Slot3StatusButton.ToolTipText = "Save slot 3";
-		            this.Slot3StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-		            // 
-		            // Slot4StatusButton
-		            // 
-		            this.Slot4StatusButton.Text = "4";
-		            this.Slot4StatusButton.ToolTipText = "Save slot 4";
-		            this.Slot4StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-		            // 
-		            // Slot5StatusButton
-		            // 
-		            this.Slot5StatusButton.Text = "5";
-		            this.Slot5StatusButton.ToolTipText = "Save slot 5";
-		            this.Slot5StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-		            // 
-		            // Slot6StatusButton
-		            // 
-		            this.Slot6StatusButton.Text = "6";
-		            this.Slot6StatusButton.ToolTipText = "Save slot 6";
-		            this.Slot6StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-		            // 
-		            // Slot7StatusButton
-		            // 
-		            this.Slot7StatusButton.Text = "7";
-		            this.Slot7StatusButton.ToolTipText = "Save slot 7";
-		            this.Slot7StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-		            // 
-		            // Slot8StatusButton
-		            // 
-		            this.Slot8StatusButton.Text = "8";
-		            this.Slot8StatusButton.ToolTipText = "Save slot 8";
-		            this.Slot8StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-		            // 
-		            // Slot9StatusButton
-		            // 
-		            this.Slot9StatusButton.Text = "9";
-		            this.Slot9StatusButton.ToolTipText = "Save slot 9";
-		            this.Slot9StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-		            // 
-		            // Slot0StatusButton
-		            // 
-		            this.Slot0StatusButton.Text = "0";
-		            this.Slot0StatusButton.ToolTipText = "Save slot 10";
-		            this.Slot0StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-		            // 
-		            // CheatStatusButton
-		            // 
-		            this.CheatStatusButton.Click += new System.EventHandler(this.FreezeStatus_Click);
-		            // 
-		            // KeyPriorityStatusLabel
-		            // 
-		            this.KeyPriorityStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-		            this.KeyPriorityStatusLabel.Margin = new System.Windows.Forms.Padding(5, 3, 5, 0);
-		            this.KeyPriorityStatusLabel.Text = "KeyPriority";
-		            this.KeyPriorityStatusLabel.Click += new System.EventHandler(this.KeyPriorityStatusLabel_Click);
-		            // 
-		            // CoreNameStatusBarButton
-		            // 
-		            this.CoreNameStatusBarButton.Text = "<core name>";
-		            // 
-		            // ProfileFirstBootLabel
-		            // 
-		            this.ProfileFirstBootLabel.AutoToolTip = true;
-		            this.ProfileFirstBootLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-		            this.ProfileFirstBootLabel.Text = "ProfileFirstBootLabel";
-		            this.ProfileFirstBootLabel.ToolTipText = "Set up your profile before use";
-		            this.ProfileFirstBootLabel.Visible = false;
-		            this.ProfileFirstBootLabel.Click += new System.EventHandler(this.ProfileFirstBootLabel_Click);
-		            // 
-		            // LinkConnectStatusBarButton
-		            // 
-		            this.LinkConnectStatusBarButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-		            this.LinkConnectStatusBarButton.Text = "Link connection is currently enabled";
-		            this.LinkConnectStatusBarButton.ToolTipText = "Link connection is currently enabled";
-		            this.LinkConnectStatusBarButton.Click += new System.EventHandler(this.LinkConnectStatusBarButton_Click);
-		            // 
-		            // UpdateNotification
-		            // 
-		            this.UpdateNotification.IsLink = true;
-		            this.UpdateNotification.LinkColor = System.Drawing.Color.Red;
-		            this.UpdateNotification.Spring = true;
-		            this.UpdateNotification.Text = "New version available!";
-		            this.UpdateNotification.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-		            this.UpdateNotification.Click += new System.EventHandler(this.UpdateNotification_Click);
-		            // 
-		            // MainFormContextMenu
-		            // 
-		            this.MainFormContextMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
-		            this.MainFormContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.OpenRomContextMenuItem,
-		            this.LoadLastRomContextMenuItem,
-		            this.StopAVContextMenuItem,
-		            this.ContextSeparator_AfterROM,
-		            this.RecordMovieContextMenuItem,
-		            this.PlayMovieContextMenuItem,
-		            this.RestartMovieContextMenuItem,
-		            this.StopMovieContextMenuItem,
-		            this.LoadLastMovieContextMenuItem,
-		            this.BackupMovieContextMenuItem,
-		            this.StopNoSaveContextMenuItem,
-		            this.ViewSubtitlesContextMenuItem,
-		            this.AddSubtitleContextMenuItem,
-		            this.ViewCommentsContextMenuItem,
-		            this.SaveMovieContextMenuItem,
-		            this.SaveMovieAsContextMenuItem,
-		            this.ContextSeparator_AfterMovie,
-		            this.UndoSavestateContextMenuItem,
-		            this.ContextSeparator_AfterUndo,
-		            this.ConfigContextMenuItem,
-		            this.ScreenshotContextMenuItem,
-		            this.CloseRomContextMenuItem,
-		            this.ClearSRAMContextMenuItem,
-		            this.ShowMenuContextMenuSeparator,
-		            this.ShowMenuContextMenuItem});
-		            this.MainFormContextMenu.Name = "contextMenuStrip1";
-		            this.MainFormContextMenu.Size = new System.Drawing.Size(257, 532);
-		            this.MainFormContextMenu.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.MainFormContextMenu_Closing);
-		            this.MainFormContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.MainFormContextMenu_Opening);
-		            // 
-		            // OpenRomContextMenuItem
-		            // 
-		            this.OpenRomContextMenuItem.Text = "Open Rom";
-		            this.OpenRomContextMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
-		            // 
-		            // LoadLastRomContextMenuItem
-		            // 
-		            this.LoadLastRomContextMenuItem.Text = "Load Last ROM";
-		            this.LoadLastRomContextMenuItem.Click += new System.EventHandler(this.LoadLastRomContextMenuItem_Click);
-		            // 
-		            // StopAVContextMenuItem
-		            // 
-		            this.StopAVContextMenuItem.Text = "Stop AVI/WAV";
-		            this.StopAVContextMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
-		            // 
-		            // RecordMovieContextMenuItem
-		            // 
-		            this.RecordMovieContextMenuItem.Text = "Record Movie";
-		            this.RecordMovieContextMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
-		            // 
-		            // PlayMovieContextMenuItem
-		            // 
-		            this.PlayMovieContextMenuItem.Text = "Play Movie";
-		            this.PlayMovieContextMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
-		            // 
-		            // RestartMovieContextMenuItem
-		            // 
-		            this.RestartMovieContextMenuItem.Text = "Restart Movie";
-		            this.RestartMovieContextMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
-		            // 
-		            // StopMovieContextMenuItem
-		            // 
-		            this.StopMovieContextMenuItem.Text = "Stop Movie";
-		            this.StopMovieContextMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
-		            // 
-		            // LoadLastMovieContextMenuItem
-		            // 
-		            this.LoadLastMovieContextMenuItem.Text = "Load Last Movie";
-		            this.LoadLastMovieContextMenuItem.Click += new System.EventHandler(this.LoadLastMovieContextMenuItem_Click);
-		            // 
-		            // BackupMovieContextMenuItem
-		            // 
-		            this.BackupMovieContextMenuItem.Text = "Backup Movie";
-		            this.BackupMovieContextMenuItem.Click += new System.EventHandler(this.BackupMovieContextMenuItem_Click);
-		            // 
-		            // StopNoSaveContextMenuItem
-		            // 
-		            this.StopNoSaveContextMenuItem.Text = "Stop Movie without Saving";
-		            this.StopNoSaveContextMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
-		            // 
-		            // ViewSubtitlesContextMenuItem
-		            // 
-		            this.ViewSubtitlesContextMenuItem.Text = "View Subtitles";
-		            this.ViewSubtitlesContextMenuItem.Click += new System.EventHandler(this.ViewSubtitlesContextMenuItem_Click);
-		            // 
-		            // AddSubtitleContextMenuItem
-		            // 
-		            this.AddSubtitleContextMenuItem.Text = "Add Subtitle";
-		            this.AddSubtitleContextMenuItem.Click += new System.EventHandler(this.AddSubtitleContextMenuItem_Click);
-		            // 
-		            // ViewCommentsContextMenuItem
-		            // 
-		            this.ViewCommentsContextMenuItem.Text = "View Comments";
-		            this.ViewCommentsContextMenuItem.Click += new System.EventHandler(this.ViewCommentsContextMenuItem_Click);
-		            // 
-		            // SaveMovieContextMenuItem
-		            // 
-		            this.SaveMovieContextMenuItem.Text = "Save Movie";
-		            this.SaveMovieContextMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
-		            // 
-		            // SaveMovieAsContextMenuItem
-		            // 
-		            this.SaveMovieAsContextMenuItem.Text = "Save Movie As...";
-		            this.SaveMovieAsContextMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
-		            // 
-		            // UndoSavestateContextMenuItem
-		            // 
-		            this.UndoSavestateContextMenuItem.Text = "Undo Savestate";
-		            this.UndoSavestateContextMenuItem.Click += new System.EventHandler(this.UndoSavestateContextMenuItem_Click);
-		            // 
-		            // ConfigContextMenuItem
-		            // 
-		            this.ConfigContextMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-		            this.toolStripMenuItem6,
-		            this.toolStripMenuItem7,
-		            this.toolStripMenuItem8,
-		            this.toolStripMenuItem9,
-		            this.toolStripMenuItem10,
-		            this.toolStripMenuItem11,
-		            this.toolStripMenuItem12,
-		            this.toolStripMenuItem13,
-		            this.toolStripMenuItem14,
-		            this.toolStripMenuItem15,
-		            this.customizeToolStripMenuItem,
-		            this.toolStripSeparator30,
-		            this.toolStripMenuItem66,
-		            this.toolStripMenuItem67});
-		            this.ConfigContextMenuItem.Text = "Config";
-		            // 
-		            // toolStripMenuItem6
-		            // 
-		            this.toolStripMenuItem6.Text = "&Controllers...";
-		            this.toolStripMenuItem6.Click += new System.EventHandler(this.ControllersMenuItem_Click);
-		            // 
-		            // toolStripMenuItem7
-		            // 
-		            this.toolStripMenuItem7.Text = "&Hotkeys...";
-		            this.toolStripMenuItem7.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
-		            // 
-		            // toolStripMenuItem8
-		            // 
-		            this.toolStripMenuItem8.Text = "Display...";
-		            this.toolStripMenuItem8.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
-		            // 
-		            // toolStripMenuItem9
-		            // 
-		            this.toolStripMenuItem9.Text = "&Sound...";
-		            this.toolStripMenuItem9.Click += new System.EventHandler(this.SoundMenuItem_Click);
-		            // 
-		            // toolStripMenuItem10
-		            // 
-		            this.toolStripMenuItem10.Text = "Paths...";
-		            this.toolStripMenuItem10.Click += new System.EventHandler(this.PathsMenuItem_Click);
-		            // 
-		            // toolStripMenuItem11
-		            // 
-		            this.toolStripMenuItem11.Text = "&Firmwares...";
-		            this.toolStripMenuItem11.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
-		            // 
-		            // toolStripMenuItem12
-		            // 
-		            this.toolStripMenuItem12.Text = "&Messages...";
-		            this.toolStripMenuItem12.Click += new System.EventHandler(this.MessagesMenuItem_Click);
-		            // 
-		            // toolStripMenuItem13
-		            // 
-		            this.toolStripMenuItem13.Text = "&Autofire...";
-		            this.toolStripMenuItem13.Click += new System.EventHandler(this.AutofireMenuItem_Click);
-		            // 
-		            // toolStripMenuItem14
-		            // 
-		            this.toolStripMenuItem14.Text = "&Rewind...";
-		            this.toolStripMenuItem14.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
-		            // 
-		            // toolStripMenuItem15
-		            // 
-		            this.toolStripMenuItem15.Text = "File Extensions...";
-		            this.toolStripMenuItem15.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
-		            // 
-		            // customizeToolStripMenuItem
-		            // 
-		            this.customizeToolStripMenuItem.Text = "Customize...";
-		            this.customizeToolStripMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
-		            // 
-		            // toolStripMenuItem66
-		            // 
-		            this.toolStripMenuItem66.Text = "Save Config";
-		            this.toolStripMenuItem66.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
-		            // 
-		            // toolStripMenuItem67
-		            // 
-		            this.toolStripMenuItem67.Text = "Load Config";
-		            this.toolStripMenuItem67.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
-		            // 
-		            // ScreenshotContextMenuItem
-		            // 
-		            this.ScreenshotContextMenuItem.Text = "Screenshot";
-		            this.ScreenshotContextMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
-		            // 
-		            // CloseRomContextMenuItem
-		            // 
-		            this.CloseRomContextMenuItem.Text = "Close ROM";
-		            this.CloseRomContextMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
-		            // 
-		            // ClearSRAMContextMenuItem
-		            // 
-		            this.ClearSRAMContextMenuItem.Text = "Close and Clear SRAM";
-		            this.ClearSRAMContextMenuItem.Click += new System.EventHandler(this.ClearSramContextMenuItem_Click);
-		            // 
-		            // ShowMenuContextMenuItem
-		            // 
-		            this.ShowMenuContextMenuItem.Text = "Show Menu";
-		            this.ShowMenuContextMenuItem.Click += new System.EventHandler(this.ShowMenuContextMenuItem_Click);
-		            // 
-		            // timerMouseIdle
-		            // 
-		            this.timerMouseIdle.Enabled = true;
-		            this.timerMouseIdle.Interval = 2000;
-		            this.timerMouseIdle.Tick += new System.EventHandler(this.TimerMouseIdle_Tick);
-		            // 
-		            // MainForm
-		            // 
-		            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-		            this.ClientSize = new System.Drawing.Size(470, 408);
-		            this.Controls.Add(this.MainStatusBar);
-		            this.Controls.Add(this.MainformMenu);
-		            this.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-		            this.MainMenuStrip = this.MainformMenu;
-		            this.Name = "MainForm";
-		            this.Activated += new System.EventHandler(this.MainForm_Activated);
-		            this.Deactivate += new System.EventHandler(this.MainForm_Deactivate);
-		            this.Load += new System.EventHandler(this.MainForm_Load);
-		            this.Shown += new System.EventHandler(this.MainForm_Shown);
-		            this.Enter += new System.EventHandler(this.MainForm_Enter);
-		            this.Resize += new System.EventHandler(this.MainForm_Resize);
-		            this.MainformMenu.ResumeLayout(false);
-		            this.MainformMenu.PerformLayout();
-		            this.MainStatusBar.ResumeLayout(false);
-		            this.MainStatusBar.PerformLayout();
-		            this.MainFormContextMenu.ResumeLayout(false);
-		            this.ResumeLayout(false);
-		            this.PerformLayout();
+			this.components = new System.ComponentModel.Container();
+			this.MainformMenu = new BizHawk.WinForms.Controls.MenuStripEx();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OpenRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecentRomSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.OpenAdvancedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CloseRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SaveStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SaveNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator24 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.AutosaveLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.LoadNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator21 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.AutoloadLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveSlotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PreviousSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NextSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SaveToCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveRAMSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FlushSaveRAMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.MovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ReadonlyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator15 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.RecentMovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator16 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.RecordMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PlayMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PlayFromBeginningMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ImportMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMovieAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopMovieWithoutSavingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator14 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.AutomaticallyBackupMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FullMovieLoadstatesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieEndSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieEndFinishMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieEndRecordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieEndStopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieEndPauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AVSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ConfigAndRecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopAVIMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator19 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.CaptureOSDMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CaptureLuaMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.SynclessRecordingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotClientClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator20 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.ScreenshotCaptureOSDMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EmulationSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RebootCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SoftResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HardResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EmulatorMenuSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.LoadedCoreNameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ViewSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.WindowSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.mzMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SwitchToFullscreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.DisplayFPSMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayFrameCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayLagCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayRerecordCountMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplaySubtitlesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.DisplayStatusBarMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayMessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.DisplayLogWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ControllersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HotkeysMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SoundMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PathsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FirmwaresMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AutofireMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RewindOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.extensionsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClientOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ProfilesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator9 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SpeedSkipSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClockThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AudioThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VsyncThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator27 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.VsyncEnabledMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.miUnthrottled = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MinimizeSkippingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NeverSkipMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem17 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.Speed50MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Speed75MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Speed100MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Speed150MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Speed200MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Speed400MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.KeyPrioritySubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BothHkAndControllerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.InputOverHkMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HkOverInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CoresSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator10 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SaveConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveConfigAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadConfigFromMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ToolsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ToolBoxMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator12 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.RamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RamSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LuaConsoleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.TAStudioMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HexEditorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.TraceLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CodeDataLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MacroToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VirtualPadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BasicBotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator11 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.CheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GameSharkConverterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator29 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.MultiDiskBundlerFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BatchRunnerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ExternalToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.dummyExternalTool = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StartRetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NESPPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NESNametableViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MusicRipperMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator17 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.NesControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NESGraphicSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NESSoundChannelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VSSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator22 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.FDSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FdsEjectDiskMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VSInsertCoinP1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VSInsertCoinP2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VSServiceSwitchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BarcodeReaderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.TI83SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.KeypadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadTIFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator13 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.paletteToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.A7800SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.A7800ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.A7800FilterSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GBSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GBcoreSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SameBoyColorChooserMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator28 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.GBGPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GBPrinterViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PSXSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PSXControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PSXOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PSXDiscControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PSXHashDiscsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SNESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SNESControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator18 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SnesGfxDebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SnesOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ColecoSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ColecoControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator35 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.ColecoSkipBiosMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ColecoUseSGMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.N64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.N64PluginSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.N64ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator23 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.N64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MupenStyleLagMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.N64ExpansionSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Ares64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Ares64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Ares64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GBLSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GBLsettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AppleSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AppleDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator31 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.settingsToolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.C64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.C64DisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator36 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.C64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.IntvSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.IntVControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.zXSpectrumToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumCoreEmulationSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumAudioSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumNonSyncSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumMediaMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.zxt1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.zxt2ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumExportSnapshotMenuItemMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GenericCoreSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.amstradCPCToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.amstradCPCCoreEmulationSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCAudioSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCNonSyncSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCMediaToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.cpct1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.cpcd1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HelpSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OnlineHelpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ForumsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FeaturesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AboutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.A7800HawkCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MainStatusBar = new BizHawk.WinForms.Controls.StatusStripEx();
+			this.DumpStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
+			this.EmuStatus = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.PlayRecordStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
+			this.PauseStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
+			this.RebootStatusBarIcon = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.AVIStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.LedLightStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.SaveSlotsStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot1StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot2StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot3StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot4StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot5StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot6StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot7StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot8StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot9StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot0StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.CheatStatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.KeyPriorityStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.CoreNameStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.ProfileFirstBootLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.LinkConnectStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.UpdateNotification = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.MainFormContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+			this.OpenRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadLastRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopAVContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ContextSeparator_AfterROM = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.RecordMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PlayMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RestartMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadLastMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BackupMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopNoSaveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ViewSubtitlesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AddSubtitleContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ViewCommentsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMovieAsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ContextSeparator_AfterMovie = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.UndoSavestateContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ContextSeparator_AfterUndo = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.ConfigContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem6 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem7 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem8 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem9 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem10 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem11 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem12 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem13 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem14 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem15 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.customizeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator30 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.toolStripMenuItem66 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem67 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CloseRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClearSRAMContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ShowMenuContextMenuSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.ShowMenuContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
+			this.MainformMenu.SuspendLayout();
+			this.MainStatusBar.SuspendLayout();
+			this.MainFormContextMenu.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// MainformMenu
+			// 
+			this.MainformMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
+			this.MainformMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.FileSubMenu,
+			this.EmulationSubMenu,
+			this.ViewSubMenu,
+			this.ConfigSubMenu,
+			this.ToolsSubMenu,
+			this.NESSubMenu,
+			this.TI83SubMenu,
+			this.A7800SubMenu,
+			this.GBSubMenu,
+			this.PSXSubMenu,
+			this.SNESSubMenu,
+			this.ColecoSubMenu,
+			this.N64SubMenu,
+			this.Ares64SubMenu,
+			this.GBLSubMenu,
+			this.AppleSubMenu,
+			this.C64SubMenu,
+			this.IntvSubMenu,
+			this.zXSpectrumToolStripMenuItem,
+			this.GenericCoreSubMenu,
+			this.amstradCPCToolStripMenuItem,
+			this.HelpSubMenu});
+			this.MainformMenu.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
+			this.MainformMenu.TabIndex = 0;
+			this.MainformMenu.MenuActivate += new System.EventHandler(this.MainformMenu_MenuActivate);
+			this.MainformMenu.MenuDeactivate += new System.EventHandler(this.MainformMenu_MenuDeactivate);
+			// 
+			// FileSubMenu
+			// 
+			this.FileSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.OpenRomMenuItem,
+			this.RecentRomSubMenu,
+			this.OpenAdvancedMenuItem,
+			this.CloseRomMenuItem,
+			this.toolStripMenuItem1,
+			this.SaveStateSubMenu,
+			this.LoadStateSubMenu,
+			this.SaveSlotSubMenu,
+			this.SaveRAMSubMenu,
+			this.toolStripMenuItem2,
+			this.MovieSubMenu,
+			this.AVSubMenu,
+			this.ScreenshotSubMenu,
+			this.toolStripSeparator4,
+			this.ExitMenuItem});
+			this.FileSubMenu.Text = "&File";
+			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
+			// 
+			// OpenRomMenuItem
+			// 
+			this.OpenRomMenuItem.Text = "&Open ROM...";
+			this.OpenRomMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
+			// 
+			// RecentRomSubMenu
+			// 
+			this.RecentRomSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolStripSeparator3});
+			this.RecentRomSubMenu.Text = "&Recent ROM";
+			this.RecentRomSubMenu.DropDownOpened += new System.EventHandler(this.RecentRomMenuItem_DropDownOpened);
+			// 
+			// OpenAdvancedMenuItem
+			// 
+			this.OpenAdvancedMenuItem.Text = "Open Ad&vanced...";
+			this.OpenAdvancedMenuItem.Click += new System.EventHandler(this.OpenAdvancedMenuItem_Click);
+			// 
+			// CloseRomMenuItem
+			// 
+			this.CloseRomMenuItem.Text = "&Close ROM";
+			this.CloseRomMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
+			// 
+			// SaveStateSubMenu
+			// 
+			this.SaveStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.SaveState1MenuItem,
+			this.SaveState2MenuItem,
+			this.SaveState3MenuItem,
+			this.SaveState4MenuItem,
+			this.SaveState5MenuItem,
+			this.SaveState6MenuItem,
+			this.SaveState7MenuItem,
+			this.SaveState8MenuItem,
+			this.SaveState9MenuItem,
+			this.SaveState0MenuItem,
+			this.toolStripSeparator6,
+			this.SaveNamedStateMenuItem,
+			this.toolStripSeparator24,
+			this.AutosaveLastSlotMenuItem});
+			this.SaveStateSubMenu.Text = "&Save State";
+			this.SaveStateSubMenu.DropDownOpened += new System.EventHandler(this.SaveStateSubMenu_DropDownOpened);
+			// 
+			// SaveState1MenuItem
+			// 
+			this.SaveState1MenuItem.Text = "1";
+			this.SaveState1MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+			// 
+			// SaveState2MenuItem
+			// 
+			this.SaveState2MenuItem.Text = "2";
+			this.SaveState2MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+			// 
+			// SaveState3MenuItem
+			// 
+			this.SaveState3MenuItem.Text = "3";
+			this.SaveState3MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+			// 
+			// SaveState4MenuItem
+			// 
+			this.SaveState4MenuItem.Text = "4";
+			this.SaveState4MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+			// 
+			// SaveState5MenuItem
+			// 
+			this.SaveState5MenuItem.Text = "5";
+			this.SaveState5MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+			// 
+			// SaveState6MenuItem
+			// 
+			this.SaveState6MenuItem.Text = "6";
+			this.SaveState6MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+			// 
+			// SaveState7MenuItem
+			// 
+			this.SaveState7MenuItem.Text = "7";
+			this.SaveState7MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+			// 
+			// SaveState8MenuItem
+			// 
+			this.SaveState8MenuItem.Text = "8";
+			this.SaveState8MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+			// 
+			// SaveState9MenuItem
+			// 
+			this.SaveState9MenuItem.Text = "9";
+			this.SaveState9MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+			// 
+			// SaveState0MenuItem
+			// 
+			this.SaveState0MenuItem.Text = "10";
+			this.SaveState0MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+			// 
+			// SaveNamedStateMenuItem
+			// 
+			this.SaveNamedStateMenuItem.Text = "Save Named State...";
+			this.SaveNamedStateMenuItem.Click += new System.EventHandler(this.SaveNamedStateMenuItem_Click);
+			// 
+			// AutosaveLastSlotMenuItem
+			// 
+			this.AutosaveLastSlotMenuItem.Text = "Autosave Last Slot";
+			this.AutosaveLastSlotMenuItem.Click += new System.EventHandler(this.AutosaveLastSlotMenuItem_Click);
+			// 
+			// LoadStateSubMenu
+			// 
+			this.LoadStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.LoadState1MenuItem,
+			this.LoadState2MenuItem,
+			this.LoadState3MenuItem,
+			this.LoadState4MenuItem,
+			this.LoadState5MenuItem,
+			this.LoadState6MenuItem,
+			this.LoadState7MenuItem,
+			this.LoadState8MenuItem,
+			this.LoadState9MenuItem,
+			this.LoadState0MenuItem,
+			this.toolStripSeparator7,
+			this.LoadNamedStateMenuItem,
+			this.toolStripSeparator21,
+			this.AutoloadLastSlotMenuItem});
+			this.LoadStateSubMenu.Text = "&Load State";
+			this.LoadStateSubMenu.DropDownOpened += new System.EventHandler(this.LoadStateSubMenu_DropDownOpened);
+			// 
+			// LoadState1MenuItem
+			// 
+			this.LoadState1MenuItem.Text = "1";
+			this.LoadState1MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+			// 
+			// LoadState2MenuItem
+			// 
+			this.LoadState2MenuItem.Text = "2";
+			this.LoadState2MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+			// 
+			// LoadState3MenuItem
+			// 
+			this.LoadState3MenuItem.Text = "3";
+			this.LoadState3MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+			// 
+			// LoadState4MenuItem
+			// 
+			this.LoadState4MenuItem.Text = "4";
+			this.LoadState4MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+			// 
+			// LoadState5MenuItem
+			// 
+			this.LoadState5MenuItem.Text = "5";
+			this.LoadState5MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+			// 
+			// LoadState6MenuItem
+			// 
+			this.LoadState6MenuItem.Text = "6";
+			this.LoadState6MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+			// 
+			// LoadState7MenuItem
+			// 
+			this.LoadState7MenuItem.Text = "7";
+			this.LoadState7MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+			// 
+			// LoadState8MenuItem
+			// 
+			this.LoadState8MenuItem.Text = "8";
+			this.LoadState8MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+			// 
+			// LoadState9MenuItem
+			// 
+			this.LoadState9MenuItem.Text = "9";
+			this.LoadState9MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+			// 
+			// LoadState0MenuItem
+			// 
+			this.LoadState0MenuItem.Text = "10";
+			this.LoadState0MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+			// 
+			// LoadNamedStateMenuItem
+			// 
+			this.LoadNamedStateMenuItem.Text = "Load Named State...";
+			this.LoadNamedStateMenuItem.Click += new System.EventHandler(this.LoadNamedStateMenuItem_Click);
+			// 
+			// AutoloadLastSlotMenuItem
+			// 
+			this.AutoloadLastSlotMenuItem.Text = "Autoload Last Slot";
+			this.AutoloadLastSlotMenuItem.Click += new System.EventHandler(this.AutoloadLastSlotMenuItem_Click);
+			// 
+			// SaveSlotSubMenu
+			// 
+			this.SaveSlotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.SelectSlot1MenuItem,
+			this.SelectSlot2MenuItem,
+			this.SelectSlot3MenuItem,
+			this.SelectSlot4MenuItem,
+			this.SelectSlot5MenuItem,
+			this.SelectSlot6MenuItem,
+			this.SelectSlot7MenuItem,
+			this.SelectSlot8MenuItem,
+			this.SelectSlot9MenuItem,
+			this.SelectSlot0MenuItem,
+			this.PreviousSlotMenuItem,
+			this.NextSlotMenuItem,
+			this.toolStripSeparator5,
+			this.SaveToCurrentSlotMenuItem,
+			this.LoadCurrentSlotMenuItem});
+			this.SaveSlotSubMenu.Text = "Save S&lot";
+			this.SaveSlotSubMenu.DropDownOpened += new System.EventHandler(this.SaveSlotSubMenu_DropDownOpened);
+			// 
+			// SelectSlot1MenuItem
+			// 
+			this.SelectSlot1MenuItem.Text = "Select Slot 1";
+			this.SelectSlot1MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
+			// SelectSlot2MenuItem
+			// 
+			this.SelectSlot2MenuItem.Text = "Select Slot 2";
+			this.SelectSlot2MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
+			// SelectSlot3MenuItem
+			// 
+			this.SelectSlot3MenuItem.Text = "Select Slot 3";
+			this.SelectSlot3MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
+			// SelectSlot4MenuItem
+			// 
+			this.SelectSlot4MenuItem.Text = "Select Slot 4";
+			this.SelectSlot4MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
+			// SelectSlot5MenuItem
+			// 
+			this.SelectSlot5MenuItem.Text = "Select Slot 5";
+			this.SelectSlot5MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
+			// SelectSlot6MenuItem
+			// 
+			this.SelectSlot6MenuItem.Text = "Select Slot 6";
+			this.SelectSlot6MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
+			// SelectSlot7MenuItem
+			// 
+			this.SelectSlot7MenuItem.Text = "Select Slot 7";
+			this.SelectSlot7MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
+			// SelectSlot8MenuItem
+			// 
+			this.SelectSlot8MenuItem.Text = "Select Slot 8";
+			this.SelectSlot8MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
+			// SelectSlot9MenuItem
+			// 
+			this.SelectSlot9MenuItem.Text = "Select Slot 9";
+			this.SelectSlot9MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
+			// SelectSlot0MenuItem
+			// 
+			this.SelectSlot0MenuItem.Text = "Select Slot 10";
+			this.SelectSlot0MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+			// 
+			// PreviousSlotMenuItem
+			// 
+			this.PreviousSlotMenuItem.Text = "Previous Slot";
+			this.PreviousSlotMenuItem.Click += new System.EventHandler(this.PreviousSlotMenuItem_Click);
+			// 
+			// NextSlotMenuItem
+			// 
+			this.NextSlotMenuItem.Text = "Next Slot";
+			this.NextSlotMenuItem.Click += new System.EventHandler(this.NextSlotMenuItem_Click);
+			// 
+			// SaveToCurrentSlotMenuItem
+			// 
+			this.SaveToCurrentSlotMenuItem.Text = "Save to Current Slot";
+			this.SaveToCurrentSlotMenuItem.Click += new System.EventHandler(this.SaveToCurrentSlotMenuItem_Click);
+			// 
+			// LoadCurrentSlotMenuItem
+			// 
+			this.LoadCurrentSlotMenuItem.Text = "Load Current Slot";
+			this.LoadCurrentSlotMenuItem.Click += new System.EventHandler(this.LoadCurrentSlotMenuItem_Click);
+			// 
+			// SaveRAMSubMenu
+			// 
+			this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.FlushSaveRAMMenuItem});
+			this.SaveRAMSubMenu.Text = "Save &RAM";
+			this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
+			// 
+			// FlushSaveRAMMenuItem
+			// 
+			this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
+			this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
+			// 
+			// MovieSubMenu
+			// 
+			this.MovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.ReadonlyMenuItem,
+			this.toolStripSeparator15,
+			this.RecentMovieSubMenu,
+			this.RecordMovieMenuItem,
+			this.PlayMovieMenuItem,
+			this.StopMovieMenuItem,
+			this.PlayFromBeginningMenuItem,
+			this.ImportMoviesMenuItem,
+			this.SaveMovieMenuItem,
+			this.SaveMovieAsMenuItem,
+			this.StopMovieWithoutSavingMenuItem,
+			this.toolStripSeparator14,
+			this.AutomaticallyBackupMoviesMenuItem,
+			this.FullMovieLoadstatesMenuItem,
+			this.MovieEndSubMenu});
+			this.MovieSubMenu.Text = "&Movie";
+			this.MovieSubMenu.DropDownOpened += new System.EventHandler(this.MovieSubMenu_DropDownOpened);
+			// 
+			// ReadonlyMenuItem
+			// 
+			this.ReadonlyMenuItem.Text = "Read-only";
+			this.ReadonlyMenuItem.Click += new System.EventHandler(this.ReadonlyMenuItem_Click);
+			// 
+			// RecentMovieSubMenu
+			// 
+			this.RecentMovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolStripSeparator16});
+			this.RecentMovieSubMenu.Text = "Recent";
+			this.RecentMovieSubMenu.DropDownOpened += new System.EventHandler(this.RecentMovieSubMenu_DropDownOpened);
+			// 
+			// RecordMovieMenuItem
+			// 
+			this.RecordMovieMenuItem.Text = "&Record Movie...";
+			this.RecordMovieMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
+			// 
+			// PlayMovieMenuItem
+			// 
+			this.PlayMovieMenuItem.Text = "&Play Movie...";
+			this.PlayMovieMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
+			// 
+			// StopMovieMenuItem
+			// 
+			this.StopMovieMenuItem.Text = "Stop Movie";
+			this.StopMovieMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
+			// 
+			// PlayFromBeginningMenuItem
+			// 
+			this.PlayFromBeginningMenuItem.Text = "Play from Beginning";
+			this.PlayFromBeginningMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
+			// 
+			// ImportMoviesMenuItem
+			// 
+			this.ImportMoviesMenuItem.Text = "Import Movies...";
+			this.ImportMoviesMenuItem.Click += new System.EventHandler(this.ImportMovieMenuItem_Click);
+			// 
+			// SaveMovieMenuItem
+			// 
+			this.SaveMovieMenuItem.Text = "&Save Movie";
+			this.SaveMovieMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
+			// 
+			// SaveMovieAsMenuItem
+			// 
+			this.SaveMovieAsMenuItem.Text = "Save Movie As...";
+			this.SaveMovieAsMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
+			// 
+			// StopMovieWithoutSavingMenuItem
+			// 
+			this.StopMovieWithoutSavingMenuItem.Text = "Stop Movie without Saving";
+			this.StopMovieWithoutSavingMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
+			// 
+			// AutomaticallyBackupMoviesMenuItem
+			// 
+			this.AutomaticallyBackupMoviesMenuItem.Text = "Automatically Backup Movies";
+			this.AutomaticallyBackupMoviesMenuItem.Click += new System.EventHandler(this.AutomaticMovieBackupMenuItem_Click);
+			// 
+			// FullMovieLoadstatesMenuItem
+			// 
+			this.FullMovieLoadstatesMenuItem.Text = "Full Movie Loadstates";
+			this.FullMovieLoadstatesMenuItem.Click += new System.EventHandler(this.FullMovieLoadstatesMenuItem_Click);
+			// 
+			// MovieEndSubMenu
+			// 
+			this.MovieEndSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.MovieEndFinishMenuItem,
+			this.MovieEndRecordMenuItem,
+			this.MovieEndStopMenuItem,
+			this.MovieEndPauseMenuItem});
+			this.MovieEndSubMenu.Text = "On Movie End";
+			this.MovieEndSubMenu.DropDownOpened += new System.EventHandler(this.MovieEndSubMenu_DropDownOpened);
+			// 
+			// MovieEndFinishMenuItem
+			// 
+			this.MovieEndFinishMenuItem.Text = "Switch to Finished";
+			this.MovieEndFinishMenuItem.Click += new System.EventHandler(this.MovieEndFinishMenuItem_Click);
+			// 
+			// MovieEndRecordMenuItem
+			// 
+			this.MovieEndRecordMenuItem.Text = "Switch To Record";
+			this.MovieEndRecordMenuItem.Click += new System.EventHandler(this.MovieEndRecordMenuItem_Click);
+			// 
+			// MovieEndStopMenuItem
+			// 
+			this.MovieEndStopMenuItem.Text = "Stop";
+			this.MovieEndStopMenuItem.Click += new System.EventHandler(this.MovieEndStopMenuItem_Click);
+			// 
+			// MovieEndPauseMenuItem
+			// 
+			this.MovieEndPauseMenuItem.Text = "Pause";
+			this.MovieEndPauseMenuItem.Click += new System.EventHandler(this.MovieEndPauseMenuItem_Click);
+			// 
+			// AVSubMenu
+			// 
+			this.AVSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.RecordAVMenuItem,
+			this.ConfigAndRecordAVMenuItem,
+			this.StopAVIMenuItem,
+			this.toolStripSeparator19,
+			this.CaptureOSDMenuItem,
+			this.CaptureLuaMenuItem,
+			this.SynclessRecordingMenuItem});
+			this.AVSubMenu.Text = "&AVI/WAV";
+			this.AVSubMenu.DropDownOpened += new System.EventHandler(this.AVSubMenu_DropDownOpened);
+			// 
+			// RecordAVMenuItem
+			// 
+			this.RecordAVMenuItem.Text = "&Record AVI/WAV";
+			this.RecordAVMenuItem.Click += new System.EventHandler(this.RecordAVMenuItem_Click);
+			// 
+			// ConfigAndRecordAVMenuItem
+			// 
+			this.ConfigAndRecordAVMenuItem.Text = "Config and Record AVI/WAV...";
+			this.ConfigAndRecordAVMenuItem.Click += new System.EventHandler(this.ConfigAndRecordAVMenuItem_Click);
+			// 
+			// StopAVIMenuItem
+			// 
+			this.StopAVIMenuItem.Text = "&Stop AVI/WAV";
+			this.StopAVIMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
+			// 
+			// CaptureOSDMenuItem
+			// 
+			this.CaptureOSDMenuItem.CheckOnClick = true;
+			this.CaptureOSDMenuItem.Text = "Capture OSD";
+			this.CaptureOSDMenuItem.Click += new System.EventHandler(this.CaptureOSDMenuItem_Click);
+			// 
+			// CaptureLuaMenuItem
+			// 
+			this.CaptureLuaMenuItem.CheckOnClick = true;
+			this.CaptureLuaMenuItem.Name = "CaptureLuaMenuItem";
+			this.CaptureLuaMenuItem.Size = new System.Drawing.Size(288, 26);
+			this.CaptureLuaMenuItem.Text = "Capture Lua";
+			this.CaptureLuaMenuItem.Click += new System.EventHandler(this.CaptureLuaMenuItem_Click);
+			// 
+			// SynclessRecordingMenuItem
+			// 
+			this.SynclessRecordingMenuItem.Text = "S&yncless Recording Tools";
+			// 
+			// ScreenshotSubMenu
+			// 
+			this.ScreenshotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.ScreenshotMenuItem,
+			this.ScreenshotAsMenuItem,
+			this.ScreenshotClipboardMenuItem,
+			this.ScreenshotClientClipboardMenuItem,
+			this.toolStripSeparator20,
+			this.ScreenshotCaptureOSDMenuItem1});
+			this.ScreenshotSubMenu.Text = "Scree&nshot";
+			this.ScreenshotSubMenu.DropDownOpening += new System.EventHandler(this.ScreenshotSubMenu_DropDownOpening);
+			// 
+			// ScreenshotMenuItem
+			// 
+			this.ScreenshotMenuItem.Text = "Screenshot";
+			this.ScreenshotMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
+			// 
+			// ScreenshotAsMenuItem
+			// 
+			this.ScreenshotAsMenuItem.Text = "Screenshot As...";
+			this.ScreenshotAsMenuItem.Click += new System.EventHandler(this.ScreenshotAsMenuItem_Click);
+			// 
+			// ScreenshotClipboardMenuItem
+			// 
+			this.ScreenshotClipboardMenuItem.Text = "Screenshot (raw) -> Clipboard";
+			this.ScreenshotClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClipboardMenuItem_Click);
+			// 
+			// ScreenshotClientClipboardMenuItem
+			// 
+			this.ScreenshotClientClipboardMenuItem.Text = "Screenshot (client) -> Clipboard";
+			this.ScreenshotClientClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClientClipboardMenuItem_Click);
+			// 
+			// ScreenshotCaptureOSDMenuItem1
+			// 
+			this.ScreenshotCaptureOSDMenuItem1.Text = "Capture OSD";
+			this.ScreenshotCaptureOSDMenuItem1.Click += new System.EventHandler(this.ScreenshotCaptureOSDMenuItem_Click);
+			// 
+			// ExitMenuItem
+			// 
+			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
+			this.ExitMenuItem.Text = "E&xit";
+			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
+			// 
+			// EmulationSubMenu
+			// 
+			this.EmulationSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.PauseMenuItem,
+			this.RebootCoreMenuItem,
+			this.toolStripSeparator1,
+			this.SoftResetMenuItem,
+			this.HardResetMenuItem,
+			this.EmulatorMenuSeparator2,
+			this.LoadedCoreNameMenuItem});
+			this.EmulationSubMenu.Text = "&Emulation";
+			this.EmulationSubMenu.DropDownOpened += new System.EventHandler(this.EmulationMenuItem_DropDownOpened);
+			// 
+			// PauseMenuItem
+			// 
+			this.PauseMenuItem.Text = "&Pause";
+			this.PauseMenuItem.Click += new System.EventHandler(this.PauseMenuItem_Click);
+			// 
+			// RebootCoreMenuItem
+			// 
+			this.RebootCoreMenuItem.Text = "&Reboot Core";
+			this.RebootCoreMenuItem.Click += new System.EventHandler(this.PowerMenuItem_Click);
+			// 
+			// SoftResetMenuItem
+			// 
+			this.SoftResetMenuItem.Text = "&Soft Reset";
+			this.SoftResetMenuItem.Click += new System.EventHandler(this.SoftResetMenuItem_Click);
+			// 
+			// HardResetMenuItem
+			// 
+			this.HardResetMenuItem.Text = "&Hard Reset";
+			this.HardResetMenuItem.Click += new System.EventHandler(this.HardResetMenuItem_Click);
+			// 
+			// LoadedCoreNameMenuItem
+			// 
+			this.LoadedCoreNameMenuItem.Enabled = false;
+			this.LoadedCoreNameMenuItem.Text = "Loaded core: <core name> (sysID)";
+			// 
+			// ViewSubMenu
+			// 
+			this.ViewSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.WindowSizeSubMenu,
+			this.SwitchToFullscreenMenuItem,
+			this.toolStripSeparator2,
+			this.DisplayFPSMenuItem,
+			this.DisplayFrameCounterMenuItem,
+			this.DisplayLagCounterMenuItem,
+			this.DisplayInputMenuItem,
+			this.DisplayRerecordCountMenuItem,
+			this.DisplaySubtitlesMenuItem,
+			this.toolStripMenuItem4,
+			this.DisplayStatusBarMenuItem,
+			this.DisplayMessagesMenuItem,
+			this.toolStripSeparator8,
+			this.DisplayLogWindowMenuItem});
+			this.ViewSubMenu.Text = "&View";
+			this.ViewSubMenu.DropDownOpened += new System.EventHandler(this.ViewSubMenu_DropDownOpened);
+			// 
+			// WindowSizeSubMenu
+			// 
+			this.WindowSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.x1MenuItem,
+			this.x2MenuItem,
+			this.x3MenuItem,
+			this.x4MenuItem,
+			this.x5MenuItem,
+			this.x6MenuItem,
+			this.x7MenuItem,
+			this.x8MenuItem,
+			this.x9MenuItem,
+			this.mzMenuItem});
+			this.WindowSizeSubMenu.Text = "&Window Size";
+			this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
+			// 
+			// x1MenuItem
+			// 
+			this.x1MenuItem.Text = "&1x";
+			this.x1MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+			// 
+			// x2MenuItem
+			// 
+			this.x2MenuItem.Text = "&2x";
+			this.x2MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+			// 
+			// x3MenuItem
+			// 
+			this.x3MenuItem.Text = "&3x";
+			this.x3MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+			// 
+			// x4MenuItem
+			// 
+			this.x4MenuItem.Text = "&4x";
+			this.x4MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+			// 
+			// x5MenuItem
+			// 
+			this.x5MenuItem.Text = "&5x";
+			this.x5MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+			// 
+			// x6MenuItem
+			// 
+			this.x6MenuItem.Text = "&6x";
+			this.x6MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+			// 
+			// x7MenuItem
+			// 
+			this.x7MenuItem.Text = "&7x";
+			this.x7MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+			// 
+			// x8MenuItem
+			// 
+			this.x8MenuItem.Text = "&8x";
+			this.x8MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+			// 
+			// x9MenuItem
+			// 
+			this.x9MenuItem.Text = "&9x";
+			this.x9MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+			// 
+			// mzMenuItem
+			// 
+			this.mzMenuItem.Text = "1&0x";
+			this.mzMenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+			// 
+			// SwitchToFullscreenMenuItem
+			// 
+			this.SwitchToFullscreenMenuItem.Text = "Switch to Fullscreen";
+			this.SwitchToFullscreenMenuItem.Click += new System.EventHandler(this.SwitchToFullscreenMenuItem_Click);
+			// 
+			// DisplayFPSMenuItem
+			// 
+			this.DisplayFPSMenuItem.Text = "Display FPS";
+			this.DisplayFPSMenuItem.Click += new System.EventHandler(this.DisplayFpsMenuItem_Click);
+			// 
+			// DisplayFrameCounterMenuItem
+			// 
+			this.DisplayFrameCounterMenuItem.Text = "Display Frame Count";
+			this.DisplayFrameCounterMenuItem.Click += new System.EventHandler(this.DisplayFrameCounterMenuItem_Click);
+			// 
+			// DisplayLagCounterMenuItem
+			// 
+			this.DisplayLagCounterMenuItem.Text = "Display Lag Frame Count";
+			this.DisplayLagCounterMenuItem.Click += new System.EventHandler(this.DisplayLagCounterMenuItem_Click);
+			// 
+			// DisplayInputMenuItem
+			// 
+			this.DisplayInputMenuItem.Text = "Display Input";
+			this.DisplayInputMenuItem.Click += new System.EventHandler(this.DisplayInputMenuItem_Click);
+			// 
+			// DisplayRerecordCountMenuItem
+			// 
+			this.DisplayRerecordCountMenuItem.Text = "Display Rerecord Count";
+			this.DisplayRerecordCountMenuItem.Click += new System.EventHandler(this.DisplayRerecordsMenuItem_Click);
+			// 
+			// DisplaySubtitlesMenuItem
+			// 
+			this.DisplaySubtitlesMenuItem.Text = "Display Subtitles";
+			this.DisplaySubtitlesMenuItem.Click += new System.EventHandler(this.DisplaySubtitlesMenuItem_Click);
+			// 
+			// DisplayStatusBarMenuItem
+			// 
+			this.DisplayStatusBarMenuItem.Text = "Display Status Bar";
+			this.DisplayStatusBarMenuItem.Click += new System.EventHandler(this.DisplayStatusBarMenuItem_Click);
+			// 
+			// DisplayMessagesMenuItem
+			// 
+			this.DisplayMessagesMenuItem.Text = "Display Messages";
+			this.DisplayMessagesMenuItem.Click += new System.EventHandler(this.DisplayMessagesMenuItem_Click);
+			// 
+			// DisplayLogWindowMenuItem
+			// 
+			this.DisplayLogWindowMenuItem.Text = "Open &Log Window...";
+			this.DisplayLogWindowMenuItem.Click += new System.EventHandler(this.DisplayLogWindowMenuItem_Click);
+			// 
+			// ConfigSubMenu
+			// 
+			this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.ControllersMenuItem,
+			this.HotkeysMenuItem,
+			this.DisplayConfigMenuItem,
+			this.SoundMenuItem,
+			this.PathsMenuItem,
+			this.FirmwaresMenuItem,
+			this.MessagesMenuItem,
+			this.AutofireMenuItem,
+			this.RewindOptionsMenuItem,
+			this.extensionsToolStripMenuItem,
+			this.ClientOptionsMenuItem,
+			this.ProfilesMenuItem,
+			this.toolStripSeparator9,
+			this.SpeedSkipSubMenu,
+			this.KeyPrioritySubMenu,
+			this.CoresSubMenu,
+			this.toolStripSeparator10,
+			this.SaveConfigMenuItem,
+			this.SaveConfigAsMenuItem,
+			this.LoadConfigMenuItem,
+			this.LoadConfigFromMenuItem});
+			this.ConfigSubMenu.Text = "&Config";
+			this.ConfigSubMenu.DropDownOpened += new System.EventHandler(this.ConfigSubMenu_DropDownOpened);
+			// 
+			// ControllersMenuItem
+			// 
+			this.ControllersMenuItem.Text = "&Controllers...";
+			this.ControllersMenuItem.Click += new System.EventHandler(this.ControllersMenuItem_Click);
+			// 
+			// HotkeysMenuItem
+			// 
+			this.HotkeysMenuItem.Text = "&Hotkeys...";
+			this.HotkeysMenuItem.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
+			// 
+			// DisplayConfigMenuItem
+			// 
+			this.DisplayConfigMenuItem.Text = "Display...";
+			this.DisplayConfigMenuItem.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
+			// 
+			// SoundMenuItem
+			// 
+			this.SoundMenuItem.Text = "&Sound...";
+			this.SoundMenuItem.Click += new System.EventHandler(this.SoundMenuItem_Click);
+			// 
+			// PathsMenuItem
+			// 
+			this.PathsMenuItem.Text = "Paths...";
+			this.PathsMenuItem.Click += new System.EventHandler(this.PathsMenuItem_Click);
+			// 
+			// FirmwaresMenuItem
+			// 
+			this.FirmwaresMenuItem.Text = "&Firmwares...";
+			this.FirmwaresMenuItem.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
+			// 
+			// MessagesMenuItem
+			// 
+			this.MessagesMenuItem.Text = "&Messages...";
+			this.MessagesMenuItem.Click += new System.EventHandler(this.MessagesMenuItem_Click);
+			// 
+			// AutofireMenuItem
+			// 
+			this.AutofireMenuItem.Text = "&Autofire...";
+			this.AutofireMenuItem.Click += new System.EventHandler(this.AutofireMenuItem_Click);
+			// 
+			// RewindOptionsMenuItem
+			// 
+			this.RewindOptionsMenuItem.Text = "&Rewind && States...";
+			this.RewindOptionsMenuItem.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
+			// 
+			// extensionsToolStripMenuItem
+			// 
+			this.extensionsToolStripMenuItem.Text = "File Extensions...";
+			this.extensionsToolStripMenuItem.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
+			// 
+			// ClientOptionsMenuItem
+			// 
+			this.ClientOptionsMenuItem.Text = "&Customize...";
+			this.ClientOptionsMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
+			// 
+			// ProfilesMenuItem
+			// 
+			this.ProfilesMenuItem.Text = "&Profiles...";
+			this.ProfilesMenuItem.Click += new System.EventHandler(this.ProfilesMenuItem_Click);
+			// 
+			// SpeedSkipSubMenu
+			// 
+			this.SpeedSkipSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.ClockThrottleMenuItem,
+			this.AudioThrottleMenuItem,
+			this.VsyncThrottleMenuItem,
+			this.toolStripSeparator27,
+			this.VsyncEnabledMenuItem,
+			this.toolStripMenuItem3,
+			this.miUnthrottled,
+			this.MinimizeSkippingMenuItem,
+			this.NeverSkipMenuItem,
+			this.toolStripMenuItem17,
+			this.toolStripMenuItem5,
+			this.Speed50MenuItem,
+			this.Speed75MenuItem,
+			this.Speed100MenuItem,
+			this.Speed150MenuItem,
+			this.Speed200MenuItem,
+			this.Speed400MenuItem});
+			this.SpeedSkipSubMenu.Text = "Speed/Skip";
+			this.SpeedSkipSubMenu.DropDownOpened += new System.EventHandler(this.FrameSkipMenuItem_DropDownOpened);
+			// 
+			// ClockThrottleMenuItem
+			// 
+			this.ClockThrottleMenuItem.Text = "Clock Throttle";
+			this.ClockThrottleMenuItem.Click += new System.EventHandler(this.ClockThrottleMenuItem_Click);
+			// 
+			// AudioThrottleMenuItem
+			// 
+			this.AudioThrottleMenuItem.Text = "Audio Throttle";
+			this.AudioThrottleMenuItem.Click += new System.EventHandler(this.AudioThrottleMenuItem_Click);
+			// 
+			// VsyncThrottleMenuItem
+			// 
+			this.VsyncThrottleMenuItem.Text = "VSync Throttle";
+			this.VsyncThrottleMenuItem.Click += new System.EventHandler(this.VsyncThrottleMenuItem_Click);
+			// 
+			// VsyncEnabledMenuItem
+			// 
+			this.VsyncEnabledMenuItem.Text = "VSync Enabled";
+			this.VsyncEnabledMenuItem.Click += new System.EventHandler(this.VsyncEnabledMenuItem_Click);
+			// 
+			// miUnthrottled
+			// 
+			this.miUnthrottled.Text = "Unthrottled";
+			this.miUnthrottled.Click += new System.EventHandler(this.UnthrottledMenuItem_Click);
+			// 
+			// MinimizeSkippingMenuItem
+			// 
+			this.MinimizeSkippingMenuItem.Text = "Auto-minimize skipping";
+			this.MinimizeSkippingMenuItem.Click += new System.EventHandler(this.MinimizeSkippingMenuItem_Click);
+			// 
+			// NeverSkipMenuItem
+			// 
+			this.NeverSkipMenuItem.Text = "Skip 0 (never)";
+			this.NeverSkipMenuItem.Click += new System.EventHandler(this.NeverSkipMenuItem_Click);
+			// 
+			// toolStripMenuItem17
+			// 
+			this.toolStripMenuItem17.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.Frameskip1MenuItem,
+			this.Frameskip2MenuItem,
+			this.Frameskip3MenuItem,
+			this.Frameskip4MenuItem,
+			this.Frameskip5MenuItem,
+			this.Frameskip6MenuItem,
+			this.Frameskip7MenuItem,
+			this.Frameskip8MenuItem,
+			this.Frameskip9MenuItem});
+			this.toolStripMenuItem17.Text = "Skip 1..9";
+			// 
+			// Frameskip1MenuItem
+			// 
+			this.Frameskip1MenuItem.Text = "1";
+			this.Frameskip1MenuItem.Click += new System.EventHandler(this.Frameskip1MenuItem_Click);
+			// 
+			// Frameskip2MenuItem
+			// 
+			this.Frameskip2MenuItem.Text = "2";
+			this.Frameskip2MenuItem.Click += new System.EventHandler(this.Frameskip2MenuItem_Click);
+			// 
+			// Frameskip3MenuItem
+			// 
+			this.Frameskip3MenuItem.Text = "3";
+			this.Frameskip3MenuItem.Click += new System.EventHandler(this.Frameskip3MenuItem_Click);
+			// 
+			// Frameskip4MenuItem
+			// 
+			this.Frameskip4MenuItem.Text = "4";
+			this.Frameskip4MenuItem.Click += new System.EventHandler(this.Frameskip4MenuItem_Click);
+			// 
+			// Frameskip5MenuItem
+			// 
+			this.Frameskip5MenuItem.Text = "5";
+			this.Frameskip5MenuItem.Click += new System.EventHandler(this.Frameskip5MenuItem_Click);
+			// 
+			// Frameskip6MenuItem
+			// 
+			this.Frameskip6MenuItem.Text = "6";
+			this.Frameskip6MenuItem.Click += new System.EventHandler(this.Frameskip6MenuItem_Click);
+			// 
+			// Frameskip7MenuItem
+			// 
+			this.Frameskip7MenuItem.Text = "7";
+			this.Frameskip7MenuItem.Click += new System.EventHandler(this.Frameskip7MenuItem_Click);
+			// 
+			// Frameskip8MenuItem
+			// 
+			this.Frameskip8MenuItem.Text = "8";
+			this.Frameskip8MenuItem.Click += new System.EventHandler(this.Frameskip8MenuItem_Click);
+			// 
+			// Frameskip9MenuItem
+			// 
+			this.Frameskip9MenuItem.Text = "9";
+			this.Frameskip9MenuItem.Click += new System.EventHandler(this.Frameskip9MenuItem_Click);
+			// 
+			// Speed50MenuItem
+			// 
+			this.Speed50MenuItem.Text = "Speed 50%";
+			this.Speed50MenuItem.Click += new System.EventHandler(this.Speed50MenuItem_Click);
+			// 
+			// Speed75MenuItem
+			// 
+			this.Speed75MenuItem.Text = "Speed 75%";
+			this.Speed75MenuItem.Click += new System.EventHandler(this.Speed75MenuItem_Click);
+			// 
+			// Speed100MenuItem
+			// 
+			this.Speed100MenuItem.Text = "Speed 100%";
+			this.Speed100MenuItem.Click += new System.EventHandler(this.Speed100MenuItem_Click);
+			// 
+			// Speed150MenuItem
+			// 
+			this.Speed150MenuItem.Text = "Speed 150%";
+			this.Speed150MenuItem.Click += new System.EventHandler(this.Speed150MenuItem_Click);
+			// 
+			// Speed200MenuItem
+			// 
+			this.Speed200MenuItem.Text = "Speed 200%";
+			this.Speed200MenuItem.Click += new System.EventHandler(this.Speed200MenuItem_Click);
+			// 
+			// Speed400MenuItem
+			// 
+			this.Speed400MenuItem.Text = "Speed 400%";
+			this.Speed400MenuItem.Click += new System.EventHandler(this.Speed400MenuItem_Click);
+			// 
+			// KeyPrioritySubMenu
+			// 
+			this.KeyPrioritySubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.BothHkAndControllerMenuItem,
+			this.InputOverHkMenuItem,
+			this.HkOverInputMenuItem});
+			this.KeyPrioritySubMenu.Text = "Key Priority";
+			this.KeyPrioritySubMenu.DropDownOpened += new System.EventHandler(this.KeyPriorityMenuItem_DropDownOpened);
+			// 
+			// BothHkAndControllerMenuItem
+			// 
+			this.BothHkAndControllerMenuItem.Text = "Both Hotkeys and Controllers";
+			this.BothHkAndControllerMenuItem.Click += new System.EventHandler(this.BothHkAndControllerMenuItem_Click);
+			// 
+			// InputOverHkMenuItem
+			// 
+			this.InputOverHkMenuItem.Text = "Input overrides Hotkeys";
+			this.InputOverHkMenuItem.Click += new System.EventHandler(this.InputOverHkMenuItem_Click);
+			// 
+			// HkOverInputMenuItem
+			// 
+			this.HkOverInputMenuItem.Text = "Hotkeys override Input";
+			this.HkOverInputMenuItem.Click += new System.EventHandler(this.HkOverInputMenuItem_Click);
+			// 
+			// CoresSubMenu
+			// 
+			this.CoresSubMenu.Text = "Preferred Cores";
+			// 
+			// SaveConfigMenuItem
+			// 
+			this.SaveConfigMenuItem.Text = "Save Config";
+			this.SaveConfigMenuItem.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
+			// 
+			// SaveConfigAsMenuItem
+			// 
+			this.SaveConfigAsMenuItem.Text = "Save Config As...";
+			this.SaveConfigAsMenuItem.Click += new System.EventHandler(this.SaveConfigAsMenuItem_Click);
+			// 
+			// LoadConfigMenuItem
+			// 
+			this.LoadConfigMenuItem.Text = "Load Config";
+			this.LoadConfigMenuItem.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
+			// 
+			// LoadConfigFromMenuItem
+			// 
+			this.LoadConfigFromMenuItem.Text = "Load Config From...";
+			this.LoadConfigFromMenuItem.Click += new System.EventHandler(this.LoadConfigFromMenuItem_Click);
+			// 
+			// ToolsSubMenu
+			// 
+			this.ToolsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.ToolBoxMenuItem,
+			this.toolStripSeparator12,
+			this.RamWatchMenuItem,
+			this.RamSearchMenuItem,
+			this.LuaConsoleMenuItem,
+			this.TAStudioMenuItem,
+			this.HexEditorMenuItem,
+			this.TraceLoggerMenuItem,
+			this.DebuggerMenuItem,
+			this.CodeDataLoggerMenuItem,
+			this.MacroToolMenuItem,
+			this.VirtualPadMenuItem,
+			this.BasicBotMenuItem,
+			this.toolStripSeparator11,
+			this.CheatsMenuItem,
+			this.GameSharkConverterMenuItem,
+			this.toolStripSeparator29,
+			this.MultiDiskBundlerFileMenuItem,
+			this.BatchRunnerMenuItem,
+			this.ExternalToolMenuItem,
+			this.RetroAchievementsMenuItem});
+			this.ToolsSubMenu.Text = "&Tools";
+			this.ToolsSubMenu.DropDownOpened += new System.EventHandler(this.ToolsSubMenu_DropDownOpened);
+			// 
+			// ToolBoxMenuItem
+			// 
+			this.ToolBoxMenuItem.Text = "&Tool Box";
+			this.ToolBoxMenuItem.Click += new System.EventHandler(this.ToolBoxMenuItem_Click);
+			// 
+			// RamWatchMenuItem
+			// 
+			this.RamWatchMenuItem.Text = "RAM &Watch";
+			this.RamWatchMenuItem.Click += new System.EventHandler(this.RamWatchMenuItem_Click);
+			// 
+			// RamSearchMenuItem
+			// 
+			this.RamSearchMenuItem.Text = "RAM &Search";
+			this.RamSearchMenuItem.Click += new System.EventHandler(this.RamSearchMenuItem_Click);
+			// 
+			// LuaConsoleMenuItem
+			// 
+			this.LuaConsoleMenuItem.Text = "Lua Console";
+			this.LuaConsoleMenuItem.Click += new System.EventHandler(this.LuaConsoleMenuItem_Click);
+			// 
+			// TAStudioMenuItem
+			// 
+			this.TAStudioMenuItem.Text = "&TAStudio";
+			this.TAStudioMenuItem.Click += new System.EventHandler(this.TAStudioMenuItem_Click);
+			// 
+			// HexEditorMenuItem
+			// 
+			this.HexEditorMenuItem.Text = "&Hex Editor";
+			this.HexEditorMenuItem.Click += new System.EventHandler(this.HexEditorMenuItem_Click);
+			// 
+			// TraceLoggerMenuItem
+			// 
+			this.TraceLoggerMenuItem.Text = "Trace &Logger";
+			this.TraceLoggerMenuItem.Click += new System.EventHandler(this.TraceLoggerMenuItem_Click);
+			// 
+			// DebuggerMenuItem
+			// 
+			this.DebuggerMenuItem.Text = "&Debugger";
+			this.DebuggerMenuItem.Click += new System.EventHandler(this.DebuggerMenuItem_Click);
+			// 
+			// CodeDataLoggerMenuItem
+			// 
+			this.CodeDataLoggerMenuItem.Text = "Code-Data Logger";
+			this.CodeDataLoggerMenuItem.Click += new System.EventHandler(this.CodeDataLoggerMenuItem_Click);
+			// 
+			// MacroToolMenuItem
+			// 
+			this.MacroToolMenuItem.Text = "&Macro Tool";
+			this.MacroToolMenuItem.Click += new System.EventHandler(this.MacroToolMenuItem_Click);
+			// 
+			// VirtualPadMenuItem
+			// 
+			this.VirtualPadMenuItem.Text = "Virtual Pad";
+			this.VirtualPadMenuItem.Click += new System.EventHandler(this.VirtualPadMenuItem_Click);
+			// 
+			// BasicBotMenuItem
+			// 
+			this.BasicBotMenuItem.Text = "Basic Bot";
+			this.BasicBotMenuItem.Click += new System.EventHandler(this.BasicBotMenuItem_Click);
+			// 
+			// CheatsMenuItem
+			// 
+			this.CheatsMenuItem.Text = "Cheats";
+			this.CheatsMenuItem.Click += new System.EventHandler(this.CheatsMenuItem_Click);
+			// 
+			// GameSharkConverterMenuItem
+			// 
+			this.GameSharkConverterMenuItem.Text = "Cheat Code Converter";
+			this.GameSharkConverterMenuItem.Click += new System.EventHandler(this.CheatCodeConverterMenuItem_Click);
+			// 
+			// MultiDiskBundlerFileMenuItem
+			// 
+			this.MultiDiskBundlerFileMenuItem.Text = "Multi-disk Bundler";
+			this.MultiDiskBundlerFileMenuItem.Click += new System.EventHandler(this.MultidiskBundlerMenuItem_Click);
+			// 
+			// BatchRunnerMenuItem
+			// 
+			this.BatchRunnerMenuItem.Text = "Batch Runner...";
+			this.BatchRunnerMenuItem.Visible = false;
+			this.BatchRunnerMenuItem.Click += new System.EventHandler(this.BatchRunnerMenuItem_Click);
+			// 
+			// ExternalToolMenuItem
+			// 
+			this.ExternalToolMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.dummyExternalTool});
+			this.ExternalToolMenuItem.Text = "External Tool";
+			this.ExternalToolMenuItem.DropDownOpening += new System.EventHandler(this.ExternalToolMenuItem_DropDownOpening);
+			// 
+			// dummyExternalTool
+			// 
+			this.dummyExternalTool.Text = "None";
+			// 
+			// RetroAchievementsMenuItem
+			// 
+			this.RetroAchievementsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.StartRetroAchievementsMenuItem});
+			this.RetroAchievementsMenuItem.Text = "&RetroAchievements";
+			// 
+			// StartRetroAchievementsMenuItem
+			// 
+			this.StartRetroAchievementsMenuItem.Text = "&Start RetroAchievements";
+			this.StartRetroAchievementsMenuItem.Click += new System.EventHandler(this.StartRetroAchievementsMenuItem_Click);
+			// 
+			// NESSubMenu
+			// 
+			this.NESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.NESPPUViewerMenuItem,
+			this.NESNametableViewerMenuItem,
+			this.MusicRipperMenuItem,
+			this.toolStripSeparator17,
+			this.NesControllerSettingsMenuItem,
+			this.NESGraphicSettingsMenuItem,
+			this.NESSoundChannelsMenuItem,
+			this.VSSettingsMenuItem,
+			this.MovieSettingsMenuItem,
+			this.toolStripSeparator22,
+			this.FDSControlsMenuItem,
+			this.VSControlsMenuItem,
+			this.BarcodeReaderMenuItem});
+			this.NESSubMenu.Text = "&NES";
+			this.NESSubMenu.DropDownOpened += new System.EventHandler(this.NesSubMenu_DropDownOpened);
+			// 
+			// NESPPUViewerMenuItem
+			// 
+			this.NESPPUViewerMenuItem.Text = "&PPU Viewer";
+			this.NESPPUViewerMenuItem.Click += new System.EventHandler(this.NesPpuViewerMenuItem_Click);
+			// 
+			// NESNametableViewerMenuItem
+			// 
+			this.NESNametableViewerMenuItem.Text = "&Nametable Viewer";
+			this.NESNametableViewerMenuItem.Click += new System.EventHandler(this.NesNametableViewerMenuItem_Click);
+			// 
+			// MusicRipperMenuItem
+			// 
+			this.MusicRipperMenuItem.Text = "Music Ripper";
+			this.MusicRipperMenuItem.Click += new System.EventHandler(this.MusicRipperMenuItem_Click);
+			// 
+			// NesControllerSettingsMenuItem
+			// 
+			this.NesControllerSettingsMenuItem.Text = "Controller Settings...";
+			this.NesControllerSettingsMenuItem.Click += new System.EventHandler(this.NesControllerSettingsMenuItem_Click);
+			// 
+			// NESGraphicSettingsMenuItem
+			// 
+			this.NESGraphicSettingsMenuItem.Text = "Graphics Settings...";
+			this.NESGraphicSettingsMenuItem.Click += new System.EventHandler(this.NesGraphicSettingsMenuItem_Click);
+			// 
+			// NESSoundChannelsMenuItem
+			// 
+			this.NESSoundChannelsMenuItem.Text = "Sound Channels...";
+			this.NESSoundChannelsMenuItem.Click += new System.EventHandler(this.NesSoundChannelsMenuItem_Click);
+			// 
+			// VSSettingsMenuItem
+			// 
+			this.VSSettingsMenuItem.Text = "VS Settings...";
+			this.VSSettingsMenuItem.Click += new System.EventHandler(this.VsSettingsMenuItem_Click);
+			// 
+			// MovieSettingsMenuItem
+			// 
+			this.MovieSettingsMenuItem.Text = "Advanced Settings...";
+			this.MovieSettingsMenuItem.Click += new System.EventHandler(this.MovieSettingsMenuItem_Click);
+			// 
+			// FDSControlsMenuItem
+			// 
+			this.FDSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.FdsEjectDiskMenuItem});
+			this.FDSControlsMenuItem.Text = "FDS Controls";
+			this.FDSControlsMenuItem.DropDownOpened += new System.EventHandler(this.FdsControlsMenuItem_DropDownOpened);
+			// 
+			// FdsEjectDiskMenuItem
+			// 
+			this.FdsEjectDiskMenuItem.Text = "&Eject Disk";
+			this.FdsEjectDiskMenuItem.Click += new System.EventHandler(this.FdsEjectDiskMenuItem_Click);
+			// 
+			// VSControlsMenuItem
+			// 
+			this.VSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.VSInsertCoinP1MenuItem,
+			this.VSInsertCoinP2MenuItem,
+			this.VSServiceSwitchMenuItem});
+			this.VSControlsMenuItem.Text = "VS Controls";
+			// 
+			// VSInsertCoinP1MenuItem
+			// 
+			this.VSInsertCoinP1MenuItem.Text = "Insert Coin P1";
+			this.VSInsertCoinP1MenuItem.Click += new System.EventHandler(this.VsInsertCoinP1MenuItem_Click);
+			// 
+			// VSInsertCoinP2MenuItem
+			// 
+			this.VSInsertCoinP2MenuItem.Text = "Insert Coin P2";
+			this.VSInsertCoinP2MenuItem.Click += new System.EventHandler(this.VsInsertCoinP2MenuItem_Click);
+			// 
+			// VSServiceSwitchMenuItem
+			// 
+			this.VSServiceSwitchMenuItem.Text = "Service Switch";
+			this.VSServiceSwitchMenuItem.Click += new System.EventHandler(this.VsServiceSwitchMenuItem_Click);
+			// 
+			// BarcodeReaderMenuItem
+			// 
+			this.BarcodeReaderMenuItem.Text = "Barcode Reader";
+			this.BarcodeReaderMenuItem.Click += new System.EventHandler(this.BarcodeReaderMenuItem_Click);
+			// 
+			// TI83SubMenu
+			// 
+			this.TI83SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.KeypadMenuItem,
+			this.LoadTIFileMenuItem,
+			this.toolStripSeparator13,
+			this.paletteToolStripMenuItem});
+			this.TI83SubMenu.Text = "TI83";
+			// 
+			// KeypadMenuItem
+			// 
+			this.KeypadMenuItem.Text = "Keypad";
+			this.KeypadMenuItem.Click += new System.EventHandler(this.Ti83KeypadMenuItem_Click);
+			// 
+			// LoadTIFileMenuItem
+			// 
+			this.LoadTIFileMenuItem.Text = "Load TI-83 File...";
+			this.LoadTIFileMenuItem.Click += new System.EventHandler(this.Ti83LoadTIFileMenuItem_Click);
+			// 
+			// paletteToolStripMenuItem
+			// 
+			this.paletteToolStripMenuItem.Text = "Palette...";
+			this.paletteToolStripMenuItem.Click += new System.EventHandler(this.Ti83PaletteMenuItem_Click);
+			// 
+			// A7800SubMenu
+			// 
+			this.A7800SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.A7800ControllerSettingsMenuItem,
+			this.A7800FilterSettingsMenuItem});
+			this.A7800SubMenu.Text = "&A7800";
+			this.A7800SubMenu.DropDownOpened += new System.EventHandler(this.A7800SubMenu_DropDownOpened);
+			// 
+			// A7800ControllerSettingsMenuItem
+			// 
+			this.A7800ControllerSettingsMenuItem.Text = "Controller Settings";
+			this.A7800ControllerSettingsMenuItem.Click += new System.EventHandler(this.A7800ControllerSettingsMenuItem_Click);
+			// 
+			// A7800FilterSettingsMenuItem
+			// 
+			this.A7800FilterSettingsMenuItem.Text = "Filter Settings";
+			this.A7800FilterSettingsMenuItem.Click += new System.EventHandler(this.A7800FilterSettingsMenuItem_Click);
+			// 
+			// GBSubMenu
+			// 
+			this.GBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.GBcoreSettingsToolStripMenuItem,
+			this.SameBoyColorChooserMenuItem,
+			this.toolStripSeparator28,
+			this.GBGPUViewerMenuItem,
+			this.GBPrinterViewerMenuItem});
+			this.GBSubMenu.Text = "&GB";
+			// 
+			// GBcoreSettingsToolStripMenuItem
+			// 
+			this.GBcoreSettingsToolStripMenuItem.Text = "Settings...";
+			this.GBcoreSettingsToolStripMenuItem.Click += new System.EventHandler(this.GbCoreSettingsMenuItem_Click);
+			// 
+			// SameBoyColorChooserMenuItem
+			// 
+			this.SameBoyColorChooserMenuItem.Text = "&Choose Custom Palette...";
+			this.SameBoyColorChooserMenuItem.Click += new System.EventHandler(this.SameboyColorChooserMenuItem_Click);
+			// 
+			// GBGPUViewerMenuItem
+			// 
+			this.GBGPUViewerMenuItem.Text = "GPU Viewer";
+			this.GBGPUViewerMenuItem.Click += new System.EventHandler(this.GbGpuViewerMenuItem_Click);
+			// 
+			// GBPrinterViewerMenuItem
+			// 
+			this.GBPrinterViewerMenuItem.Text = "&Printer Viewer";
+			this.GBPrinterViewerMenuItem.Click += new System.EventHandler(this.GbPrinterViewerMenuItem_Click);
+			// 
+			// PSXSubMenu
+			// 
+			this.PSXSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.PSXControllerSettingsMenuItem,
+			this.PSXOptionsMenuItem,
+			this.PSXDiscControlsMenuItem,
+			this.PSXHashDiscsToolStripMenuItem});
+			this.PSXSubMenu.Text = "PSX";
+			this.PSXSubMenu.DropDownOpened += new System.EventHandler(this.PsxSubMenu_DropDownOpened);
+			// 
+			// PSXControllerSettingsMenuItem
+			// 
+			this.PSXControllerSettingsMenuItem.Text = "Controller / Memcard Settings";
+			this.PSXControllerSettingsMenuItem.Click += new System.EventHandler(this.PsxControllerSettingsMenuItem_Click);
+			// 
+			// PSXOptionsMenuItem
+			// 
+			this.PSXOptionsMenuItem.Text = "&Options";
+			this.PSXOptionsMenuItem.Click += new System.EventHandler(this.PsxOptionsMenuItem_Click);
+			// 
+			// PSXDiscControlsMenuItem
+			// 
+			this.PSXDiscControlsMenuItem.Text = "&Disc Controls";
+			this.PSXDiscControlsMenuItem.Click += new System.EventHandler(this.PsxDiscControlsMenuItem_Click);
+			// 
+			// PSXHashDiscsToolStripMenuItem
+			// 
+			this.PSXHashDiscsToolStripMenuItem.Text = "&Hash Discs";
+			this.PSXHashDiscsToolStripMenuItem.Click += new System.EventHandler(this.PsxHashDiscsMenuItem_Click);
+			// 
+			// SNESSubMenu
+			// 
+			this.SNESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.SNESControllerConfigurationMenuItem,
+			this.toolStripSeparator18,
+			this.SnesGfxDebuggerMenuItem,
+			this.SnesOptionsMenuItem});
+			this.SNESSubMenu.Text = "&SNES";
+			this.SNESSubMenu.DropDownOpened += new System.EventHandler(this.SnesSubMenu_DropDownOpened);
+			// 
+			// SNESControllerConfigurationMenuItem
+			// 
+			this.SNESControllerConfigurationMenuItem.Text = "Controller Configuration";
+			this.SNESControllerConfigurationMenuItem.Click += new System.EventHandler(this.SNESControllerConfigurationMenuItem_Click);
+			// 
+			// SnesGfxDebuggerMenuItem
+			// 
+			this.SnesGfxDebuggerMenuItem.Text = "Graphics Debugger";
+			this.SnesGfxDebuggerMenuItem.Click += new System.EventHandler(this.SnesGfxDebuggerMenuItem_Click);
+			// 
+			// SnesOptionsMenuItem
+			// 
+			this.SnesOptionsMenuItem.Text = "&Options";
+			this.SnesOptionsMenuItem.Click += new System.EventHandler(this.SnesOptionsMenuItem_Click);
+			// 
+			// ColecoSubMenu
+			// 
+			this.ColecoSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.ColecoControllerSettingsMenuItem,
+			this.toolStripSeparator35,
+			this.ColecoSkipBiosMenuItem,
+			this.ColecoUseSGMMenuItem});
+			this.ColecoSubMenu.Text = "&Coleco";
+			this.ColecoSubMenu.DropDownOpened += new System.EventHandler(this.ColecoSubMenu_DropDownOpened);
+			// 
+			// ColecoControllerSettingsMenuItem
+			// 
+			this.ColecoControllerSettingsMenuItem.Text = "&Controller Settings...";
+			this.ColecoControllerSettingsMenuItem.Click += new System.EventHandler(this.ColecoControllerSettingsMenuItem_Click);
+			// 
+			// ColecoSkipBiosMenuItem
+			// 
+			this.ColecoSkipBiosMenuItem.Text = "&Skip BIOS intro (When Applicable)";
+			this.ColecoSkipBiosMenuItem.Click += new System.EventHandler(this.ColecoSkipBiosMenuItem_Click);
+			// 
+			// ColecoUseSGMMenuItem
+			// 
+			this.ColecoUseSGMMenuItem.Text = "&Use the Super Game Module";
+			this.ColecoUseSGMMenuItem.Click += new System.EventHandler(this.ColecoUseSGMMenuItem_Click);
+			// 
+			// N64SubMenu
+			// 
+			this.N64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.N64PluginSettingsMenuItem,
+			this.N64ControllerSettingsMenuItem,
+			this.toolStripSeparator23,
+			this.N64CircularAnalogRangeMenuItem,
+			this.MupenStyleLagMenuItem,
+			this.N64ExpansionSlotMenuItem});
+			this.N64SubMenu.Text = "N64";
+			this.N64SubMenu.DropDownOpened += new System.EventHandler(this.N64SubMenu_DropDownOpened);
+			// 
+			// N64PluginSettingsMenuItem
+			// 
+			this.N64PluginSettingsMenuItem.Text = "Plugins";
+			this.N64PluginSettingsMenuItem.Click += new System.EventHandler(this.N64PluginSettingsMenuItem_Click);
+			// 
+			// N64ControllerSettingsMenuItem
+			// 
+			this.N64ControllerSettingsMenuItem.Text = "Controller Settings...";
+			this.N64ControllerSettingsMenuItem.Click += new System.EventHandler(this.N64ControllerSettingsMenuItem_Click);
+			// 
+			// N64CircularAnalogRangeMenuItem
+			// 
+			this.N64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
+			this.N64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
+			// 
+			// MupenStyleLagMenuItem
+			// 
+			this.MupenStyleLagMenuItem.Text = "&Mupen Style Lag Frames";
+			this.MupenStyleLagMenuItem.Click += new System.EventHandler(this.MupenStyleLagMenuItem_Click);
+			// 
+			// N64ExpansionSlotMenuItem
+			// 
+			this.N64ExpansionSlotMenuItem.Text = "&Use Expansion Slot";
+			this.N64ExpansionSlotMenuItem.Click += new System.EventHandler(this.N64ExpansionSlotMenuItem_Click);
+			// 
+			// Ares64SubMenu
+			// 
+			this.Ares64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.Ares64SettingsMenuItem,
+			this.Ares64CircularAnalogRangeMenuItem});
+			this.Ares64SubMenu.Text = "N64";
+			this.Ares64SubMenu.DropDownOpened += new System.EventHandler(this.Ares64SubMenu_DropDownOpened);
+			// 
+			// Ares64SettingsMenuItem
+			// 
+			this.Ares64SettingsMenuItem.Text = "Settings...";
+			this.Ares64SettingsMenuItem.Click += new System.EventHandler(this.Ares64SettingsMenuItem_Click);
+			// 
+			// Ares64CircularAnalogRangeMenuItem
+			// 
+			this.Ares64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
+			this.Ares64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
+			// 
+			// GBLSubMenu
+			// 
+			this.GBLSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.GBLsettingsToolStripMenuItem});
+			this.GBLSubMenu.Text = "&GB Link";
+			// 
+			// GBLsettingsToolStripMenuItem
+			// 
+			this.GBLsettingsToolStripMenuItem.Text = "Settings...";
+			this.GBLsettingsToolStripMenuItem.Click += new System.EventHandler(this.GblSettingsMenuItem_Click);
+			// 
+			// AppleSubMenu
+			// 
+			this.AppleSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.AppleDisksSubMenu,
+			this.settingsToolStripMenuItem1});
+			this.AppleSubMenu.Text = "Apple";
+			this.AppleSubMenu.DropDownOpened += new System.EventHandler(this.AppleSubMenu_DropDownOpened);
+			// 
+			// AppleDisksSubMenu
+			// 
+			this.AppleDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolStripSeparator31});
+			this.AppleDisksSubMenu.Text = "Disks";
+			this.AppleDisksSubMenu.DropDownOpened += new System.EventHandler(this.AppleDisksSubMenu_DropDownOpened);
+			// 
+			// settingsToolStripMenuItem1
+			// 
+			this.settingsToolStripMenuItem1.Text = "&Settings...";
+			this.settingsToolStripMenuItem1.Click += new System.EventHandler(this.AppleIISettingsMenuItem_Click);
+			// 
+			// C64SubMenu
+			// 
+			this.C64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.C64DisksSubMenu,
+			this.C64SettingsMenuItem});
+			this.C64SubMenu.Text = "&C64";
+			this.C64SubMenu.DropDownOpened += new System.EventHandler(this.C64SubMenu_DropDownOpened);
+			// 
+			// C64DisksSubMenu
+			// 
+			this.C64DisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolStripSeparator36});
+			this.C64DisksSubMenu.Text = "Disks";
+			this.C64DisksSubMenu.DropDownOpened += new System.EventHandler(this.C64DisksSubMenu_DropDownOpened);
+			// 
+			// C64SettingsMenuItem
+			// 
+			this.C64SettingsMenuItem.Text = "&Settings...";
+			this.C64SettingsMenuItem.Click += new System.EventHandler(this.C64SettingsMenuItem_Click);
+			// 
+			// IntvSubMenu
+			// 
+			this.IntvSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.IntVControllerSettingsMenuItem});
+			this.IntvSubMenu.Text = "&Intv";
+			this.IntvSubMenu.DropDownOpened += new System.EventHandler(this.IntVSubMenu_DropDownOpened);
+			// 
+			// IntVControllerSettingsMenuItem
+			// 
+			this.IntVControllerSettingsMenuItem.Text = "Controller Settings...";
+			this.IntVControllerSettingsMenuItem.Click += new System.EventHandler(this.IntVControllerSettingsMenuItem_Click);
+			// 
+			// zXSpectrumToolStripMenuItem
+			// 
+			this.zXSpectrumToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.ZXSpectrumCoreEmulationSettingsMenuItem,
+			this.ZXSpectrumControllerConfigurationMenuItem,
+			this.ZXSpectrumAudioSettingsMenuItem,
+			this.ZXSpectrumNonSyncSettingsMenuItem,
+			this.ZXSpectrumMediaMenuItem});
+			this.zXSpectrumToolStripMenuItem.Text = "ZX Spectrum";
+			// 
+			// ZXSpectrumCoreEmulationSettingsMenuItem
+			// 
+			this.ZXSpectrumCoreEmulationSettingsMenuItem.Text = "Core Emulation Settings";
+			this.ZXSpectrumCoreEmulationSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumCoreEmulationSettingsMenuItem_Click);
+			// 
+			// ZXSpectrumControllerConfigurationMenuItem
+			// 
+			this.ZXSpectrumControllerConfigurationMenuItem.Text = "Joystick Configuration";
+			this.ZXSpectrumControllerConfigurationMenuItem.Click += new System.EventHandler(this.ZXSpectrumControllerConfigurationMenuItem_Click);
+			// 
+			// ZXSpectrumAudioSettingsMenuItem
+			// 
+			this.ZXSpectrumAudioSettingsMenuItem.Text = "Audio Settings";
+			this.ZXSpectrumAudioSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumAudioSettingsMenuItem_Click);
+			// 
+			// ZXSpectrumNonSyncSettingsMenuItem
+			// 
+			this.ZXSpectrumNonSyncSettingsMenuItem.Text = "Non-Sync Settings";
+			this.ZXSpectrumNonSyncSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumNonSyncSettingsMenuItem_Click);
+			// 
+			// ZXSpectrumMediaMenuItem
+			// 
+			this.ZXSpectrumMediaMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.ZXSpectrumTapesSubMenu,
+			this.ZXSpectrumDisksSubMenu,
+			this.ZXSpectrumExportSnapshotMenuItemMenuItem});
+			this.ZXSpectrumMediaMenuItem.Text = "Media";
+			this.ZXSpectrumMediaMenuItem.DropDownOpened += new System.EventHandler(this.ZXSpectrumMediaMenuItem_DropDownOpened);
+			// 
+			// ZXSpectrumTapesSubMenu
+			// 
+			this.ZXSpectrumTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.zxt1ToolStripMenuItem});
+			this.ZXSpectrumTapesSubMenu.Text = "Tapes";
+			this.ZXSpectrumTapesSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumTapesSubMenu_DropDownOpened);
+			// 
+			// zxt1ToolStripMenuItem
+			// 
+			this.zxt1ToolStripMenuItem.Text = "zxt1";
+			// 
+			// ZXSpectrumDisksSubMenu
+			// 
+			this.ZXSpectrumDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.zxt2ToolStripMenuItem});
+			this.ZXSpectrumDisksSubMenu.Text = "Disks";
+			this.ZXSpectrumDisksSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumDisksSubMenu_DropDownOpened);
+			// 
+			// zxt2ToolStripMenuItem
+			// 
+			this.zxt2ToolStripMenuItem.Text = "zxt2";
+			// 
+			// ZXSpectrumExportSnapshotMenuItemMenuItem
+			// 
+			this.ZXSpectrumExportSnapshotMenuItemMenuItem.Text = "Export Snapshot";
+			this.ZXSpectrumExportSnapshotMenuItemMenuItem.Click += new System.EventHandler(this.ZXSpectrumExportSnapshotMenuItemMenuItem_Click);
+			// 
+			// GenericCoreSubMenu
+			// 
+			this.GenericCoreSubMenu.Text = "&Core";
+			// 
+			// amstradCPCToolStripMenuItem
+			// 
+			this.amstradCPCToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.amstradCPCCoreEmulationSettingsToolStripMenuItem,
+			this.AmstradCPCAudioSettingsToolStripMenuItem,
+			this.AmstradCPCNonSyncSettingsToolStripMenuItem,
+			this.AmstradCPCMediaToolStripMenuItem});
+			this.amstradCPCToolStripMenuItem.Text = "Amstrad CPC";
+			// 
+			// amstradCPCCoreEmulationSettingsToolStripMenuItem
+			// 
+			this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Text = "Core Emulation Settings";
+			this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcCoreEmulationSettingsMenuItem_Click);
+			// 
+			// AmstradCPCAudioSettingsToolStripMenuItem
+			// 
+			this.AmstradCPCAudioSettingsToolStripMenuItem.Text = "Audio Settings";
+			this.AmstradCPCAudioSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcAudioSettingsMenuItem_Click);
+			// 
+			// AmstradCPCNonSyncSettingsToolStripMenuItem
+			// 
+			this.AmstradCPCNonSyncSettingsToolStripMenuItem.Text = "Non-Sync Settings";
+			this.AmstradCPCNonSyncSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcNonSyncSettingsMenuItem_Click);
+			// 
+			// AmstradCPCMediaToolStripMenuItem
+			// 
+			this.AmstradCPCMediaToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.AmstradCPCTapesSubMenu,
+			this.AmstradCPCDisksSubMenu});
+			this.AmstradCPCMediaToolStripMenuItem.Text = "Media";
+			this.AmstradCPCMediaToolStripMenuItem.DropDownOpened += new System.EventHandler(this.AmstradCpcMediaMenuItem_DropDownOpened);
+			// 
+			// AmstradCPCTapesSubMenu
+			// 
+			this.AmstradCPCTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.cpct1ToolStripMenuItem});
+			this.AmstradCPCTapesSubMenu.Text = "Tapes";
+			this.AmstradCPCTapesSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcTapesSubMenu_DropDownOpened);
+			// 
+			// cpct1ToolStripMenuItem
+			// 
+			this.cpct1ToolStripMenuItem.Text = "cpct1";
+			// 
+			// AmstradCPCDisksSubMenu
+			// 
+			this.AmstradCPCDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.cpcd1ToolStripMenuItem});
+			this.AmstradCPCDisksSubMenu.Text = "Disks";
+			this.AmstradCPCDisksSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcDisksSubMenu_DropDownOpened);
+			// 
+			// cpcd1ToolStripMenuItem
+			// 
+			this.cpcd1ToolStripMenuItem.Text = "cpcd1";
+			// 
+			// HelpSubMenu
+			// 
+			this.HelpSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.OnlineHelpMenuItem,
+			this.ForumsMenuItem,
+			this.FeaturesMenuItem,
+			this.AboutMenuItem});
+			this.HelpSubMenu.Text = "&Help";
+			this.HelpSubMenu.DropDownOpened += new System.EventHandler(this.HelpSubMenu_DropDownOpened);
+			// 
+			// OnlineHelpMenuItem
+			// 
+			this.OnlineHelpMenuItem.Text = "Open TASVideos Wiki in Browser";
+			this.OnlineHelpMenuItem.Click += new System.EventHandler(this.OnlineHelpMenuItem_Click);
+			// 
+			// ForumsMenuItem
+			// 
+			this.ForumsMenuItem.Text = "Open Forums in Browser";
+			this.ForumsMenuItem.Click += new System.EventHandler(this.ForumsMenuItem_Click);
+			// 
+			// FeaturesMenuItem
+			// 
+			this.FeaturesMenuItem.Text = "&Features";
+			this.FeaturesMenuItem.Click += new System.EventHandler(this.FeaturesMenuItem_Click);
+			// 
+			// AboutMenuItem
+			// 
+			this.AboutMenuItem.Text = "&About...";
+			this.AboutMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
+			// 
+			// A7800HawkCoreMenuItem
+			// 
+			this.A7800HawkCoreMenuItem.Text = "A7800Hawk";
+			// 
+			// MainStatusBar
+			// 
+			this.MainStatusBar.ImageScalingSize = new System.Drawing.Size(20, 20);
+			this.MainStatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.DumpStatusButton,
+			this.EmuStatus,
+			this.PlayRecordStatusButton,
+			this.PauseStatusButton,
+			this.RebootStatusBarIcon,
+			this.AVIStatusLabel,
+			this.LedLightStatusLabel,
+			this.SaveSlotsStatusLabel,
+			this.Slot1StatusButton,
+			this.Slot2StatusButton,
+			this.Slot3StatusButton,
+			this.Slot4StatusButton,
+			this.Slot5StatusButton,
+			this.Slot6StatusButton,
+			this.Slot7StatusButton,
+			this.Slot8StatusButton,
+			this.Slot9StatusButton,
+			this.Slot0StatusButton,
+			this.CheatStatusButton,
+			this.KeyPriorityStatusLabel,
+			this.CoreNameStatusBarButton,
+			this.ProfileFirstBootLabel,
+			this.LinkConnectStatusBarButton,
+			this.UpdateNotification});
+			this.MainStatusBar.Location = new System.Drawing.Point(0, 382);
+			this.MainStatusBar.Name = "MainStatusBar";
+			this.MainStatusBar.ShowItemToolTips = true;
+			this.MainStatusBar.SizingGrip = false;
+			this.MainStatusBar.TabIndex = 1;
+			// 
+			// DumpStatusButton
+			// 
+			this.DumpStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.DumpStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.DumpStatusButton.Name = "DumpStatusButton";
+			this.DumpStatusButton.ShowDropDownArrow = false;
+			this.DumpStatusButton.Size = new System.Drawing.Size(4, 24);
+			this.DumpStatusButton.Text = "No ROM loaded";
+			this.DumpStatusButton.Click += new System.EventHandler(this.DumpStatusButton_Click);
+			// 
+			// PlayRecordStatusButton
+			// 
+			this.PlayRecordStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.PlayRecordStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.PlayRecordStatusButton.Name = "PlayRecordStatusButton";
+			this.PlayRecordStatusButton.ShowDropDownArrow = false;
+			this.PlayRecordStatusButton.Size = new System.Drawing.Size(4, 24);
+			this.PlayRecordStatusButton.Text = "No movie is active";
+			// 
+			// PauseStatusButton
+			// 
+			this.PauseStatusButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.PauseStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.PauseStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.PauseStatusButton.Name = "PauseStatusButton";
+			this.PauseStatusButton.ShowDropDownArrow = false;
+			this.PauseStatusButton.Size = new System.Drawing.Size(4, 24);
+			this.PauseStatusButton.Text = "toolStripDropDownButton1";
+			this.PauseStatusButton.ToolTipText = "Emulator is paused";
+			this.PauseStatusButton.Click += new System.EventHandler(this.PauseMenuItem_Click);
+			// 
+			// RebootStatusBarIcon
+			// 
+			this.RebootStatusBarIcon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.RebootStatusBarIcon.RightToLeft = System.Windows.Forms.RightToLeft.No;
+			this.RebootStatusBarIcon.Text = "Reboot";
+			this.RebootStatusBarIcon.ToolTipText = "A reboot of the core is needed for a setting change to take effect";
+			this.RebootStatusBarIcon.Click += new System.EventHandler(this.PowerMenuItem_Click);
+			// 
+			// AVIStatusLabel
+			// 
+			this.AVIStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.AVIStatusLabel.Text = "AVI Capture";
+			// 
+			// LedLightStatusLabel
+			// 
+			this.LedLightStatusLabel.ToolTipText = "Disk Drive LED Light";
+			// 
+			// SaveSlotsStatusLabel
+			// 
+			this.SaveSlotsStatusLabel.BackColor = System.Drawing.SystemColors.Control;
+			this.SaveSlotsStatusLabel.Text = "Save slots";
+			// 
+			// Slot1StatusButton
+			// 
+			this.Slot1StatusButton.Text = "1";
+			this.Slot1StatusButton.ToolTipText = "Save slot 1";
+			this.Slot1StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+			// 
+			// Slot2StatusButton
+			// 
+			this.Slot2StatusButton.Text = "2";
+			this.Slot2StatusButton.ToolTipText = "Save slot 2";
+			this.Slot2StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+			// 
+			// Slot3StatusButton
+			// 
+			this.Slot3StatusButton.Text = "3";
+			this.Slot3StatusButton.ToolTipText = "Save slot 3";
+			this.Slot3StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+			// 
+			// Slot4StatusButton
+			// 
+			this.Slot4StatusButton.Text = "4";
+			this.Slot4StatusButton.ToolTipText = "Save slot 4";
+			this.Slot4StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+			// 
+			// Slot5StatusButton
+			// 
+			this.Slot5StatusButton.Text = "5";
+			this.Slot5StatusButton.ToolTipText = "Save slot 5";
+			this.Slot5StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+			// 
+			// Slot6StatusButton
+			// 
+			this.Slot6StatusButton.Text = "6";
+			this.Slot6StatusButton.ToolTipText = "Save slot 6";
+			this.Slot6StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+			// 
+			// Slot7StatusButton
+			// 
+			this.Slot7StatusButton.Text = "7";
+			this.Slot7StatusButton.ToolTipText = "Save slot 7";
+			this.Slot7StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+			// 
+			// Slot8StatusButton
+			// 
+			this.Slot8StatusButton.Text = "8";
+			this.Slot8StatusButton.ToolTipText = "Save slot 8";
+			this.Slot8StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+			// 
+			// Slot9StatusButton
+			// 
+			this.Slot9StatusButton.Text = "9";
+			this.Slot9StatusButton.ToolTipText = "Save slot 9";
+			this.Slot9StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+			// 
+			// Slot0StatusButton
+			// 
+			this.Slot0StatusButton.Text = "0";
+			this.Slot0StatusButton.ToolTipText = "Save slot 10";
+			this.Slot0StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+			// 
+			// CheatStatusButton
+			// 
+			this.CheatStatusButton.Click += new System.EventHandler(this.FreezeStatus_Click);
+			// 
+			// KeyPriorityStatusLabel
+			// 
+			this.KeyPriorityStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.KeyPriorityStatusLabel.Margin = new System.Windows.Forms.Padding(5, 3, 5, 0);
+			this.KeyPriorityStatusLabel.Text = "KeyPriority";
+			this.KeyPriorityStatusLabel.Click += new System.EventHandler(this.KeyPriorityStatusLabel_Click);
+			// 
+			// CoreNameStatusBarButton
+			// 
+			this.CoreNameStatusBarButton.Text = "<core name>";
+			// 
+			// ProfileFirstBootLabel
+			// 
+			this.ProfileFirstBootLabel.AutoToolTip = true;
+			this.ProfileFirstBootLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.ProfileFirstBootLabel.Text = "ProfileFirstBootLabel";
+			this.ProfileFirstBootLabel.ToolTipText = "Set up your profile before use";
+			this.ProfileFirstBootLabel.Visible = false;
+			this.ProfileFirstBootLabel.Click += new System.EventHandler(this.ProfileFirstBootLabel_Click);
+			// 
+			// LinkConnectStatusBarButton
+			// 
+			this.LinkConnectStatusBarButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.LinkConnectStatusBarButton.Text = "Link connection is currently enabled";
+			this.LinkConnectStatusBarButton.ToolTipText = "Link connection is currently enabled";
+			this.LinkConnectStatusBarButton.Click += new System.EventHandler(this.LinkConnectStatusBarButton_Click);
+			// 
+			// UpdateNotification
+			// 
+			this.UpdateNotification.IsLink = true;
+			this.UpdateNotification.LinkColor = System.Drawing.Color.Red;
+			this.UpdateNotification.Spring = true;
+			this.UpdateNotification.Text = "New version available!";
+			this.UpdateNotification.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			this.UpdateNotification.Click += new System.EventHandler(this.UpdateNotification_Click);
+			// 
+			// MainFormContextMenu
+			// 
+			this.MainFormContextMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
+			this.MainFormContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.OpenRomContextMenuItem,
+			this.LoadLastRomContextMenuItem,
+			this.StopAVContextMenuItem,
+			this.ContextSeparator_AfterROM,
+			this.RecordMovieContextMenuItem,
+			this.PlayMovieContextMenuItem,
+			this.RestartMovieContextMenuItem,
+			this.StopMovieContextMenuItem,
+			this.LoadLastMovieContextMenuItem,
+			this.BackupMovieContextMenuItem,
+			this.StopNoSaveContextMenuItem,
+			this.ViewSubtitlesContextMenuItem,
+			this.AddSubtitleContextMenuItem,
+			this.ViewCommentsContextMenuItem,
+			this.SaveMovieContextMenuItem,
+			this.SaveMovieAsContextMenuItem,
+			this.ContextSeparator_AfterMovie,
+			this.UndoSavestateContextMenuItem,
+			this.ContextSeparator_AfterUndo,
+			this.ConfigContextMenuItem,
+			this.ScreenshotContextMenuItem,
+			this.CloseRomContextMenuItem,
+			this.ClearSRAMContextMenuItem,
+			this.ShowMenuContextMenuSeparator,
+			this.ShowMenuContextMenuItem});
+			this.MainFormContextMenu.Name = "contextMenuStrip1";
+			this.MainFormContextMenu.Size = new System.Drawing.Size(257, 532);
+			this.MainFormContextMenu.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.MainFormContextMenu_Closing);
+			this.MainFormContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.MainFormContextMenu_Opening);
+			// 
+			// OpenRomContextMenuItem
+			// 
+			this.OpenRomContextMenuItem.Text = "Open Rom";
+			this.OpenRomContextMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
+			// 
+			// LoadLastRomContextMenuItem
+			// 
+			this.LoadLastRomContextMenuItem.Text = "Load Last ROM";
+			this.LoadLastRomContextMenuItem.Click += new System.EventHandler(this.LoadLastRomContextMenuItem_Click);
+			// 
+			// StopAVContextMenuItem
+			// 
+			this.StopAVContextMenuItem.Text = "Stop AVI/WAV";
+			this.StopAVContextMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
+			// 
+			// RecordMovieContextMenuItem
+			// 
+			this.RecordMovieContextMenuItem.Text = "Record Movie";
+			this.RecordMovieContextMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
+			// 
+			// PlayMovieContextMenuItem
+			// 
+			this.PlayMovieContextMenuItem.Text = "Play Movie";
+			this.PlayMovieContextMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
+			// 
+			// RestartMovieContextMenuItem
+			// 
+			this.RestartMovieContextMenuItem.Text = "Restart Movie";
+			this.RestartMovieContextMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
+			// 
+			// StopMovieContextMenuItem
+			// 
+			this.StopMovieContextMenuItem.Text = "Stop Movie";
+			this.StopMovieContextMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
+			// 
+			// LoadLastMovieContextMenuItem
+			// 
+			this.LoadLastMovieContextMenuItem.Text = "Load Last Movie";
+			this.LoadLastMovieContextMenuItem.Click += new System.EventHandler(this.LoadLastMovieContextMenuItem_Click);
+			// 
+			// BackupMovieContextMenuItem
+			// 
+			this.BackupMovieContextMenuItem.Text = "Backup Movie";
+			this.BackupMovieContextMenuItem.Click += new System.EventHandler(this.BackupMovieContextMenuItem_Click);
+			// 
+			// StopNoSaveContextMenuItem
+			// 
+			this.StopNoSaveContextMenuItem.Text = "Stop Movie without Saving";
+			this.StopNoSaveContextMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
+			// 
+			// ViewSubtitlesContextMenuItem
+			// 
+			this.ViewSubtitlesContextMenuItem.Text = "View Subtitles";
+			this.ViewSubtitlesContextMenuItem.Click += new System.EventHandler(this.ViewSubtitlesContextMenuItem_Click);
+			// 
+			// AddSubtitleContextMenuItem
+			// 
+			this.AddSubtitleContextMenuItem.Text = "Add Subtitle";
+			this.AddSubtitleContextMenuItem.Click += new System.EventHandler(this.AddSubtitleContextMenuItem_Click);
+			// 
+			// ViewCommentsContextMenuItem
+			// 
+			this.ViewCommentsContextMenuItem.Text = "View Comments";
+			this.ViewCommentsContextMenuItem.Click += new System.EventHandler(this.ViewCommentsContextMenuItem_Click);
+			// 
+			// SaveMovieContextMenuItem
+			// 
+			this.SaveMovieContextMenuItem.Text = "Save Movie";
+			this.SaveMovieContextMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
+			// 
+			// SaveMovieAsContextMenuItem
+			// 
+			this.SaveMovieAsContextMenuItem.Text = "Save Movie As...";
+			this.SaveMovieAsContextMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
+			// 
+			// UndoSavestateContextMenuItem
+			// 
+			this.UndoSavestateContextMenuItem.Text = "Undo Savestate";
+			this.UndoSavestateContextMenuItem.Click += new System.EventHandler(this.UndoSavestateContextMenuItem_Click);
+			// 
+			// ConfigContextMenuItem
+			// 
+			this.ConfigContextMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolStripMenuItem6,
+			this.toolStripMenuItem7,
+			this.toolStripMenuItem8,
+			this.toolStripMenuItem9,
+			this.toolStripMenuItem10,
+			this.toolStripMenuItem11,
+			this.toolStripMenuItem12,
+			this.toolStripMenuItem13,
+			this.toolStripMenuItem14,
+			this.toolStripMenuItem15,
+			this.customizeToolStripMenuItem,
+			this.toolStripSeparator30,
+			this.toolStripMenuItem66,
+			this.toolStripMenuItem67});
+			this.ConfigContextMenuItem.Text = "Config";
+			// 
+			// toolStripMenuItem6
+			// 
+			this.toolStripMenuItem6.Text = "&Controllers...";
+			this.toolStripMenuItem6.Click += new System.EventHandler(this.ControllersMenuItem_Click);
+			// 
+			// toolStripMenuItem7
+			// 
+			this.toolStripMenuItem7.Text = "&Hotkeys...";
+			this.toolStripMenuItem7.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
+			// 
+			// toolStripMenuItem8
+			// 
+			this.toolStripMenuItem8.Text = "Display...";
+			this.toolStripMenuItem8.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
+			// 
+			// toolStripMenuItem9
+			// 
+			this.toolStripMenuItem9.Text = "&Sound...";
+			this.toolStripMenuItem9.Click += new System.EventHandler(this.SoundMenuItem_Click);
+			// 
+			// toolStripMenuItem10
+			// 
+			this.toolStripMenuItem10.Text = "Paths...";
+			this.toolStripMenuItem10.Click += new System.EventHandler(this.PathsMenuItem_Click);
+			// 
+			// toolStripMenuItem11
+			// 
+			this.toolStripMenuItem11.Text = "&Firmwares...";
+			this.toolStripMenuItem11.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
+			// 
+			// toolStripMenuItem12
+			// 
+			this.toolStripMenuItem12.Text = "&Messages...";
+			this.toolStripMenuItem12.Click += new System.EventHandler(this.MessagesMenuItem_Click);
+			// 
+			// toolStripMenuItem13
+			// 
+			this.toolStripMenuItem13.Text = "&Autofire...";
+			this.toolStripMenuItem13.Click += new System.EventHandler(this.AutofireMenuItem_Click);
+			// 
+			// toolStripMenuItem14
+			// 
+			this.toolStripMenuItem14.Text = "&Rewind...";
+			this.toolStripMenuItem14.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
+			// 
+			// toolStripMenuItem15
+			// 
+			this.toolStripMenuItem15.Text = "File Extensions...";
+			this.toolStripMenuItem15.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
+			// 
+			// customizeToolStripMenuItem
+			// 
+			this.customizeToolStripMenuItem.Text = "Customize...";
+			this.customizeToolStripMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
+			// 
+			// toolStripMenuItem66
+			// 
+			this.toolStripMenuItem66.Text = "Save Config";
+			this.toolStripMenuItem66.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
+			// 
+			// toolStripMenuItem67
+			// 
+			this.toolStripMenuItem67.Text = "Load Config";
+			this.toolStripMenuItem67.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
+			// 
+			// ScreenshotContextMenuItem
+			// 
+			this.ScreenshotContextMenuItem.Text = "Screenshot";
+			this.ScreenshotContextMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
+			// 
+			// CloseRomContextMenuItem
+			// 
+			this.CloseRomContextMenuItem.Text = "Close ROM";
+			this.CloseRomContextMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
+			// 
+			// ClearSRAMContextMenuItem
+			// 
+			this.ClearSRAMContextMenuItem.Text = "Close and Clear SRAM";
+			this.ClearSRAMContextMenuItem.Click += new System.EventHandler(this.ClearSramContextMenuItem_Click);
+			// 
+			// ShowMenuContextMenuItem
+			// 
+			this.ShowMenuContextMenuItem.Text = "Show Menu";
+			this.ShowMenuContextMenuItem.Click += new System.EventHandler(this.ShowMenuContextMenuItem_Click);
+			// 
+			// timerMouseIdle
+			// 
+			this.timerMouseIdle.Enabled = true;
+			this.timerMouseIdle.Interval = 2000;
+			this.timerMouseIdle.Tick += new System.EventHandler(this.TimerMouseIdle_Tick);
+			// 
+			// MainForm
+			// 
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+			this.ClientSize = new System.Drawing.Size(470, 408);
+			this.Controls.Add(this.MainStatusBar);
+			this.Controls.Add(this.MainformMenu);
+			this.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.MainMenuStrip = this.MainformMenu;
+			this.Name = "MainForm";
+			this.Activated += new System.EventHandler(this.MainForm_Activated);
+			this.Deactivate += new System.EventHandler(this.MainForm_Deactivate);
+			this.Load += new System.EventHandler(this.MainForm_Load);
+			this.Shown += new System.EventHandler(this.MainForm_Shown);
+			this.Enter += new System.EventHandler(this.MainForm_Enter);
+			this.Resize += new System.EventHandler(this.MainForm_Resize);
+			this.MainformMenu.ResumeLayout(false);
+			this.MainformMenu.PerformLayout();
+			this.MainStatusBar.ResumeLayout(false);
+			this.MainStatusBar.PerformLayout();
+			this.MainFormContextMenu.ResumeLayout(false);
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -17,2432 +17,2462 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			this.MainformMenu = new BizHawk.WinForms.Controls.MenuStripEx();
-			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.OpenRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.RecentRomSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.OpenAdvancedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.CloseRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.SaveStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.SaveNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator24 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.AutosaveLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.LoadNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator21 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.AutoloadLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveSlotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SelectSlot9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PreviousSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.NextSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.SaveToCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveRAMSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.FlushSaveRAMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.MovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ReadonlyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator15 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.RecentMovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator16 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.RecordMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PlayMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.StopMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PlayFromBeginningMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ImportMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveMovieAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.StopMovieWithoutSavingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator14 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.AutomaticallyBackupMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.FullMovieLoadstatesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MovieEndSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MovieEndFinishMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MovieEndRecordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MovieEndStopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MovieEndPauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AVSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.RecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ConfigAndRecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.StopAVIMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator19 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.CaptureOSDMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.CaptureLuaMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SynclessRecordingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ScreenshotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ScreenshotAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ScreenshotClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ScreenshotClientClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator20 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.ScreenshotCaptureOSDMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.EmulationSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.RebootCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.SoftResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.HardResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.EmulatorMenuSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.LoadedCoreNameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ViewSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.WindowSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.mzMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SwitchToFullscreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.DisplayFPSMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.DisplayFrameCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.DisplayLagCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.DisplayInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.DisplayRerecordCountMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.DisplaySubtitlesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.DisplayStatusBarMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.DisplayMessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.DisplayLogWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ControllersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.HotkeysMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.DisplayConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SoundMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PathsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.FirmwaresMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AutofireMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.RewindOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.extensionsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ClientOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ProfilesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator9 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.SpeedSkipSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ClockThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AudioThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.VsyncThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator27 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.VsyncEnabledMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.miUnthrottled = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MinimizeSkippingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.NeverSkipMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem17 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Frameskip1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Frameskip2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Frameskip3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Frameskip4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Frameskip5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Frameskip6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Frameskip7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Frameskip8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Frameskip9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.Speed50MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Speed75MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Speed100MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Speed150MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Speed200MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Speed400MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.KeyPrioritySubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.BothHkAndControllerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.InputOverHkMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.HkOverInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.CoresSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator10 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.SaveConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveConfigAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadConfigFromMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ToolsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ToolBoxMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator12 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.RamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.RamSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LuaConsoleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.TAStudioMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.HexEditorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.TraceLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.DebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.CodeDataLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MacroToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.VirtualPadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.BasicBotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator11 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.CheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.GameSharkConverterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator29 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.MultiDiskBundlerFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ExternalToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.dummyExternalTool = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.BatchRunnerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.RetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.StartRetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.NESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.NESPPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.NESNametableViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MusicRipperMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator17 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.NesControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.NESGraphicSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.NESSoundChannelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.VSSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MovieSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator22 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.FDSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.FdsEjectDiskMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.VSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.VSInsertCoinP1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.VSInsertCoinP2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.VSServiceSwitchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.BarcodeReaderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.TI83SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.KeypadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadTIFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator13 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.paletteToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.A7800SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.A7800ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.A7800FilterSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.GBSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.GBcoreSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SameBoyColorChooserMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator28 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.GBGPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.GBPrinterViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PSXSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PSXControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PSXOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PSXDiscControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PSXHashDiscsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SNESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SNESControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator18 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.SnesGfxDebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SnesOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ColecoSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ColecoControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator35 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.ColecoSkipBiosMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ColecoUseSGMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.N64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.N64PluginSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Ares64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Ares64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.N64ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator23 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.N64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.Ares64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MupenStyleLagMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.N64ExpansionSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.GBLSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.GBLsettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AppleSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AppleDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator31 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.settingsToolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.C64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.C64DisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator36 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.C64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.IntvSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.IntVControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.zXSpectrumToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ZXSpectrumCoreEmulationSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ZXSpectrumControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ZXSpectrumAudioSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ZXSpectrumNonSyncSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ZXSpectrumMediaMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ZXSpectrumTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.zxt1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ZXSpectrumDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.zxt2ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ZXSpectrumExportSnapshotMenuItemMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.GenericCoreSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.amstradCPCToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.amstradCPCCoreEmulationSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AmstradCPCAudioSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AmstradCPCNonSyncSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AmstradCPCMediaToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AmstradCPCTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.cpct1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AmstradCPCDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.cpcd1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.HelpSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.OnlineHelpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ForumsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.FeaturesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AboutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.A7800HawkCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MainStatusBar = new BizHawk.WinForms.Controls.StatusStripEx();
-			this.DumpStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-			this.EmuStatus = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.PlayRecordStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-			this.PauseStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-			this.RebootStatusBarIcon = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.AVIStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.LedLightStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.SaveSlotsStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.Slot1StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.Slot2StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.Slot3StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.Slot4StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.Slot5StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.Slot6StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.Slot7StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.Slot8StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.Slot9StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.Slot0StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.CheatStatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.KeyPriorityStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.CoreNameStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.ProfileFirstBootLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.LinkConnectStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.UpdateNotification = new BizHawk.WinForms.Controls.StatusLabelEx();
-			this.MainFormContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.OpenRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadLastRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.StopAVContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ContextSeparator_AfterROM = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.RecordMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.PlayMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.RestartMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.StopMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.LoadLastMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.BackupMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.StopNoSaveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ViewSubtitlesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.AddSubtitleContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ViewCommentsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.SaveMovieAsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ContextSeparator_AfterMovie = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.UndoSavestateContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ContextSeparator_AfterUndo = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.ConfigContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem6 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem7 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem8 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem9 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem10 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem11 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem12 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem13 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem14 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem15 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.customizeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator30 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.toolStripMenuItem66 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem67 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ScreenshotContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.CloseRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ClearSRAMContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ShowMenuContextMenuSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.ShowMenuContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
-			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-			this.MainformMenu.SuspendLayout();
-			this.MainStatusBar.SuspendLayout();
-			this.MainFormContextMenu.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// MainformMenu
-			// 
-			this.MainformMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.FileSubMenu,
-			this.EmulationSubMenu,
-			this.ViewSubMenu,
-			this.ConfigSubMenu,
-			this.ToolsSubMenu,
-			this.NESSubMenu,
-			this.TI83SubMenu,
-			this.A7800SubMenu,
-			this.GBSubMenu,
-			this.PSXSubMenu,
-			this.SNESSubMenu,
-			this.ColecoSubMenu,
-			this.N64SubMenu,
-			this.Ares64SubMenu,
-			this.GBLSubMenu,
-			this.AppleSubMenu,
-			this.C64SubMenu,
-			this.IntvSubMenu,
-			this.zXSpectrumToolStripMenuItem,
-			this.GenericCoreSubMenu,
-			this.amstradCPCToolStripMenuItem,
-			this.HelpSubMenu});
-			this.MainformMenu.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
-			this.MainformMenu.TabIndex = 0;
-			this.MainformMenu.MenuActivate += new System.EventHandler(this.MainformMenu_MenuActivate);
-			this.MainformMenu.MenuDeactivate += new System.EventHandler(this.MainformMenu_MenuDeactivate);
-			// 
-			// FileSubMenu
-			// 
-			this.FileSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.OpenRomMenuItem,
-			this.RecentRomSubMenu,
-			this.OpenAdvancedMenuItem,
-			this.CloseRomMenuItem,
-			this.toolStripMenuItem1,
-			this.SaveStateSubMenu,
-			this.LoadStateSubMenu,
-			this.SaveSlotSubMenu,
-			this.SaveRAMSubMenu,
-			this.toolStripMenuItem2,
-			this.MovieSubMenu,
-			this.AVSubMenu,
-			this.ScreenshotSubMenu,
-			this.toolStripSeparator4,
-			this.ExitMenuItem});
-			this.FileSubMenu.Text = "&File";
-			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
-			// 
-			// OpenRomMenuItem
-			// 
-			this.OpenRomMenuItem.Text = "&Open ROM...";
-			this.OpenRomMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
-			// 
-			// RecentRomSubMenu
-			// 
-			this.RecentRomSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripSeparator3});
-			this.RecentRomSubMenu.Text = "&Recent ROM";
-			this.RecentRomSubMenu.DropDownOpened += new System.EventHandler(this.RecentRomMenuItem_DropDownOpened);
-			// 
-			// OpenAdvancedMenuItem
-			// 
-			this.OpenAdvancedMenuItem.Text = "Open Ad&vanced...";
-			this.OpenAdvancedMenuItem.Click += new System.EventHandler(this.OpenAdvancedMenuItem_Click);
-			// 
-			// CloseRomMenuItem
-			// 
-			this.CloseRomMenuItem.Text = "&Close ROM";
-			this.CloseRomMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
-			// 
-			// SaveStateSubMenu
-			// 
-			this.SaveStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.SaveState1MenuItem,
-			this.SaveState2MenuItem,
-			this.SaveState3MenuItem,
-			this.SaveState4MenuItem,
-			this.SaveState5MenuItem,
-			this.SaveState6MenuItem,
-			this.SaveState7MenuItem,
-			this.SaveState8MenuItem,
-			this.SaveState9MenuItem,
-			this.SaveState0MenuItem,
-			this.toolStripSeparator6,
-			this.SaveNamedStateMenuItem,
-			this.toolStripSeparator24,
-			this.AutosaveLastSlotMenuItem});
-			this.SaveStateSubMenu.Text = "&Save State";
-			this.SaveStateSubMenu.DropDownOpened += new System.EventHandler(this.SaveStateSubMenu_DropDownOpened);
-			// 
-			// SaveState1MenuItem
-			// 
-			this.SaveState1MenuItem.Text = "1";
-			this.SaveState1MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-			// 
-			// SaveState2MenuItem
-			// 
-			this.SaveState2MenuItem.Text = "2";
-			this.SaveState2MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-			// 
-			// SaveState3MenuItem
-			// 
-			this.SaveState3MenuItem.Text = "3";
-			this.SaveState3MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-			// 
-			// SaveState4MenuItem
-			// 
-			this.SaveState4MenuItem.Text = "4";
-			this.SaveState4MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-			// 
-			// SaveState5MenuItem
-			// 
-			this.SaveState5MenuItem.Text = "5";
-			this.SaveState5MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-			// 
-			// SaveState6MenuItem
-			// 
-			this.SaveState6MenuItem.Text = "6";
-			this.SaveState6MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-			// 
-			// SaveState7MenuItem
-			// 
-			this.SaveState7MenuItem.Text = "7";
-			this.SaveState7MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-			// 
-			// SaveState8MenuItem
-			// 
-			this.SaveState8MenuItem.Text = "8";
-			this.SaveState8MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-			// 
-			// SaveState9MenuItem
-			// 
-			this.SaveState9MenuItem.Text = "9";
-			this.SaveState9MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-			// 
-			// SaveState0MenuItem
-			// 
-			this.SaveState0MenuItem.Text = "10";
-			this.SaveState0MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-			// 
-			// SaveNamedStateMenuItem
-			// 
-			this.SaveNamedStateMenuItem.Text = "Save Named State...";
-			this.SaveNamedStateMenuItem.Click += new System.EventHandler(this.SaveNamedStateMenuItem_Click);
-			// 
-			// AutosaveLastSlotMenuItem
-			// 
-			this.AutosaveLastSlotMenuItem.Name = "AutosaveLastSlotMenuItem";
-			this.AutosaveLastSlotMenuItem.Text = "Autosave Last Slot";
-			this.AutosaveLastSlotMenuItem.Click += new System.EventHandler(this.AutosaveLastSlotMenuItem_Click);
-			// 
-			// LoadStateSubMenu
-			// 
-			this.LoadStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.LoadState1MenuItem,
-			this.LoadState2MenuItem,
-			this.LoadState3MenuItem,
-			this.LoadState4MenuItem,
-			this.LoadState5MenuItem,
-			this.LoadState6MenuItem,
-			this.LoadState7MenuItem,
-			this.LoadState8MenuItem,
-			this.LoadState9MenuItem,
-			this.LoadState0MenuItem,
-			this.toolStripSeparator7,
-			this.LoadNamedStateMenuItem,
-			this.toolStripSeparator21,
-			this.AutoloadLastSlotMenuItem});
-			this.LoadStateSubMenu.Text = "&Load State";
-			this.LoadStateSubMenu.DropDownOpened += new System.EventHandler(this.LoadStateSubMenu_DropDownOpened);
-			// 
-			// LoadState1MenuItem
-			// 
-			this.LoadState1MenuItem.Text = "1";
-			this.LoadState1MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-			// 
-			// LoadState2MenuItem
-			// 
-			this.LoadState2MenuItem.Text = "2";
-			this.LoadState2MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-			// 
-			// LoadState3MenuItem
-			// 
-			this.LoadState3MenuItem.Text = "3";
-			this.LoadState3MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-			// 
-			// LoadState4MenuItem
-			// 
-			this.LoadState4MenuItem.Text = "4";
-			this.LoadState4MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-			// 
-			// LoadState5MenuItem
-			// 
-			this.LoadState5MenuItem.Text = "5";
-			this.LoadState5MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-			// 
-			// LoadState6MenuItem
-			// 
-			this.LoadState6MenuItem.Text = "6";
-			this.LoadState6MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-			// 
-			// LoadState7MenuItem
-			// 
-			this.LoadState7MenuItem.Text = "7";
-			this.LoadState7MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-			// 
-			// LoadState8MenuItem
-			// 
-			this.LoadState8MenuItem.Text = "8";
-			this.LoadState8MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-			// 
-			// LoadState9MenuItem
-			// 
-			this.LoadState9MenuItem.Text = "9";
-			this.LoadState9MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-			// 
-			// LoadState0MenuItem
-			// 
-			this.LoadState0MenuItem.Text = "10";
-			this.LoadState0MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-			// 
-			// LoadNamedStateMenuItem
-			// 
-			this.LoadNamedStateMenuItem.Text = "Load Named State...";
-			this.LoadNamedStateMenuItem.Click += new System.EventHandler(this.LoadNamedStateMenuItem_Click);
-			// 
-			// AutoloadLastSlotMenuItem
-			// 
-			this.AutoloadLastSlotMenuItem.Text = "Autoload Last Slot";
-			this.AutoloadLastSlotMenuItem.Click += new System.EventHandler(this.AutoloadLastSlotMenuItem_Click);
-			// 
-			// SaveSlotSubMenu
-			// 
-			this.SaveSlotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.SelectSlot1MenuItem,
-			this.SelectSlot2MenuItem,
-			this.SelectSlot3MenuItem,
-			this.SelectSlot4MenuItem,
-			this.SelectSlot5MenuItem,
-			this.SelectSlot6MenuItem,
-			this.SelectSlot7MenuItem,
-			this.SelectSlot8MenuItem,
-			this.SelectSlot9MenuItem,
-			this.SelectSlot0MenuItem,
-			this.PreviousSlotMenuItem,
-			this.NextSlotMenuItem,
-			this.toolStripSeparator5,
-			this.SaveToCurrentSlotMenuItem,
-			this.LoadCurrentSlotMenuItem});
-			this.SaveSlotSubMenu.Text = "Save S&lot";
-			this.SaveSlotSubMenu.DropDownOpened += new System.EventHandler(this.SaveSlotSubMenu_DropDownOpened);
-			// 
-			// SelectSlot0MenuItem
-			// 
-			this.SelectSlot0MenuItem.Text = "Select Slot 10";
-			this.SelectSlot0MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// SelectSlot1MenuItem
-			// 
-			this.SelectSlot1MenuItem.Text = "Select Slot 1";
-			this.SelectSlot1MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// SelectSlot2MenuItem
-			// 
-			this.SelectSlot2MenuItem.Text = "Select Slot 2";
-			this.SelectSlot2MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// SelectSlot3MenuItem
-			// 
-			this.SelectSlot3MenuItem.Text = "Select Slot 3";
-			this.SelectSlot3MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// SelectSlot4MenuItem
-			// 
-			this.SelectSlot4MenuItem.Text = "Select Slot 4";
-			this.SelectSlot4MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// SelectSlot5MenuItem
-			// 
-			this.SelectSlot5MenuItem.Text = "Select Slot 5";
-			this.SelectSlot5MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// SelectSlot6MenuItem
-			// 
-			this.SelectSlot6MenuItem.Text = "Select Slot 6";
-			this.SelectSlot6MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// SelectSlot7MenuItem
-			// 
-			this.SelectSlot7MenuItem.Text = "Select Slot 7";
-			this.SelectSlot7MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// SelectSlot8MenuItem
-			// 
-			this.SelectSlot8MenuItem.Text = "Select Slot 8";
-			this.SelectSlot8MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// SelectSlot9MenuItem
-			// 
-			this.SelectSlot9MenuItem.Text = "Select Slot 9";
-			this.SelectSlot9MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-			// 
-			// PreviousSlotMenuItem
-			// 
-			this.PreviousSlotMenuItem.Text = "Previous Slot";
-			this.PreviousSlotMenuItem.Click += new System.EventHandler(this.PreviousSlotMenuItem_Click);
-			// 
-			// NextSlotMenuItem
-			// 
-			this.NextSlotMenuItem.Text = "Next Slot";
-			this.NextSlotMenuItem.Click += new System.EventHandler(this.NextSlotMenuItem_Click);
-			// 
-			// SaveToCurrentSlotMenuItem
-			// 
-			this.SaveToCurrentSlotMenuItem.Text = "Save to Current Slot";
-			this.SaveToCurrentSlotMenuItem.Click += new System.EventHandler(this.SaveToCurrentSlotMenuItem_Click);
-			// 
-			// LoadCurrentSlotMenuItem
-			// 
-			this.LoadCurrentSlotMenuItem.Text = "Load Current Slot";
-			this.LoadCurrentSlotMenuItem.Click += new System.EventHandler(this.LoadCurrentSlotMenuItem_Click);
-			// 
-			// SaveRAMSubMenu
-			// 
-			this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.FlushSaveRAMMenuItem});
-			this.SaveRAMSubMenu.Text = "Save &RAM";
-			this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
-			// 
-			// FlushSaveRAMMenuItem
-			// 
-			this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
-			this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
-			// 
-			// MovieSubMenu
-			// 
-			this.MovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ReadonlyMenuItem,
-			this.toolStripSeparator15,
-			this.RecentMovieSubMenu,
-			this.RecordMovieMenuItem,
-			this.PlayMovieMenuItem,
-			this.StopMovieMenuItem,
-			this.PlayFromBeginningMenuItem,
-			this.ImportMoviesMenuItem,
-			this.SaveMovieMenuItem,
-			this.SaveMovieAsMenuItem,
-			this.StopMovieWithoutSavingMenuItem,
-			this.toolStripSeparator14,
-			this.AutomaticallyBackupMoviesMenuItem,
-			this.FullMovieLoadstatesMenuItem,
-			this.MovieEndSubMenu});
-			this.MovieSubMenu.Text = "&Movie";
-			this.MovieSubMenu.DropDownOpened += new System.EventHandler(this.MovieSubMenu_DropDownOpened);
-			// 
-			// ReadonlyMenuItem
-			// 
-			this.ReadonlyMenuItem.Text = "Read-only";
-			this.ReadonlyMenuItem.Click += new System.EventHandler(this.ReadonlyMenuItem_Click);
-			// 
-			// RecentMovieSubMenu
-			// 
-			this.RecentMovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripSeparator16});
-			this.RecentMovieSubMenu.Text = "Recent";
-			this.RecentMovieSubMenu.DropDownOpened += new System.EventHandler(this.RecentMovieSubMenu_DropDownOpened);
-			// 
-			// RecordMovieMenuItem
-			// 
-			this.RecordMovieMenuItem.Text = "&Record Movie...";
-			this.RecordMovieMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
-			// 
-			// PlayMovieMenuItem
-			// 
-			this.PlayMovieMenuItem.Text = "&Play Movie...";
-			this.PlayMovieMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
-			// 
-			// StopMovieMenuItem
-			// 
-			this.StopMovieMenuItem.Text = "Stop Movie";
-			this.StopMovieMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
-			// 
-			// PlayFromBeginningMenuItem
-			// 
-			this.PlayFromBeginningMenuItem.Text = "Play from Beginning";
-			this.PlayFromBeginningMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
-			// 
-			// ImportMoviesMenuItem
-			// 
-			this.ImportMoviesMenuItem.Text = "Import Movies...";
-			this.ImportMoviesMenuItem.Click += new System.EventHandler(this.ImportMovieMenuItem_Click);
-			// 
-			// SaveMovieMenuItem
-			// 
-			this.SaveMovieMenuItem.Text = "&Save Movie";
-			this.SaveMovieMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
-			// 
-			// SaveMovieAsMenuItem
-			// 
-			this.SaveMovieAsMenuItem.Text = "Save Movie As...";
-			this.SaveMovieAsMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
-			// 
-			// StopMovieWithoutSavingMenuItem
-			// 
-			this.StopMovieWithoutSavingMenuItem.Text = "Stop Movie without Saving";
-			this.StopMovieWithoutSavingMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
-			// 
-			// AutomaticallyBackupMoviesMenuItem
-			// 
-			this.AutomaticallyBackupMoviesMenuItem.Text = "Automatically Backup Movies";
-			this.AutomaticallyBackupMoviesMenuItem.Click += new System.EventHandler(this.AutomaticMovieBackupMenuItem_Click);
-			// 
-			// FullMovieLoadstatesMenuItem
-			// 
-			this.FullMovieLoadstatesMenuItem.Text = "Full Movie Loadstates";
-			this.FullMovieLoadstatesMenuItem.Click += new System.EventHandler(this.FullMovieLoadstatesMenuItem_Click);
-			// 
-			// MovieEndSubMenu
-			// 
-			this.MovieEndSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.MovieEndFinishMenuItem,
-			this.MovieEndRecordMenuItem,
-			this.MovieEndStopMenuItem,
-			this.MovieEndPauseMenuItem});
-			this.MovieEndSubMenu.Text = "On Movie End";
-			this.MovieEndSubMenu.DropDownOpened += new System.EventHandler(this.MovieEndSubMenu_DropDownOpened);
-			// 
-			// MovieEndFinishMenuItem
-			// 
-			this.MovieEndFinishMenuItem.Text = "Switch to Finished";
-			this.MovieEndFinishMenuItem.Click += new System.EventHandler(this.MovieEndFinishMenuItem_Click);
-			// 
-			// MovieEndRecordMenuItem
-			// 
-			this.MovieEndRecordMenuItem.Text = "Switch To Record";
-			this.MovieEndRecordMenuItem.Click += new System.EventHandler(this.MovieEndRecordMenuItem_Click);
-			// 
-			// MovieEndStopMenuItem
-			// 
-			this.MovieEndStopMenuItem.Text = "Stop";
-			this.MovieEndStopMenuItem.Click += new System.EventHandler(this.MovieEndStopMenuItem_Click);
-			// 
-			// MovieEndPauseMenuItem
-			// 
-			this.MovieEndPauseMenuItem.Text = "Pause";
-			this.MovieEndPauseMenuItem.Click += new System.EventHandler(this.MovieEndPauseMenuItem_Click);
-			// 
-			// AVSubMenu
-			// 
-			this.AVSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.RecordAVMenuItem,
-			this.ConfigAndRecordAVMenuItem,
-			this.StopAVIMenuItem,
-			this.toolStripSeparator19,
-			this.CaptureOSDMenuItem,
-			this.CaptureLuaMenuItem,
-			this.SynclessRecordingMenuItem});
-			this.AVSubMenu.Text = "&AVI/WAV";
-			this.AVSubMenu.DropDownOpened += new System.EventHandler(this.AVSubMenu_DropDownOpened);
-			// 
-			// RecordAVMenuItem
-			// 
-			this.RecordAVMenuItem.Text = "&Record AVI/WAV";
-			this.RecordAVMenuItem.Click += new System.EventHandler(this.RecordAVMenuItem_Click);
-			// 
-			// ConfigAndRecordAVMenuItem
-			// 
-			this.ConfigAndRecordAVMenuItem.Text = "Config and Record AVI/WAV...";
-			this.ConfigAndRecordAVMenuItem.Click += new System.EventHandler(this.ConfigAndRecordAVMenuItem_Click);
-			// 
-			// StopAVIMenuItem
-			// 
-			this.StopAVIMenuItem.Text = "&Stop AVI/WAV";
-			this.StopAVIMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
-			// 
-			// CaptureOSDMenuItem
-			// 
-			this.CaptureOSDMenuItem.CheckOnClick = true;
-			this.CaptureOSDMenuItem.Text = "Capture OSD";
-			this.CaptureOSDMenuItem.Click += new System.EventHandler(this.CaptureOSDMenuItem_Click);
-			// 
-			// CaptureLuaMenuItem
-			// 
-			this.CaptureLuaMenuItem.CheckOnClick = true;
-			this.CaptureLuaMenuItem.Name = "CaptureLuaMenuItem";
-			this.CaptureLuaMenuItem.Size = new System.Drawing.Size(225, 22);
-			this.CaptureLuaMenuItem.Text = "Capture Lua";
-			this.CaptureLuaMenuItem.Click += new System.EventHandler(this.CaptureLuaMenuItem_Click);
-			// 
-			// SynclessRecordingMenuItem
-			// 
-			this.SynclessRecordingMenuItem.Text = "S&yncless Recording Tools";
-			// 
-			// ScreenshotSubMenu
-			// 
-			this.ScreenshotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ScreenshotMenuItem,
-			this.ScreenshotAsMenuItem,
-			this.ScreenshotClipboardMenuItem,
-			this.ScreenshotClientClipboardMenuItem,
-			this.toolStripSeparator20,
-			this.ScreenshotCaptureOSDMenuItem1});
-			this.ScreenshotSubMenu.Text = "Scree&nshot";
-			this.ScreenshotSubMenu.DropDownOpening += new System.EventHandler(this.ScreenshotSubMenu_DropDownOpening);
-			// 
-			// ScreenshotMenuItem
-			// 
-			this.ScreenshotMenuItem.Text = "Screenshot";
-			this.ScreenshotMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
-			// 
-			// ScreenshotAsMenuItem
-			// 
-			this.ScreenshotAsMenuItem.Text = "Screenshot As...";
-			this.ScreenshotAsMenuItem.Click += new System.EventHandler(this.ScreenshotAsMenuItem_Click);
-			// 
-			// ScreenshotClipboardMenuItem
-			// 
-			this.ScreenshotClipboardMenuItem.Text = "Screenshot (raw) -> Clipboard";
-			this.ScreenshotClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClipboardMenuItem_Click);
-			// 
-			// ScreenshotClientClipboardMenuItem
-			// 
-			this.ScreenshotClientClipboardMenuItem.Text = "Screenshot (client) -> Clipboard";
-			this.ScreenshotClientClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClientClipboardMenuItem_Click);
-			// 
-			// ScreenshotCaptureOSDMenuItem1
-			// 
-			this.ScreenshotCaptureOSDMenuItem1.Text = "Capture OSD";
-			this.ScreenshotCaptureOSDMenuItem1.Click += new System.EventHandler(this.ScreenshotCaptureOSDMenuItem_Click);
-			// 
-			// ExitMenuItem
-			// 
-			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.ExitMenuItem.Text = "E&xit";
-			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
-			// 
-			// EmulationSubMenu
-			// 
-			this.EmulationSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.PauseMenuItem,
-			this.RebootCoreMenuItem,
-			this.toolStripSeparator1,
-			this.SoftResetMenuItem,
-			this.HardResetMenuItem,
-			this.EmulatorMenuSeparator2,
-			this.LoadedCoreNameMenuItem});
-			this.EmulationSubMenu.Text = "&Emulation";
-			this.EmulationSubMenu.DropDownOpened += new System.EventHandler(this.EmulationMenuItem_DropDownOpened);
-			// 
-			// PauseMenuItem
-			// 
-			this.PauseMenuItem.Text = "&Pause";
-			this.PauseMenuItem.Click += new System.EventHandler(this.PauseMenuItem_Click);
-			// 
-			// RebootCoreMenuItem
-			// 
-			this.RebootCoreMenuItem.Text = "&Reboot Core";
-			this.RebootCoreMenuItem.Click += new System.EventHandler(this.PowerMenuItem_Click);
-			// 
-			// SoftResetMenuItem
-			// 
-			this.SoftResetMenuItem.Text = "&Soft Reset";
-			this.SoftResetMenuItem.Click += new System.EventHandler(this.SoftResetMenuItem_Click);
-			// 
-			// HardResetMenuItem
-			// 
-			this.HardResetMenuItem.Text = "&Hard Reset";
-			this.HardResetMenuItem.Click += new System.EventHandler(this.HardResetMenuItem_Click);
-			// 
-			// LoadedCoreNameMenuItem
-			// 
-			this.LoadedCoreNameMenuItem.Enabled = false;
-			this.LoadedCoreNameMenuItem.Text = "Loaded core: <core name> (sysID)";
-			// 
-			// ViewSubMenu
-			// 
-			this.ViewSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.WindowSizeSubMenu,
-			this.SwitchToFullscreenMenuItem,
-			this.toolStripSeparator2,
-			this.DisplayFPSMenuItem,
-			this.DisplayFrameCounterMenuItem,
-			this.DisplayLagCounterMenuItem,
-			this.DisplayInputMenuItem,
-			this.DisplayRerecordCountMenuItem,
-			this.DisplaySubtitlesMenuItem,
-			this.toolStripMenuItem4,
-			this.DisplayStatusBarMenuItem,
-			this.DisplayMessagesMenuItem,
-			this.toolStripSeparator8,
-			this.DisplayLogWindowMenuItem});
-			this.ViewSubMenu.Text = "&View";
-			this.ViewSubMenu.DropDownOpened += new System.EventHandler(this.ViewSubMenu_DropDownOpened);
-			// 
-			// WindowSizeSubMenu
-			// 
-			this.WindowSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.x1MenuItem,
-			this.x2MenuItem,
-			this.x3MenuItem,
-			this.x4MenuItem,
-			this.x5MenuItem,
-			this.mzMenuItem});
-			this.WindowSizeSubMenu.Text = "&Window Size";
-			this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
-			// 
-			// x1MenuItem
-			// 
-			this.x1MenuItem.Text = "&1x";
-			this.x1MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x2MenuItem
-			// 
-			this.x2MenuItem.Text = "&2x";
-			this.x2MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x3MenuItem
-			// 
-			this.x3MenuItem.Text = "&3x";
-			this.x3MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x4MenuItem
-			// 
-			this.x4MenuItem.Text = "&4x";
-			this.x4MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x5MenuItem
-			// 
-			this.x5MenuItem.Text = "&5x";
-			this.x5MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// mzMenuItem
-			// 
-			this.mzMenuItem.Text = "1&0x";
-			this.mzMenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// SwitchToFullscreenMenuItem
-			// 
-			this.SwitchToFullscreenMenuItem.Text = "Switch to Fullscreen";
-			this.SwitchToFullscreenMenuItem.Click += new System.EventHandler(this.SwitchToFullscreenMenuItem_Click);
-			// 
-			// DisplayFPSMenuItem
-			// 
-			this.DisplayFPSMenuItem.Text = "Display FPS";
-			this.DisplayFPSMenuItem.Click += new System.EventHandler(this.DisplayFpsMenuItem_Click);
-			// 
-			// DisplayFrameCounterMenuItem
-			// 
-			this.DisplayFrameCounterMenuItem.Text = "Display Frame Count";
-			this.DisplayFrameCounterMenuItem.Click += new System.EventHandler(this.DisplayFrameCounterMenuItem_Click);
-			// 
-			// DisplayLagCounterMenuItem
-			// 
-			this.DisplayLagCounterMenuItem.Text = "Display Lag Frame Count";
-			this.DisplayLagCounterMenuItem.Click += new System.EventHandler(this.DisplayLagCounterMenuItem_Click);
-			// 
-			// DisplayInputMenuItem
-			// 
-			this.DisplayInputMenuItem.Text = "Display Input";
-			this.DisplayInputMenuItem.Click += new System.EventHandler(this.DisplayInputMenuItem_Click);
-			// 
-			// DisplayRerecordCountMenuItem
-			// 
-			this.DisplayRerecordCountMenuItem.Text = "Display Rerecord Count";
-			this.DisplayRerecordCountMenuItem.Click += new System.EventHandler(this.DisplayRerecordsMenuItem_Click);
-			// 
-			// DisplaySubtitlesMenuItem
-			// 
-			this.DisplaySubtitlesMenuItem.Text = "Display Subtitles";
-			this.DisplaySubtitlesMenuItem.Click += new System.EventHandler(this.DisplaySubtitlesMenuItem_Click);
-			// 
-			// DisplayStatusBarMenuItem
-			// 
-			this.DisplayStatusBarMenuItem.Text = "Display Status Bar";
-			this.DisplayStatusBarMenuItem.Click += new System.EventHandler(this.DisplayStatusBarMenuItem_Click);
-			// 
-			// DisplayMessagesMenuItem
-			// 
-			this.DisplayMessagesMenuItem.Text = "Display Messages";
-			this.DisplayMessagesMenuItem.Click += new System.EventHandler(this.DisplayMessagesMenuItem_Click);
-			// 
-			// DisplayLogWindowMenuItem
-			// 
-			this.DisplayLogWindowMenuItem.Text = "Open &Log Window...";
-			this.DisplayLogWindowMenuItem.Click += new System.EventHandler(this.DisplayLogWindowMenuItem_Click);
-			// 
-			// ConfigSubMenu
-			// 
-			this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ControllersMenuItem,
-			this.HotkeysMenuItem,
-			this.DisplayConfigMenuItem,
-			this.SoundMenuItem,
-			this.PathsMenuItem,
-			this.FirmwaresMenuItem,
-			this.MessagesMenuItem,
-			this.AutofireMenuItem,
-			this.RewindOptionsMenuItem,
-			this.extensionsToolStripMenuItem,
-			this.ClientOptionsMenuItem,
-			this.ProfilesMenuItem,
-			this.toolStripSeparator9,
-			this.SpeedSkipSubMenu,
-			this.KeyPrioritySubMenu,
-			this.CoresSubMenu,
-			this.toolStripSeparator10,
-			this.SaveConfigMenuItem,
-			this.SaveConfigAsMenuItem,
-			this.LoadConfigMenuItem,
-			this.LoadConfigFromMenuItem});
-			this.ConfigSubMenu.Text = "&Config";
-			this.ConfigSubMenu.DropDownOpened += new System.EventHandler(this.ConfigSubMenu_DropDownOpened);
-			// 
-			// ControllersMenuItem
-			// 
-			this.ControllersMenuItem.Text = "&Controllers...";
-			this.ControllersMenuItem.Click += new System.EventHandler(this.ControllersMenuItem_Click);
-			// 
-			// HotkeysMenuItem
-			// 
-			this.HotkeysMenuItem.Text = "&Hotkeys...";
-			this.HotkeysMenuItem.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
-			// 
-			// DisplayConfigMenuItem
-			// 
-			this.DisplayConfigMenuItem.Text = "Display...";
-			this.DisplayConfigMenuItem.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
-			// 
-			// SoundMenuItem
-			// 
-			this.SoundMenuItem.Text = "&Sound...";
-			this.SoundMenuItem.Click += new System.EventHandler(this.SoundMenuItem_Click);
-			// 
-			// PathsMenuItem
-			// 
-			this.PathsMenuItem.Text = "Paths...";
-			this.PathsMenuItem.Click += new System.EventHandler(this.PathsMenuItem_Click);
-			// 
-			// FirmwaresMenuItem
-			// 
-			this.FirmwaresMenuItem.Text = "&Firmwares...";
-			this.FirmwaresMenuItem.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
-			// 
-			// MessagesMenuItem
-			// 
-			this.MessagesMenuItem.Text = "&Messages...";
-			this.MessagesMenuItem.Click += new System.EventHandler(this.MessagesMenuItem_Click);
-			// 
-			// AutofireMenuItem
-			// 
-			this.AutofireMenuItem.Text = "&Autofire...";
-			this.AutofireMenuItem.Click += new System.EventHandler(this.AutofireMenuItem_Click);
-			// 
-			// RewindOptionsMenuItem
-			// 
-			this.RewindOptionsMenuItem.Text = "&Rewind && States...";
-			this.RewindOptionsMenuItem.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
-			// 
-			// extensionsToolStripMenuItem
-			// 
-			this.extensionsToolStripMenuItem.Text = "File Extensions...";
-			this.extensionsToolStripMenuItem.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
-			// 
-			// ClientOptionsMenuItem
-			// 
-			this.ClientOptionsMenuItem.Text = "&Customize...";
-			this.ClientOptionsMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
-			// 
-			// ProfilesMenuItem
-			// 
-			this.ProfilesMenuItem.Text = "&Profiles...";
-			this.ProfilesMenuItem.Click += new System.EventHandler(this.ProfilesMenuItem_Click);
-			// 
-			// SpeedSkipSubMenu
-			// 
-			this.SpeedSkipSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ClockThrottleMenuItem,
-			this.AudioThrottleMenuItem,
-			this.VsyncThrottleMenuItem,
-			this.toolStripSeparator27,
-			this.VsyncEnabledMenuItem,
-			this.toolStripMenuItem3,
-			this.miUnthrottled,
-			this.MinimizeSkippingMenuItem,
-			this.NeverSkipMenuItem,
-			this.toolStripMenuItem17,
-			this.toolStripMenuItem5,
-			this.Speed50MenuItem,
-			this.Speed75MenuItem,
-			this.Speed100MenuItem,
-			this.Speed150MenuItem,
-			this.Speed200MenuItem,
-			this.Speed400MenuItem});
-			this.SpeedSkipSubMenu.Text = "Speed/Skip";
-			this.SpeedSkipSubMenu.DropDownOpened += new System.EventHandler(this.FrameSkipMenuItem_DropDownOpened);
-			// 
-			// ClockThrottleMenuItem
-			// 
-			this.ClockThrottleMenuItem.Text = "Clock Throttle";
-			this.ClockThrottleMenuItem.Click += new System.EventHandler(this.ClockThrottleMenuItem_Click);
-			// 
-			// AudioThrottleMenuItem
-			// 
-			this.AudioThrottleMenuItem.Text = "Audio Throttle";
-			this.AudioThrottleMenuItem.Click += new System.EventHandler(this.AudioThrottleMenuItem_Click);
-			// 
-			// VsyncThrottleMenuItem
-			// 
-			this.VsyncThrottleMenuItem.Text = "VSync Throttle";
-			this.VsyncThrottleMenuItem.Click += new System.EventHandler(this.VsyncThrottleMenuItem_Click);
-			// 
-			// VsyncEnabledMenuItem
-			// 
-			this.VsyncEnabledMenuItem.Text = "VSync Enabled";
-			this.VsyncEnabledMenuItem.Click += new System.EventHandler(this.VsyncEnabledMenuItem_Click);
-			// 
-			// miUnthrottled
-			// 
-			this.miUnthrottled.Text = "Unthrottled";
-			this.miUnthrottled.Click += new System.EventHandler(this.UnthrottledMenuItem_Click);
-			// 
-			// MinimizeSkippingMenuItem
-			// 
-			this.MinimizeSkippingMenuItem.Text = "Auto-minimize skipping";
-			this.MinimizeSkippingMenuItem.Click += new System.EventHandler(this.MinimizeSkippingMenuItem_Click);
-			// 
-			// NeverSkipMenuItem
-			// 
-			this.NeverSkipMenuItem.Text = "Skip 0 (never)";
-			this.NeverSkipMenuItem.Click += new System.EventHandler(this.NeverSkipMenuItem_Click);
-			// 
-			// toolStripMenuItem17
-			// 
-			this.toolStripMenuItem17.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.Frameskip1MenuItem,
-			this.Frameskip2MenuItem,
-			this.Frameskip3MenuItem,
-			this.Frameskip4MenuItem,
-			this.Frameskip5MenuItem,
-			this.Frameskip6MenuItem,
-			this.Frameskip7MenuItem,
-			this.Frameskip8MenuItem,
-			this.Frameskip9MenuItem});
-			this.toolStripMenuItem17.Text = "Skip 1..9";
-			// 
-			// Frameskip1MenuItem
-			// 
-			this.Frameskip1MenuItem.Text = "1";
-			this.Frameskip1MenuItem.Click += new System.EventHandler(this.Frameskip1MenuItem_Click);
-			// 
-			// Frameskip2MenuItem
-			// 
-			this.Frameskip2MenuItem.Text = "2";
-			this.Frameskip2MenuItem.Click += new System.EventHandler(this.Frameskip2MenuItem_Click);
-			// 
-			// Frameskip3MenuItem
-			// 
-			this.Frameskip3MenuItem.Text = "3";
-			this.Frameskip3MenuItem.Click += new System.EventHandler(this.Frameskip3MenuItem_Click);
-			// 
-			// Frameskip4MenuItem
-			// 
-			this.Frameskip4MenuItem.Text = "4";
-			this.Frameskip4MenuItem.Click += new System.EventHandler(this.Frameskip4MenuItem_Click);
-			// 
-			// Frameskip5MenuItem
-			// 
-			this.Frameskip5MenuItem.Text = "5";
-			this.Frameskip5MenuItem.Click += new System.EventHandler(this.Frameskip5MenuItem_Click);
-			// 
-			// Frameskip6MenuItem
-			// 
-			this.Frameskip6MenuItem.Text = "6";
-			this.Frameskip6MenuItem.Click += new System.EventHandler(this.Frameskip6MenuItem_Click);
-			// 
-			// Frameskip7MenuItem
-			// 
-			this.Frameskip7MenuItem.Text = "7";
-			this.Frameskip7MenuItem.Click += new System.EventHandler(this.Frameskip7MenuItem_Click);
-			// 
-			// Frameskip8MenuItem
-			// 
-			this.Frameskip8MenuItem.Text = "8";
-			this.Frameskip8MenuItem.Click += new System.EventHandler(this.Frameskip8MenuItem_Click);
-			// 
-			// Frameskip9MenuItem
-			// 
-			this.Frameskip9MenuItem.Text = "9";
-			this.Frameskip9MenuItem.Click += new System.EventHandler(this.Frameskip9MenuItem_Click);
-			// 
-			// Speed50MenuItem
-			// 
-			this.Speed50MenuItem.Text = "Speed 50%";
-			this.Speed50MenuItem.Click += new System.EventHandler(this.Speed50MenuItem_Click);
-			// 
-			// Speed75MenuItem
-			// 
-			this.Speed75MenuItem.Text = "Speed 75%";
-			this.Speed75MenuItem.Click += new System.EventHandler(this.Speed75MenuItem_Click);
-			// 
-			// Speed100MenuItem
-			// 
-			this.Speed100MenuItem.Text = "Speed 100%";
-			this.Speed100MenuItem.Click += new System.EventHandler(this.Speed100MenuItem_Click);
-			// 
-			// Speed150MenuItem
-			// 
-			this.Speed150MenuItem.Text = "Speed 150%";
-			this.Speed150MenuItem.Click += new System.EventHandler(this.Speed150MenuItem_Click);
-			// 
-			// Speed200MenuItem
-			// 
-			this.Speed200MenuItem.Text = "Speed 200%";
-			this.Speed200MenuItem.Click += new System.EventHandler(this.Speed200MenuItem_Click);
-			// 
-			// Speed400MenuItem
-			// 
-			this.Speed400MenuItem.Text = "Speed 400%";
-			this.Speed400MenuItem.Click += new System.EventHandler(this.Speed400MenuItem_Click);
-			// 
-			// KeyPrioritySubMenu
-			// 
-			this.KeyPrioritySubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.BothHkAndControllerMenuItem,
-			this.InputOverHkMenuItem,
-			this.HkOverInputMenuItem});
-			this.KeyPrioritySubMenu.Text = "Key Priority";
-			this.KeyPrioritySubMenu.DropDownOpened += new System.EventHandler(this.KeyPriorityMenuItem_DropDownOpened);
-			// 
-			// BothHkAndControllerMenuItem
-			// 
-			this.BothHkAndControllerMenuItem.Text = "Both Hotkeys and Controllers";
-			this.BothHkAndControllerMenuItem.Click += new System.EventHandler(this.BothHkAndControllerMenuItem_Click);
-			// 
-			// InputOverHkMenuItem
-			// 
-			this.InputOverHkMenuItem.Text = "Input overrides Hotkeys";
-			this.InputOverHkMenuItem.Click += new System.EventHandler(this.InputOverHkMenuItem_Click);
-			// 
-			// HkOverInputMenuItem
-			// 
-			this.HkOverInputMenuItem.Text = "Hotkeys override Input";
-			this.HkOverInputMenuItem.Click += new System.EventHandler(this.HkOverInputMenuItem_Click);
-			// 
-			// CoresSubMenu
-			// 
-			this.CoresSubMenu.Text = "Preferred Cores";
-			// 
-			// SaveConfigMenuItem
-			// 
-			this.SaveConfigMenuItem.Text = "Save Config";
-			this.SaveConfigMenuItem.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
-			// 
-			// SaveConfigAsMenuItem
-			// 
-			this.SaveConfigAsMenuItem.Text = "Save Config As...";
-			this.SaveConfigAsMenuItem.Click += new System.EventHandler(this.SaveConfigAsMenuItem_Click);
-			// 
-			// LoadConfigMenuItem
-			// 
-			this.LoadConfigMenuItem.Text = "Load Config";
-			this.LoadConfigMenuItem.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
-			// 
-			// LoadConfigFromMenuItem
-			// 
-			this.LoadConfigFromMenuItem.Text = "Load Config From...";
-			this.LoadConfigFromMenuItem.Click += new System.EventHandler(this.LoadConfigFromMenuItem_Click);
-			// 
-			// ToolsSubMenu
-			// 
-			this.ToolsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ToolBoxMenuItem,
-			this.toolStripSeparator12,
-			this.RamWatchMenuItem,
-			this.RamSearchMenuItem,
-			this.LuaConsoleMenuItem,
-			this.TAStudioMenuItem,
-			this.HexEditorMenuItem,
-			this.TraceLoggerMenuItem,
-			this.DebuggerMenuItem,
-			this.CodeDataLoggerMenuItem,
-			this.MacroToolMenuItem,
-			this.VirtualPadMenuItem,
-			this.BasicBotMenuItem,
-			this.toolStripSeparator11,
-			this.CheatsMenuItem,
-			this.GameSharkConverterMenuItem,
-			this.toolStripSeparator29,
-			this.MultiDiskBundlerFileMenuItem,
-			this.BatchRunnerMenuItem,
-			this.ExternalToolMenuItem,
-			this.RetroAchievementsMenuItem});
-			this.ToolsSubMenu.Text = "&Tools";
-			this.ToolsSubMenu.DropDownOpened += new System.EventHandler(this.ToolsSubMenu_DropDownOpened);
-			// 
-			// ToolBoxMenuItem
-			// 
-			this.ToolBoxMenuItem.Text = "&Tool Box";
-			this.ToolBoxMenuItem.Click += new System.EventHandler(this.ToolBoxMenuItem_Click);
-			// 
-			// RamWatchMenuItem
-			// 
-			this.RamWatchMenuItem.Text = "RAM &Watch";
-			this.RamWatchMenuItem.Click += new System.EventHandler(this.RamWatchMenuItem_Click);
-			// 
-			// RamSearchMenuItem
-			// 
-			this.RamSearchMenuItem.Text = "RAM &Search";
-			this.RamSearchMenuItem.Click += new System.EventHandler(this.RamSearchMenuItem_Click);
-			// 
-			// LuaConsoleMenuItem
-			// 
-			this.LuaConsoleMenuItem.Text = "Lua Console";
-			this.LuaConsoleMenuItem.Click += new System.EventHandler(this.LuaConsoleMenuItem_Click);
-			// 
-			// TAStudioMenuItem
-			// 
-			this.TAStudioMenuItem.Text = "&TAStudio";
-			this.TAStudioMenuItem.Click += new System.EventHandler(this.TAStudioMenuItem_Click);
-			// 
-			// HexEditorMenuItem
-			// 
-			this.HexEditorMenuItem.Text = "&Hex Editor";
-			this.HexEditorMenuItem.Click += new System.EventHandler(this.HexEditorMenuItem_Click);
-			// 
-			// TraceLoggerMenuItem
-			// 
-			this.TraceLoggerMenuItem.Text = "Trace &Logger";
-			this.TraceLoggerMenuItem.Click += new System.EventHandler(this.TraceLoggerMenuItem_Click);
-			// 
-			// DebuggerMenuItem
-			// 
-			this.DebuggerMenuItem.Text = "&Debugger";
-			this.DebuggerMenuItem.Click += new System.EventHandler(this.DebuggerMenuItem_Click);
-			// 
-			// CodeDataLoggerMenuItem
-			// 
-			this.CodeDataLoggerMenuItem.Text = "Code-Data Logger";
-			this.CodeDataLoggerMenuItem.Click += new System.EventHandler(this.CodeDataLoggerMenuItem_Click);
-			// 
-			// MacroToolMenuItem
-			// 
-			this.MacroToolMenuItem.Text = "&Macro Tool";
-			this.MacroToolMenuItem.Click += new System.EventHandler(this.MacroToolMenuItem_Click);
-			// 
-			// VirtualPadMenuItem
-			// 
-			this.VirtualPadMenuItem.Text = "Virtual Pad";
-			this.VirtualPadMenuItem.Click += new System.EventHandler(this.VirtualPadMenuItem_Click);
-			// 
-			// BasicBotMenuItem
-			// 
-			this.BasicBotMenuItem.Text = "Basic Bot";
-			this.BasicBotMenuItem.Click += new System.EventHandler(this.BasicBotMenuItem_Click);
-			// 
-			// RetroAchievementsMenuItem
-			// 
-			this.RetroAchievementsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			StartRetroAchievementsMenuItem});
-			this.RetroAchievementsMenuItem.Text = "&RetroAchievements";
-			// 
-			// StartRetroAchievementsMenuItem
-			// 
-			this.StartRetroAchievementsMenuItem.Text = "&Start RetroAchievements";
-			this.StartRetroAchievementsMenuItem.Click += new System.EventHandler(this.StartRetroAchievementsMenuItem_Click);
-			// 
-			// CheatsMenuItem
-			// 
-			this.CheatsMenuItem.Text = "Cheats";
-			this.CheatsMenuItem.Click += new System.EventHandler(this.CheatsMenuItem_Click);
-			// 
-			// GameSharkConverterMenuItem
-			// 
-			this.GameSharkConverterMenuItem.Text = "Cheat Code Converter";
-			this.GameSharkConverterMenuItem.Click += new System.EventHandler(this.CheatCodeConverterMenuItem_Click);
-			// 
-			// MultiDiskBundlerFileMenuItem
-			// 
-			this.MultiDiskBundlerFileMenuItem.Text = "Multi-disk Bundler";
-			this.MultiDiskBundlerFileMenuItem.Click += new System.EventHandler(this.MultidiskBundlerMenuItem_Click);
-			// 
-			// ExternalToolMenuItem
-			// 
-			this.ExternalToolMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.dummyExternalTool});
-			this.ExternalToolMenuItem.Text = "External Tool";
-			this.ExternalToolMenuItem.DropDownOpening += new System.EventHandler(this.ExternalToolMenuItem_DropDownOpening);
-			// 
-			// dummyExternalTool
-			// 
-			this.dummyExternalTool.Text = "None";
-			// 
-			// BatchRunnerMenuItem
-			// 
-			this.BatchRunnerMenuItem.Text = "Batch Runner...";
-			this.BatchRunnerMenuItem.Visible = false;
-			this.BatchRunnerMenuItem.Click += new System.EventHandler(this.BatchRunnerMenuItem_Click);
-			// 
-			// NESSubMenu
-			// 
-			this.NESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.NESPPUViewerMenuItem,
-			this.NESNametableViewerMenuItem,
-			this.MusicRipperMenuItem,
-			this.toolStripSeparator17,
-			this.NesControllerSettingsMenuItem,
-			this.NESGraphicSettingsMenuItem,
-			this.NESSoundChannelsMenuItem,
-			this.VSSettingsMenuItem,
-			this.MovieSettingsMenuItem,
-			this.toolStripSeparator22,
-			this.FDSControlsMenuItem,
-			this.VSControlsMenuItem,
-			this.BarcodeReaderMenuItem});
-			this.NESSubMenu.Text = "&NES";
-			this.NESSubMenu.DropDownOpened += new System.EventHandler(this.NesSubMenu_DropDownOpened);
-			// 
-			// NESPPUViewerMenuItem
-			// 
-			this.NESPPUViewerMenuItem.Text = "&PPU Viewer";
-			this.NESPPUViewerMenuItem.Click += new System.EventHandler(this.NesPpuViewerMenuItem_Click);
-			// 
-			// NESNametableViewerMenuItem
-			// 
-			this.NESNametableViewerMenuItem.Text = "&Nametable Viewer";
-			this.NESNametableViewerMenuItem.Click += new System.EventHandler(this.NesNametableViewerMenuItem_Click);
-			// 
-			// MusicRipperMenuItem
-			// 
-			this.MusicRipperMenuItem.Text = "Music Ripper";
-			this.MusicRipperMenuItem.Click += new System.EventHandler(this.MusicRipperMenuItem_Click);
-			// 
-			// NesControllerSettingsMenuItem
-			// 
-			this.NesControllerSettingsMenuItem.Text = "Controller Settings...";
-			this.NesControllerSettingsMenuItem.Click += new System.EventHandler(this.NesControllerSettingsMenuItem_Click);
-			// 
-			// NESGraphicSettingsMenuItem
-			// 
-			this.NESGraphicSettingsMenuItem.Text = "Graphics Settings...";
-			this.NESGraphicSettingsMenuItem.Click += new System.EventHandler(this.NesGraphicSettingsMenuItem_Click);
-			// 
-			// NESSoundChannelsMenuItem
-			// 
-			this.NESSoundChannelsMenuItem.Text = "Sound Channels...";
-			this.NESSoundChannelsMenuItem.Click += new System.EventHandler(this.NesSoundChannelsMenuItem_Click);
-			// 
-			// VSSettingsMenuItem
-			// 
-			this.VSSettingsMenuItem.Text = "VS Settings...";
-			this.VSSettingsMenuItem.Click += new System.EventHandler(this.VsSettingsMenuItem_Click);
-			// 
-			// MovieSettingsMenuItem
-			// 
-			this.MovieSettingsMenuItem.Text = "Advanced Settings...";
-			this.MovieSettingsMenuItem.Click += new System.EventHandler(this.MovieSettingsMenuItem_Click);
-			// 
-			// FDSControlsMenuItem
-			// 
-			this.FDSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.FdsEjectDiskMenuItem});
-			this.FDSControlsMenuItem.Text = "FDS Controls";
-			this.FDSControlsMenuItem.DropDownOpened += new System.EventHandler(this.FdsControlsMenuItem_DropDownOpened);
-			// 
-			// FdsEjectDiskMenuItem
-			// 
-			this.FdsEjectDiskMenuItem.Text = "&Eject Disk";
-			this.FdsEjectDiskMenuItem.Click += new System.EventHandler(this.FdsEjectDiskMenuItem_Click);
-			// 
-			// VSControlsMenuItem
-			// 
-			this.VSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.VSInsertCoinP1MenuItem,
-			this.VSInsertCoinP2MenuItem,
-			this.VSServiceSwitchMenuItem});
-			this.VSControlsMenuItem.Text = "VS Controls";
-			// 
-			// VSInsertCoinP1MenuItem
-			// 
-			this.VSInsertCoinP1MenuItem.Text = "Insert Coin P1";
-			this.VSInsertCoinP1MenuItem.Click += new System.EventHandler(this.VsInsertCoinP1MenuItem_Click);
-			// 
-			// VSInsertCoinP2MenuItem
-			// 
-			this.VSInsertCoinP2MenuItem.Text = "Insert Coin P2";
-			this.VSInsertCoinP2MenuItem.Click += new System.EventHandler(this.VsInsertCoinP2MenuItem_Click);
-			// 
-			// VSServiceSwitchMenuItem
-			// 
-			this.VSServiceSwitchMenuItem.Text = "Service Switch";
-			this.VSServiceSwitchMenuItem.Click += new System.EventHandler(this.VsServiceSwitchMenuItem_Click);
-			// 
-			// BarcodeReaderMenuItem
-			// 
-			this.BarcodeReaderMenuItem.Text = "Barcode Reader";
-			this.BarcodeReaderMenuItem.Click += new System.EventHandler(this.BarcodeReaderMenuItem_Click);
-			// 
-			// TI83SubMenu
-			// 
-			this.TI83SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.KeypadMenuItem,
-			this.LoadTIFileMenuItem,
-			this.toolStripSeparator13,
-			this.paletteToolStripMenuItem});
-			this.TI83SubMenu.Text = "TI83";
-			// 
-			// KeypadMenuItem
-			// 
-			this.KeypadMenuItem.Text = "Keypad";
-			this.KeypadMenuItem.Click += new System.EventHandler(this.Ti83KeypadMenuItem_Click);
-			// 
-			// LoadTIFileMenuItem
-			// 
-			this.LoadTIFileMenuItem.Text = "Load TI-83 File...";
-			this.LoadTIFileMenuItem.Click += new System.EventHandler(this.Ti83LoadTIFileMenuItem_Click);
-			// 
-			// paletteToolStripMenuItem
-			// 
-			this.paletteToolStripMenuItem.Text = "Palette...";
-			this.paletteToolStripMenuItem.Click += new System.EventHandler(this.Ti83PaletteMenuItem_Click);
-			// 
-			// A7800SubMenu
-			// 
-			this.A7800SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.A7800ControllerSettingsMenuItem,
-			this.A7800FilterSettingsMenuItem});
-			this.A7800SubMenu.Text = "&A7800";
-			this.A7800SubMenu.DropDownOpened += new System.EventHandler(this.A7800SubMenu_DropDownOpened);
-			// 
-			// A7800ControllerSettingsMenuItem
-			// 
-			this.A7800ControllerSettingsMenuItem.Text = "Controller Settings";
-			this.A7800ControllerSettingsMenuItem.Click += new System.EventHandler(this.A7800ControllerSettingsMenuItem_Click);
-			// 
-			// A7800FilterSettingsMenuItem
-			// 
-			this.A7800FilterSettingsMenuItem.Text = "Filter Settings";
-			this.A7800FilterSettingsMenuItem.Click += new System.EventHandler(this.A7800FilterSettingsMenuItem_Click);
-			// 
-			// GBSubMenu
-			// 
-			this.GBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.GBcoreSettingsToolStripMenuItem,
-			this.SameBoyColorChooserMenuItem,
-			this.toolStripSeparator28,
-			this.GBGPUViewerMenuItem,
-			this.GBPrinterViewerMenuItem});
-			this.GBSubMenu.Text = "&GB";
-			// 
-			// GBcoreSettingsToolStripMenuItem
-			// 
-			this.GBcoreSettingsToolStripMenuItem.Text = "Settings...";
-			this.GBcoreSettingsToolStripMenuItem.Click += new System.EventHandler(this.GbCoreSettingsMenuItem_Click);
-			// 
-			// SameBoyColorChooserMenuItem
-			// 
-			this.SameBoyColorChooserMenuItem.Text = "&Choose Custom Palette...";
-			this.SameBoyColorChooserMenuItem.Click += new System.EventHandler(this.SameboyColorChooserMenuItem_Click);
-			// 
-			// GBGPUViewerMenuItem
-			// 
-			this.GBGPUViewerMenuItem.Text = "GPU Viewer";
-			this.GBGPUViewerMenuItem.Click += new System.EventHandler(this.GbGpuViewerMenuItem_Click);
-			// 
-			// GBPrinterViewerMenuItem
-			// 
-			this.GBPrinterViewerMenuItem.Text = "&Printer Viewer";
-			this.GBPrinterViewerMenuItem.Click += new System.EventHandler(this.GbPrinterViewerMenuItem_Click);
-			// 
-			// PSXSubMenu
-			// 
-			this.PSXSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.PSXControllerSettingsMenuItem,
-			this.PSXOptionsMenuItem,
-			this.PSXDiscControlsMenuItem,
-			this.PSXHashDiscsToolStripMenuItem});
-			this.PSXSubMenu.Text = "PSX";
-			this.PSXSubMenu.DropDownOpened += new System.EventHandler(this.PsxSubMenu_DropDownOpened);
-			// 
-			// PSXControllerSettingsMenuItem
-			// 
-			this.PSXControllerSettingsMenuItem.Text = "Controller / Memcard Settings";
-			this.PSXControllerSettingsMenuItem.Click += new System.EventHandler(this.PsxControllerSettingsMenuItem_Click);
-			// 
-			// PSXOptionsMenuItem
-			// 
-			this.PSXOptionsMenuItem.Text = "&Options";
-			this.PSXOptionsMenuItem.Click += new System.EventHandler(this.PsxOptionsMenuItem_Click);
-			// 
-			// PSXDiscControlsMenuItem
-			// 
-			this.PSXDiscControlsMenuItem.Text = "&Disc Controls";
-			this.PSXDiscControlsMenuItem.Click += new System.EventHandler(this.PsxDiscControlsMenuItem_Click);
-			// 
-			// PSXHashDiscsToolStripMenuItem
-			// 
-			this.PSXHashDiscsToolStripMenuItem.Text = "&Hash Discs";
-			this.PSXHashDiscsToolStripMenuItem.Click += new System.EventHandler(this.PsxHashDiscsMenuItem_Click);
-			// 
-			// SNESSubMenu
-			// 
-			this.SNESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.SNESControllerConfigurationMenuItem,
-			this.toolStripSeparator18,
-			this.SnesGfxDebuggerMenuItem,
-			this.SnesOptionsMenuItem});
-			this.SNESSubMenu.Text = "&SNES";
-			this.SNESSubMenu.DropDownOpened += new System.EventHandler(this.SnesSubMenu_DropDownOpened);
-			// 
-			// SNESControllerConfigurationMenuItem
-			// 
-			this.SNESControllerConfigurationMenuItem.Text = "Controller Configuration";
-			this.SNESControllerConfigurationMenuItem.Click += new System.EventHandler(this.SNESControllerConfigurationMenuItem_Click);
-			// 
-			// SnesGfxDebuggerMenuItem
-			// 
-			this.SnesGfxDebuggerMenuItem.Text = "Graphics Debugger";
-			this.SnesGfxDebuggerMenuItem.Click += new System.EventHandler(this.SnesGfxDebuggerMenuItem_Click);
-			// 
-			// SnesOptionsMenuItem
-			// 
-			this.SnesOptionsMenuItem.Text = "&Options";
-			this.SnesOptionsMenuItem.Click += new System.EventHandler(this.SnesOptionsMenuItem_Click);
-			// 
-			// ColecoSubMenu
-			// 
-			this.ColecoSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ColecoControllerSettingsMenuItem,
-			this.toolStripSeparator35,
-			this.ColecoSkipBiosMenuItem,
-			this.ColecoUseSGMMenuItem});
-			this.ColecoSubMenu.Text = "&Coleco";
-			this.ColecoSubMenu.DropDownOpened += new System.EventHandler(this.ColecoSubMenu_DropDownOpened);
-			// 
-			// ColecoControllerSettingsMenuItem
-			// 
-			this.ColecoControllerSettingsMenuItem.Text = "&Controller Settings...";
-			this.ColecoControllerSettingsMenuItem.Click += new System.EventHandler(this.ColecoControllerSettingsMenuItem_Click);
-			// 
-			// ColecoSkipBiosMenuItem
-			// 
-			this.ColecoSkipBiosMenuItem.Text = "&Skip BIOS intro (When Applicable)";
-			this.ColecoSkipBiosMenuItem.Click += new System.EventHandler(this.ColecoSkipBiosMenuItem_Click);
-			// 
-			// ColecoUseSGMMenuItem
-			// 
-			this.ColecoUseSGMMenuItem.Text = "&Use the Super Game Module";
-			this.ColecoUseSGMMenuItem.Click += new System.EventHandler(this.ColecoUseSGMMenuItem_Click);
-			// 
-			// N64SubMenu
-			// 
-			this.N64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.N64PluginSettingsMenuItem,
-			this.N64ControllerSettingsMenuItem,
-			this.toolStripSeparator23,
-			this.N64CircularAnalogRangeMenuItem,
-			this.MupenStyleLagMenuItem,
-			this.N64ExpansionSlotMenuItem});
-			this.N64SubMenu.Text = "N64";
-			this.N64SubMenu.DropDownOpened += new System.EventHandler(this.N64SubMenu_DropDownOpened);
-			// 
-			// N64PluginSettingsMenuItem
-			// 
-			this.N64PluginSettingsMenuItem.Text = "Plugins";
-			this.N64PluginSettingsMenuItem.Click += new System.EventHandler(this.N64PluginSettingsMenuItem_Click);
-			// 
-			// N64ControllerSettingsMenuItem
-			// 
-			this.N64ControllerSettingsMenuItem.Text = "Controller Settings...";
-			this.N64ControllerSettingsMenuItem.Click += new System.EventHandler(this.N64ControllerSettingsMenuItem_Click);
-			// 
-			// N64CircularAnalogRangeMenuItem
-			// 
-			this.N64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
-			this.N64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
-			// 
-			// MupenStyleLagMenuItem
-			// 
-			this.MupenStyleLagMenuItem.Text = "&Mupen Style Lag Frames";
-			this.MupenStyleLagMenuItem.Click += new System.EventHandler(this.MupenStyleLagMenuItem_Click);
-			// 
-			// N64ExpansionSlotMenuItem
-			// 
-			this.N64ExpansionSlotMenuItem.Text = "&Use Expansion Slot";
-			this.N64ExpansionSlotMenuItem.Click += new System.EventHandler(this.N64ExpansionSlotMenuItem_Click);
-			// 
-			// Ares64SubMenu
-			// 
-			this.Ares64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.Ares64SettingsMenuItem,
-			this.Ares64CircularAnalogRangeMenuItem});
-			this.Ares64SubMenu.Text = "N64";
-			this.Ares64SubMenu.DropDownOpened += new System.EventHandler(this.Ares64SubMenu_DropDownOpened);
-			// 
-			// Ares64SettingsMenuItem
-			// 
-			this.Ares64SettingsMenuItem.Text = "Settings...";
-			this.Ares64SettingsMenuItem.Click += new System.EventHandler(this.Ares64SettingsMenuItem_Click);
-			// 
-			// Ares64CircularAnalogRangeMenuItem
-			// 
-			this.Ares64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
-			this.Ares64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
-			// 
-			// GBLSubMenu
-			// 
-			this.GBLSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.GBLsettingsToolStripMenuItem});
-			this.GBLSubMenu.Text = "&GB Link";
-			// 
-			// GBLsettingsToolStripMenuItem
-			// 
-			this.GBLsettingsToolStripMenuItem.Text = "Settings...";
-			this.GBLsettingsToolStripMenuItem.Click += new System.EventHandler(this.GblSettingsMenuItem_Click);
-			// 
-			// AppleSubMenu
-			// 
-			this.AppleSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.AppleDisksSubMenu,
-			this.settingsToolStripMenuItem1});
-			this.AppleSubMenu.Text = "Apple";
-			this.AppleSubMenu.DropDownOpened += new System.EventHandler(this.AppleSubMenu_DropDownOpened);
-			// 
-			// AppleDisksSubMenu
-			// 
-			this.AppleDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripSeparator31});
-			this.AppleDisksSubMenu.Text = "Disks";
-			this.AppleDisksSubMenu.DropDownOpened += new System.EventHandler(this.AppleDisksSubMenu_DropDownOpened);
-			// 
-			// settingsToolStripMenuItem1
-			// 
-			this.settingsToolStripMenuItem1.Text = "&Settings...";
-			this.settingsToolStripMenuItem1.Click += new System.EventHandler(this.AppleIISettingsMenuItem_Click);
-			// 
-			// C64SubMenu
-			// 
-			this.C64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.C64DisksSubMenu,
-			this.C64SettingsMenuItem});
-			this.C64SubMenu.Text = "&C64";
-			this.C64SubMenu.DropDownOpened += new System.EventHandler(this.C64SubMenu_DropDownOpened);
-			// 
-			// C64DisksSubMenu
-			// 
-			this.C64DisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripSeparator36});
-			this.C64DisksSubMenu.Text = "Disks";
-			this.C64DisksSubMenu.DropDownOpened += new System.EventHandler(this.C64DisksSubMenu_DropDownOpened);
-			// 
-			// C64SettingsMenuItem
-			// 
-			this.C64SettingsMenuItem.Text = "&Settings...";
-			this.C64SettingsMenuItem.Click += new System.EventHandler(this.C64SettingsMenuItem_Click);
-			// 
-			// IntvSubMenu
-			// 
-			this.IntvSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.IntVControllerSettingsMenuItem});
-			this.IntvSubMenu.Text = "&Intv";
-			this.IntvSubMenu.DropDownOpened += new System.EventHandler(this.IntVSubMenu_DropDownOpened);
-			// 
-			// IntVControllerSettingsMenuItem
-			// 
-			this.IntVControllerSettingsMenuItem.Text = "Controller Settings...";
-			this.IntVControllerSettingsMenuItem.Click += new System.EventHandler(this.IntVControllerSettingsMenuItem_Click);
-			// 
-			// zXSpectrumToolStripMenuItem
-			// 
-			this.zXSpectrumToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ZXSpectrumCoreEmulationSettingsMenuItem,
-			this.ZXSpectrumControllerConfigurationMenuItem,
-			this.ZXSpectrumAudioSettingsMenuItem,
-			this.ZXSpectrumNonSyncSettingsMenuItem,
-			this.ZXSpectrumMediaMenuItem});
-			this.zXSpectrumToolStripMenuItem.Text = "ZX Spectrum";
-			// 
-			// ZXSpectrumCoreEmulationSettingsMenuItem
-			// 
-			this.ZXSpectrumCoreEmulationSettingsMenuItem.Text = "Core Emulation Settings";
-			this.ZXSpectrumCoreEmulationSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumCoreEmulationSettingsMenuItem_Click);
-			// 
-			// ZXSpectrumControllerConfigurationMenuItem
-			// 
-			this.ZXSpectrumControllerConfigurationMenuItem.Text = "Joystick Configuration";
-			this.ZXSpectrumControllerConfigurationMenuItem.Click += new System.EventHandler(this.ZXSpectrumControllerConfigurationMenuItem_Click);
-			// 
-			// ZXSpectrumAudioSettingsMenuItem
-			// 
-			this.ZXSpectrumAudioSettingsMenuItem.Text = "Audio Settings";
-			this.ZXSpectrumAudioSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumAudioSettingsMenuItem_Click);
-			// 
-			// ZXSpectrumNonSyncSettingsMenuItem
-			// 
-			this.ZXSpectrumNonSyncSettingsMenuItem.Text = "Non-Sync Settings";
-			this.ZXSpectrumNonSyncSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumNonSyncSettingsMenuItem_Click);
-			// 
-			// ZXSpectrumMediaMenuItem
-			// 
-			this.ZXSpectrumMediaMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ZXSpectrumTapesSubMenu,
-			this.ZXSpectrumDisksSubMenu,
-			this.ZXSpectrumExportSnapshotMenuItemMenuItem});
-			this.ZXSpectrumMediaMenuItem.Text = "Media";
-			this.ZXSpectrumMediaMenuItem.DropDownOpened += new System.EventHandler(this.ZXSpectrumMediaMenuItem_DropDownOpened);
-			// 
-			// ZXSpectrumTapesSubMenu
-			// 
-			this.ZXSpectrumTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.zxt1ToolStripMenuItem});
-			this.ZXSpectrumTapesSubMenu.Text = "Tapes";
-			this.ZXSpectrumTapesSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumTapesSubMenu_DropDownOpened);
-			// 
-			// zxt1ToolStripMenuItem
-			// 
-			this.zxt1ToolStripMenuItem.Text = "zxt1";
-			// 
-			// ZXSpectrumDisksSubMenu
-			// 
-			this.ZXSpectrumDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.zxt2ToolStripMenuItem});
-			this.ZXSpectrumDisksSubMenu.Text = "Disks";
-			this.ZXSpectrumDisksSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumDisksSubMenu_DropDownOpened);
-			// 
-			// zxt2ToolStripMenuItem
-			// 
-			this.zxt2ToolStripMenuItem.Text = "zxt2";
-			// 
-			// ZXSpectrumExportSnapshotMenuItemMenuItem
-			// 
-			this.ZXSpectrumExportSnapshotMenuItemMenuItem.Text = "Export Snapshot";
-			this.ZXSpectrumExportSnapshotMenuItemMenuItem.Click += new System.EventHandler(this.ZXSpectrumExportSnapshotMenuItemMenuItem_Click);
-			// 
-			// GenericCoreSubMenu
-			// 
-			this.GenericCoreSubMenu.Text = "&Core";
-			// 
-			// amstradCPCToolStripMenuItem
-			// 
-			this.amstradCPCToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.amstradCPCCoreEmulationSettingsToolStripMenuItem,
-			this.AmstradCPCAudioSettingsToolStripMenuItem,
-			this.AmstradCPCNonSyncSettingsToolStripMenuItem,
-			this.AmstradCPCMediaToolStripMenuItem});
-			this.amstradCPCToolStripMenuItem.Text = "Amstrad CPC";
-			// 
-			// amstradCPCCoreEmulationSettingsToolStripMenuItem
-			// 
-			this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Text = "Core Emulation Settings";
-			this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcCoreEmulationSettingsMenuItem_Click);
-			// 
-			// AmstradCPCAudioSettingsToolStripMenuItem
-			// 
-			this.AmstradCPCAudioSettingsToolStripMenuItem.Text = "Audio Settings";
-			this.AmstradCPCAudioSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcAudioSettingsMenuItem_Click);
-			// 
-			// AmstradCPCNonSyncSettingsToolStripMenuItem
-			// 
-			this.AmstradCPCNonSyncSettingsToolStripMenuItem.Text = "Non-Sync Settings";
-			this.AmstradCPCNonSyncSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcNonSyncSettingsMenuItem_Click);
-			// 
-			// AmstradCPCMediaToolStripMenuItem
-			// 
-			this.AmstradCPCMediaToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.AmstradCPCTapesSubMenu,
-			this.AmstradCPCDisksSubMenu});
-			this.AmstradCPCMediaToolStripMenuItem.Text = "Media";
-			this.AmstradCPCMediaToolStripMenuItem.DropDownOpened += new System.EventHandler(this.AmstradCpcMediaMenuItem_DropDownOpened);
-			// 
-			// AmstradCPCTapesSubMenu
-			// 
-			this.AmstradCPCTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.cpct1ToolStripMenuItem});
-			this.AmstradCPCTapesSubMenu.Text = "Tapes";
-			this.AmstradCPCTapesSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcTapesSubMenu_DropDownOpened);
-			// 
-			// cpct1ToolStripMenuItem
-			// 
-			this.cpct1ToolStripMenuItem.Text = "cpct1";
-			// 
-			// AmstradCPCDisksSubMenu
-			// 
-			this.AmstradCPCDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.cpcd1ToolStripMenuItem});
-			this.AmstradCPCDisksSubMenu.Text = "Disks";
-			this.AmstradCPCDisksSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcDisksSubMenu_DropDownOpened);
-			// 
-			// cpcd1ToolStripMenuItem
-			// 
-			this.cpcd1ToolStripMenuItem.Text = "cpcd1";
-			// 
-			// HelpSubMenu
-			// 
-			this.HelpSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.OnlineHelpMenuItem,
-			this.ForumsMenuItem,
-			this.FeaturesMenuItem,
-			this.AboutMenuItem});
-			this.HelpSubMenu.Text = "&Help";
-			this.HelpSubMenu.DropDownOpened += new System.EventHandler(this.HelpSubMenu_DropDownOpened);
-			// 
-			// OnlineHelpMenuItem
-			// 
-			this.OnlineHelpMenuItem.Text = "Open TASVideos Wiki in Browser";
-			this.OnlineHelpMenuItem.Click += new System.EventHandler(this.OnlineHelpMenuItem_Click);
-			// 
-			// ForumsMenuItem
-			// 
-			this.ForumsMenuItem.Text = "Open Forums in Browser";
-			this.ForumsMenuItem.Click += new System.EventHandler(this.ForumsMenuItem_Click);
-			// 
-			// FeaturesMenuItem
-			// 
-			this.FeaturesMenuItem.Text = "&Features";
-			this.FeaturesMenuItem.Click += new System.EventHandler(this.FeaturesMenuItem_Click);
-			// 
-			// AboutMenuItem
-			// 
-			this.AboutMenuItem.Text = "&About...";
-			this.AboutMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
-			// 
-			// A7800HawkCoreMenuItem
-			// 
-			this.A7800HawkCoreMenuItem.Text = "A7800Hawk";
-			// 
-			// MainStatusBar
-			// 
-			this.MainStatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.DumpStatusButton,
-			this.EmuStatus,
-			this.PlayRecordStatusButton,
-			this.PauseStatusButton,
-			this.RebootStatusBarIcon,
-			this.AVIStatusLabel,
-			this.LedLightStatusLabel,
-			this.SaveSlotsStatusLabel,
-			this.Slot1StatusButton,
-			this.Slot2StatusButton,
-			this.Slot3StatusButton,
-			this.Slot4StatusButton,
-			this.Slot5StatusButton,
-			this.Slot6StatusButton,
-			this.Slot7StatusButton,
-			this.Slot8StatusButton,
-			this.Slot9StatusButton,
-			this.Slot0StatusButton,
-			this.CheatStatusButton,
-			this.KeyPriorityStatusLabel,
-			this.CoreNameStatusBarButton,
-			this.ProfileFirstBootLabel,
-			this.LinkConnectStatusBarButton,
-			this.UpdateNotification});
-			this.MainStatusBar.Location = new System.Drawing.Point(0, 386);
-			this.MainStatusBar.Name = "MainStatusBar";
-			this.MainStatusBar.ShowItemToolTips = true;
-			this.MainStatusBar.SizingGrip = false;
-			this.MainStatusBar.TabIndex = 1;
-			// 
-			// DumpStatusButton
-			// 
-			this.DumpStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.DumpStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.DumpStatusButton.Name = "DumpStatusButton";
-			this.DumpStatusButton.ShowDropDownArrow = false;
-			this.DumpStatusButton.Size = new System.Drawing.Size(4, 20);
-			this.DumpStatusButton.Text = "No ROM loaded";
-			this.DumpStatusButton.Click += new System.EventHandler(this.DumpStatusButton_Click);
-			// 
-			// PlayRecordStatusButton
-			// 
-			this.PlayRecordStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.PlayRecordStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.PlayRecordStatusButton.Name = "PlayRecordStatusButton";
-			this.PlayRecordStatusButton.ShowDropDownArrow = false;
-			this.PlayRecordStatusButton.Size = new System.Drawing.Size(4, 20);
-			this.PlayRecordStatusButton.Text = "No movie is active";
-			// 
-			// PauseStatusButton
-			// 
-			this.PauseStatusButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.PauseStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.PauseStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.PauseStatusButton.Name = "PauseStatusButton";
-			this.PauseStatusButton.ShowDropDownArrow = false;
-			this.PauseStatusButton.Size = new System.Drawing.Size(4, 20);
-			this.PauseStatusButton.Text = "toolStripDropDownButton1";
-			this.PauseStatusButton.ToolTipText = "Emulator is paused";
-			this.PauseStatusButton.Click += new System.EventHandler(this.PauseMenuItem_Click);
-			// 
-			// RebootStatusBarIcon
-			// 
-			this.RebootStatusBarIcon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.RebootStatusBarIcon.RightToLeft = System.Windows.Forms.RightToLeft.No;
-			this.RebootStatusBarIcon.Text = "Reboot";
-			this.RebootStatusBarIcon.ToolTipText = "A reboot of the core is needed for a setting change to take effect";
-			this.RebootStatusBarIcon.Click += new System.EventHandler(this.PowerMenuItem_Click);
-			// 
-			// AVIStatusLabel
-			// 
-			this.AVIStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.AVIStatusLabel.Text = "AVI Capture";
-			// 
-			// LedLightStatusLabel
-			// 
-			this.LedLightStatusLabel.ToolTipText = "Disk Drive LED Light";
-			// 
-			// SaveSlotsStatusLabel
-			// 
-			this.SaveSlotsStatusLabel.BackColor = System.Drawing.SystemColors.Control;
-			this.SaveSlotsStatusLabel.Text = "Save slots";
-			// 
-			// Slot1StatusButton
-			// 
-			this.Slot1StatusButton.Text = "1";
-			this.Slot1StatusButton.ToolTipText = "Save slot 1";
-			this.Slot1StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-			// 
-			// Slot2StatusButton
-			// 
-			this.Slot2StatusButton.Text = "2";
-			this.Slot2StatusButton.ToolTipText = "Save slot 2";
-			this.Slot2StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-			// 
-			// Slot3StatusButton
-			// 
-			this.Slot3StatusButton.Text = "3";
-			this.Slot3StatusButton.ToolTipText = "Save slot 3";
-			this.Slot3StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-			// 
-			// Slot4StatusButton
-			// 
-			this.Slot4StatusButton.Text = "4";
-			this.Slot4StatusButton.ToolTipText = "Save slot 4";
-			this.Slot4StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-			// 
-			// Slot5StatusButton
-			// 
-			this.Slot5StatusButton.Text = "5";
-			this.Slot5StatusButton.ToolTipText = "Save slot 5";
-			this.Slot5StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-			// 
-			// Slot6StatusButton
-			// 
-			this.Slot6StatusButton.Text = "6";
-			this.Slot6StatusButton.ToolTipText = "Save slot 6";
-			this.Slot6StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-			// 
-			// Slot7StatusButton
-			// 
-			this.Slot7StatusButton.Text = "7";
-			this.Slot7StatusButton.ToolTipText = "Save slot 7";
-			this.Slot7StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-			// 
-			// Slot8StatusButton
-			// 
-			this.Slot8StatusButton.Text = "8";
-			this.Slot8StatusButton.ToolTipText = "Save slot 8";
-			this.Slot8StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-			// 
-			// Slot9StatusButton
-			// 
-			this.Slot9StatusButton.Text = "9";
-			this.Slot9StatusButton.ToolTipText = "Save slot 9";
-			this.Slot9StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-			// 
-			// Slot0StatusButton
-			// 
-			this.Slot0StatusButton.Text = "0";
-			this.Slot0StatusButton.ToolTipText = "Save slot 10";
-			this.Slot0StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-			// 
-			// CheatStatusButton
-			// 
-			this.CheatStatusButton.Click += new System.EventHandler(this.FreezeStatus_Click);
-			// 
-			// KeyPriorityStatusLabel
-			// 
-			this.KeyPriorityStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.KeyPriorityStatusLabel.Margin = new System.Windows.Forms.Padding(5, 3, 5, 0);
-			this.KeyPriorityStatusLabel.Text = "KeyPriority";
-			this.KeyPriorityStatusLabel.Click += new System.EventHandler(this.KeyPriorityStatusLabel_Click);
-			// 
-			// CoreNameStatusBarButton
-			// 
-			this.CoreNameStatusBarButton.Text = "<core name>";
-			// 
-			// ProfileFirstBootLabel
-			// 
-			this.ProfileFirstBootLabel.AutoToolTip = true;
-			this.ProfileFirstBootLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.ProfileFirstBootLabel.Text = "ProfileFirstBootLabel";
-			this.ProfileFirstBootLabel.ToolTipText = "Set up your profile before use";
-			this.ProfileFirstBootLabel.Visible = false;
-			this.ProfileFirstBootLabel.Click += new System.EventHandler(this.ProfileFirstBootLabel_Click);
-			// 
-			// LinkConnectStatusBarButton
-			// 
-			this.LinkConnectStatusBarButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.LinkConnectStatusBarButton.Text = "Link connection is currently enabled";
-			this.LinkConnectStatusBarButton.ToolTipText = "Link connection is currently enabled";
-			this.LinkConnectStatusBarButton.Click += new System.EventHandler(this.LinkConnectStatusBarButton_Click);
-			// 
-			// UpdateNotification
-			// 
-			this.UpdateNotification.IsLink = true;
-			this.UpdateNotification.LinkColor = System.Drawing.Color.Red;
-			this.UpdateNotification.Spring = true;
-			this.UpdateNotification.Text = "New version available!";
-			this.UpdateNotification.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.UpdateNotification.Click += new System.EventHandler(this.UpdateNotification_Click);
-			// 
-			// MainFormContextMenu
-			// 
-			this.MainFormContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.OpenRomContextMenuItem,
-			this.LoadLastRomContextMenuItem,
-			this.StopAVContextMenuItem,
-			this.ContextSeparator_AfterROM,
-			this.RecordMovieContextMenuItem,
-			this.PlayMovieContextMenuItem,
-			this.RestartMovieContextMenuItem,
-			this.StopMovieContextMenuItem,
-			this.LoadLastMovieContextMenuItem,
-			this.BackupMovieContextMenuItem,
-			this.StopNoSaveContextMenuItem,
-			this.ViewSubtitlesContextMenuItem,
-			this.AddSubtitleContextMenuItem,
-			this.ViewCommentsContextMenuItem,
-			this.SaveMovieContextMenuItem,
-			this.SaveMovieAsContextMenuItem,
-			this.ContextSeparator_AfterMovie,
-			this.UndoSavestateContextMenuItem,
-			this.ContextSeparator_AfterUndo,
-			this.ConfigContextMenuItem,
-			this.ScreenshotContextMenuItem,
-			this.CloseRomContextMenuItem,
-			this.ClearSRAMContextMenuItem,
-			this.ShowMenuContextMenuSeparator,
-			this.ShowMenuContextMenuItem});
-			this.MainFormContextMenu.Name = "contextMenuStrip1";
-			this.MainFormContextMenu.Size = new System.Drawing.Size(217, 490);
-			this.MainFormContextMenu.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.MainFormContextMenu_Closing);
-			this.MainFormContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.MainFormContextMenu_Opening);
-			// 
-			// OpenRomContextMenuItem
-			// 
-			this.OpenRomContextMenuItem.Text = "Open Rom";
-			this.OpenRomContextMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
-			// 
-			// LoadLastRomContextMenuItem
-			// 
-			this.LoadLastRomContextMenuItem.Text = "Load Last ROM";
-			this.LoadLastRomContextMenuItem.Click += new System.EventHandler(this.LoadLastRomContextMenuItem_Click);
-			// 
-			// StopAVContextMenuItem
-			// 
-			this.StopAVContextMenuItem.Text = "Stop AVI/WAV";
-			this.StopAVContextMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
-			// 
-			// RecordMovieContextMenuItem
-			// 
-			this.RecordMovieContextMenuItem.Text = "Record Movie";
-			this.RecordMovieContextMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
-			// 
-			// PlayMovieContextMenuItem
-			// 
-			this.PlayMovieContextMenuItem.Text = "Play Movie";
-			this.PlayMovieContextMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
-			// 
-			// RestartMovieContextMenuItem
-			// 
-			this.RestartMovieContextMenuItem.Text = "Restart Movie";
-			this.RestartMovieContextMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
-			// 
-			// StopMovieContextMenuItem
-			// 
-			this.StopMovieContextMenuItem.Text = "Stop Movie";
-			this.StopMovieContextMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
-			// 
-			// LoadLastMovieContextMenuItem
-			// 
-			this.LoadLastMovieContextMenuItem.Text = "Load Last Movie";
-			this.LoadLastMovieContextMenuItem.Click += new System.EventHandler(this.LoadLastMovieContextMenuItem_Click);
-			// 
-			// BackupMovieContextMenuItem
-			// 
-			this.BackupMovieContextMenuItem.Text = "Backup Movie";
-			this.BackupMovieContextMenuItem.Click += new System.EventHandler(this.BackupMovieContextMenuItem_Click);
-			// 
-			// StopNoSaveContextMenuItem
-			// 
-			this.StopNoSaveContextMenuItem.Text = "Stop Movie without Saving";
-			this.StopNoSaveContextMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
-			// 
-			// ViewSubtitlesContextMenuItem
-			// 
-			this.ViewSubtitlesContextMenuItem.Text = "View Subtitles";
-			this.ViewSubtitlesContextMenuItem.Click += new System.EventHandler(this.ViewSubtitlesContextMenuItem_Click);
-			// 
-			// AddSubtitleContextMenuItem
-			// 
-			this.AddSubtitleContextMenuItem.Text = "Add Subtitle";
-			this.AddSubtitleContextMenuItem.Click += new System.EventHandler(this.AddSubtitleContextMenuItem_Click);
-			// 
-			// ViewCommentsContextMenuItem
-			// 
-			this.ViewCommentsContextMenuItem.Text = "View Comments";
-			this.ViewCommentsContextMenuItem.Click += new System.EventHandler(this.ViewCommentsContextMenuItem_Click);
-			// 
-			// SaveMovieContextMenuItem
-			// 
-			this.SaveMovieContextMenuItem.Text = "Save Movie";
-			this.SaveMovieContextMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
-			// 
-			// SaveMovieAsContextMenuItem
-			// 
-			this.SaveMovieAsContextMenuItem.Text = "Save Movie As...";
-			this.SaveMovieAsContextMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
-			// 
-			// UndoSavestateContextMenuItem
-			// 
-			this.UndoSavestateContextMenuItem.Text = "Undo Savestate";
-			this.UndoSavestateContextMenuItem.Click += new System.EventHandler(this.UndoSavestateContextMenuItem_Click);
-			// 
-			// ConfigContextMenuItem
-			// 
-			this.ConfigContextMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripMenuItem6,
-			this.toolStripMenuItem7,
-			this.toolStripMenuItem8,
-			this.toolStripMenuItem9,
-			this.toolStripMenuItem10,
-			this.toolStripMenuItem11,
-			this.toolStripMenuItem12,
-			this.toolStripMenuItem13,
-			this.toolStripMenuItem14,
-			this.toolStripMenuItem15,
-			this.customizeToolStripMenuItem,
-			this.toolStripSeparator30,
-			this.toolStripMenuItem66,
-			this.toolStripMenuItem67});
-			this.ConfigContextMenuItem.Text = "Config";
-			// 
-			// toolStripMenuItem6
-			// 
-			this.toolStripMenuItem6.Text = "&Controllers...";
-			this.toolStripMenuItem6.Click += new System.EventHandler(this.ControllersMenuItem_Click);
-			// 
-			// toolStripMenuItem7
-			// 
-			this.toolStripMenuItem7.Text = "&Hotkeys...";
-			this.toolStripMenuItem7.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
-			// 
-			// toolStripMenuItem8
-			// 
-			this.toolStripMenuItem8.Text = "Display...";
-			this.toolStripMenuItem8.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
-			// 
-			// toolStripMenuItem9
-			// 
-			this.toolStripMenuItem9.Text = "&Sound...";
-			this.toolStripMenuItem9.Click += new System.EventHandler(this.SoundMenuItem_Click);
-			// 
-			// toolStripMenuItem10
-			// 
-			this.toolStripMenuItem10.Text = "Paths...";
-			this.toolStripMenuItem10.Click += new System.EventHandler(this.PathsMenuItem_Click);
-			// 
-			// toolStripMenuItem11
-			// 
-			this.toolStripMenuItem11.Text = "&Firmwares...";
-			this.toolStripMenuItem11.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
-			// 
-			// toolStripMenuItem12
-			// 
-			this.toolStripMenuItem12.Text = "&Messages...";
-			this.toolStripMenuItem12.Click += new System.EventHandler(this.MessagesMenuItem_Click);
-			// 
-			// toolStripMenuItem13
-			// 
-			this.toolStripMenuItem13.Text = "&Autofire...";
-			this.toolStripMenuItem13.Click += new System.EventHandler(this.AutofireMenuItem_Click);
-			// 
-			// toolStripMenuItem14
-			// 
-			this.toolStripMenuItem14.Text = "&Rewind...";
-			this.toolStripMenuItem14.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
-			// 
-			// toolStripMenuItem15
-			// 
-			this.toolStripMenuItem15.Text = "File Extensions...";
-			this.toolStripMenuItem15.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
-			// 
-			// customizeToolStripMenuItem
-			// 
-			this.customizeToolStripMenuItem.Text = "Customize...";
-			this.customizeToolStripMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
-			// 
-			// toolStripMenuItem66
-			// 
-			this.toolStripMenuItem66.Text = "Save Config";
-			this.toolStripMenuItem66.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
-			// 
-			// toolStripMenuItem67
-			// 
-			this.toolStripMenuItem67.Text = "Load Config";
-			this.toolStripMenuItem67.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
-			// 
-			// ScreenshotContextMenuItem
-			// 
-			this.ScreenshotContextMenuItem.Text = "Screenshot";
-			this.ScreenshotContextMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
-			// 
-			// CloseRomContextMenuItem
-			// 
-			this.CloseRomContextMenuItem.Text = "Close ROM";
-			this.CloseRomContextMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
-			// 
-			// ClearSRAMContextMenuItem
-			// 
-			this.ClearSRAMContextMenuItem.Text = "Close and Clear SRAM";
-			this.ClearSRAMContextMenuItem.Click += new System.EventHandler(this.ClearSramContextMenuItem_Click);
-			// 
-			// ShowMenuContextMenuItem
-			// 
-			this.ShowMenuContextMenuItem.Text = "Show Menu";
-			this.ShowMenuContextMenuItem.Click += new System.EventHandler(this.ShowMenuContextMenuItem_Click);
-			// 
-			// timerMouseIdle
-			// 
-			this.timerMouseIdle.Enabled = true;
-			this.timerMouseIdle.Interval = 2000;
-			this.timerMouseIdle.Tick += new System.EventHandler(this.TimerMouseIdle_Tick);
-			// 
-			// MainForm
-			// 
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-			this.ClientSize = new System.Drawing.Size(470, 408);
-			this.Controls.Add(this.MainStatusBar);
-			this.Controls.Add(this.MainformMenu);
-			this.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.MainMenuStrip = this.MainformMenu;
-			this.Name = "MainForm";
-			this.Activated += new System.EventHandler(this.MainForm_Activated);
-			this.Deactivate += new System.EventHandler(this.MainForm_Deactivate);
-			this.Load += new System.EventHandler(this.MainForm_Load);
-			this.Shown += new System.EventHandler(this.MainForm_Shown);
-			this.Enter += new System.EventHandler(this.MainForm_Enter);
-			this.Resize += new System.EventHandler(this.MainForm_Resize);
-			this.MainformMenu.ResumeLayout(false);
-			this.MainformMenu.PerformLayout();
-			this.MainStatusBar.ResumeLayout(false);
-			this.MainStatusBar.PerformLayout();
-			this.MainFormContextMenu.ResumeLayout(false);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.components = new System.ComponentModel.Container();
+            this.MainformMenu = new BizHawk.WinForms.Controls.MenuStripEx();
+            this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.OpenRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.RecentRomSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.OpenAdvancedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.CloseRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.SaveStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.SaveNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator24 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.AutosaveLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.LoadNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator21 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.AutoloadLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveSlotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectSlot1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectSlot2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectSlot3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectSlot4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectSlot5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectSlot6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectSlot7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectSlot8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectSlot9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectSlot0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PreviousSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.NextSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.SaveToCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveRAMSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.FlushSaveRAMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.MovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ReadonlyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator15 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.RecentMovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator16 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.RecordMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PlayMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.StopMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PlayFromBeginningMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ImportMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveMovieAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.StopMovieWithoutSavingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator14 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.AutomaticallyBackupMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.FullMovieLoadstatesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MovieEndSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MovieEndFinishMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MovieEndRecordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MovieEndStopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MovieEndPauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AVSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.RecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ConfigAndRecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.StopAVIMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator19 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.CaptureOSDMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.CaptureLuaMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.SynclessRecordingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ScreenshotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ScreenshotAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ScreenshotClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ScreenshotClientClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator20 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.ScreenshotCaptureOSDMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.EmulationSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.RebootCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.SoftResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.HardResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.EmulatorMenuSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.LoadedCoreNameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ViewSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.WindowSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.x1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.x2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.x3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.x4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.x5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.x6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.x7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.x8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.x9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.mzMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SwitchToFullscreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.DisplayFPSMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DisplayFrameCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DisplayLagCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DisplayInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DisplayRerecordCountMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DisplaySubtitlesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.DisplayStatusBarMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DisplayMessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.DisplayLogWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ControllersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.HotkeysMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DisplayConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SoundMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PathsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.FirmwaresMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AutofireMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.RewindOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.extensionsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ClientOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ProfilesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator9 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.SpeedSkipSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ClockThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AudioThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.VsyncThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator27 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.VsyncEnabledMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.miUnthrottled = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MinimizeSkippingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.NeverSkipMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem17 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Frameskip1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Frameskip2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Frameskip3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Frameskip4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Frameskip5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Frameskip6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Frameskip7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Frameskip8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Frameskip9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.Speed50MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Speed75MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Speed100MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Speed150MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Speed200MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Speed400MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.KeyPrioritySubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.BothHkAndControllerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.InputOverHkMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.HkOverInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.CoresSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator10 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.SaveConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveConfigAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadConfigFromMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ToolsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ToolBoxMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator12 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.RamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.RamSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LuaConsoleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.TAStudioMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.HexEditorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.TraceLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.CodeDataLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MacroToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.VirtualPadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.BasicBotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator11 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.CheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.GameSharkConverterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator29 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.MultiDiskBundlerFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.BatchRunnerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ExternalToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.dummyExternalTool = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.RetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.StartRetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.NESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.NESPPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.NESNametableViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MusicRipperMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator17 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.NesControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.NESGraphicSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.NESSoundChannelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.VSSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MovieSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator22 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.FDSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.FdsEjectDiskMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.VSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.VSInsertCoinP1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.VSInsertCoinP2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.VSServiceSwitchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.BarcodeReaderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.TI83SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.KeypadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadTIFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator13 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.paletteToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.A7800SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.A7800ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.A7800FilterSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.GBSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.GBcoreSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SameBoyColorChooserMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator28 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.GBGPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.GBPrinterViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PSXSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PSXControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PSXOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PSXDiscControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PSXHashDiscsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SNESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SNESControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator18 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.SnesGfxDebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SnesOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ColecoSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ColecoControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator35 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.ColecoSkipBiosMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ColecoUseSGMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.N64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.N64PluginSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.N64ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator23 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.N64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MupenStyleLagMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.N64ExpansionSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Ares64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Ares64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.Ares64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.GBLSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.GBLsettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AppleSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AppleDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator31 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.settingsToolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.C64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.C64DisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator36 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.C64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.IntvSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.IntVControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.zXSpectrumToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ZXSpectrumCoreEmulationSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ZXSpectrumControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ZXSpectrumAudioSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ZXSpectrumNonSyncSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ZXSpectrumMediaMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ZXSpectrumTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.zxt1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ZXSpectrumDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.zxt2ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ZXSpectrumExportSnapshotMenuItemMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.GenericCoreSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.amstradCPCToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.amstradCPCCoreEmulationSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AmstradCPCAudioSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AmstradCPCNonSyncSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AmstradCPCMediaToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AmstradCPCTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.cpct1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AmstradCPCDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.cpcd1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.HelpSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.OnlineHelpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ForumsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.FeaturesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AboutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.A7800HawkCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MainStatusBar = new BizHawk.WinForms.Controls.StatusStripEx();
+            this.DumpStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
+            this.EmuStatus = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.PlayRecordStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
+            this.PauseStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
+            this.RebootStatusBarIcon = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.AVIStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.LedLightStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.SaveSlotsStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.Slot1StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.Slot2StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.Slot3StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.Slot4StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.Slot5StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.Slot6StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.Slot7StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.Slot8StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.Slot9StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.Slot0StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.CheatStatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.KeyPriorityStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.CoreNameStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.ProfileFirstBootLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.LinkConnectStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.UpdateNotification = new BizHawk.WinForms.Controls.StatusLabelEx();
+            this.MainFormContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.OpenRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadLastRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.StopAVContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ContextSeparator_AfterROM = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.RecordMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PlayMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.RestartMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.StopMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LoadLastMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.BackupMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.StopNoSaveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ViewSubtitlesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AddSubtitleContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ViewCommentsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveMovieAsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ContextSeparator_AfterMovie = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.UndoSavestateContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ContextSeparator_AfterUndo = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.ConfigContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem6 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem7 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem8 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem9 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem10 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem11 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem12 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem13 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem14 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem15 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.customizeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripSeparator30 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.toolStripMenuItem66 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.toolStripMenuItem67 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ScreenshotContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.CloseRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ClearSRAMContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ShowMenuContextMenuSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.ShowMenuContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
+            this.MainformMenu.SuspendLayout();
+            this.MainStatusBar.SuspendLayout();
+            this.MainFormContextMenu.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // MainformMenu
+            // 
+            this.MainformMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.MainformMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.FileSubMenu,
+            this.EmulationSubMenu,
+            this.ViewSubMenu,
+            this.ConfigSubMenu,
+            this.ToolsSubMenu,
+            this.NESSubMenu,
+            this.TI83SubMenu,
+            this.A7800SubMenu,
+            this.GBSubMenu,
+            this.PSXSubMenu,
+            this.SNESSubMenu,
+            this.ColecoSubMenu,
+            this.N64SubMenu,
+            this.Ares64SubMenu,
+            this.GBLSubMenu,
+            this.AppleSubMenu,
+            this.C64SubMenu,
+            this.IntvSubMenu,
+            this.zXSpectrumToolStripMenuItem,
+            this.GenericCoreSubMenu,
+            this.amstradCPCToolStripMenuItem,
+            this.HelpSubMenu});
+            this.MainformMenu.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
+            this.MainformMenu.TabIndex = 0;
+            this.MainformMenu.MenuActivate += new System.EventHandler(this.MainformMenu_MenuActivate);
+            this.MainformMenu.MenuDeactivate += new System.EventHandler(this.MainformMenu_MenuDeactivate);
+            // 
+            // FileSubMenu
+            // 
+            this.FileSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.OpenRomMenuItem,
+            this.RecentRomSubMenu,
+            this.OpenAdvancedMenuItem,
+            this.CloseRomMenuItem,
+            this.toolStripMenuItem1,
+            this.SaveStateSubMenu,
+            this.LoadStateSubMenu,
+            this.SaveSlotSubMenu,
+            this.SaveRAMSubMenu,
+            this.toolStripMenuItem2,
+            this.MovieSubMenu,
+            this.AVSubMenu,
+            this.ScreenshotSubMenu,
+            this.toolStripSeparator4,
+            this.ExitMenuItem});
+            this.FileSubMenu.Text = "&File";
+            this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
+            // 
+            // OpenRomMenuItem
+            // 
+            this.OpenRomMenuItem.Text = "&Open ROM...";
+            this.OpenRomMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
+            // 
+            // RecentRomSubMenu
+            // 
+            this.RecentRomSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripSeparator3});
+            this.RecentRomSubMenu.Text = "&Recent ROM";
+            this.RecentRomSubMenu.DropDownOpened += new System.EventHandler(this.RecentRomMenuItem_DropDownOpened);
+            // 
+            // OpenAdvancedMenuItem
+            // 
+            this.OpenAdvancedMenuItem.Text = "Open Ad&vanced...";
+            this.OpenAdvancedMenuItem.Click += new System.EventHandler(this.OpenAdvancedMenuItem_Click);
+            // 
+            // CloseRomMenuItem
+            // 
+            this.CloseRomMenuItem.Text = "&Close ROM";
+            this.CloseRomMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
+            // 
+            // SaveStateSubMenu
+            // 
+            this.SaveStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.SaveState1MenuItem,
+            this.SaveState2MenuItem,
+            this.SaveState3MenuItem,
+            this.SaveState4MenuItem,
+            this.SaveState5MenuItem,
+            this.SaveState6MenuItem,
+            this.SaveState7MenuItem,
+            this.SaveState8MenuItem,
+            this.SaveState9MenuItem,
+            this.SaveState0MenuItem,
+            this.toolStripSeparator6,
+            this.SaveNamedStateMenuItem,
+            this.toolStripSeparator24,
+            this.AutosaveLastSlotMenuItem});
+            this.SaveStateSubMenu.Text = "&Save State";
+            this.SaveStateSubMenu.DropDownOpened += new System.EventHandler(this.SaveStateSubMenu_DropDownOpened);
+            // 
+            // SaveState1MenuItem
+            // 
+            this.SaveState1MenuItem.Text = "1";
+            this.SaveState1MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+            // 
+            // SaveState2MenuItem
+            // 
+            this.SaveState2MenuItem.Text = "2";
+            this.SaveState2MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+            // 
+            // SaveState3MenuItem
+            // 
+            this.SaveState3MenuItem.Text = "3";
+            this.SaveState3MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+            // 
+            // SaveState4MenuItem
+            // 
+            this.SaveState4MenuItem.Text = "4";
+            this.SaveState4MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+            // 
+            // SaveState5MenuItem
+            // 
+            this.SaveState5MenuItem.Text = "5";
+            this.SaveState5MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+            // 
+            // SaveState6MenuItem
+            // 
+            this.SaveState6MenuItem.Text = "6";
+            this.SaveState6MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+            // 
+            // SaveState7MenuItem
+            // 
+            this.SaveState7MenuItem.Text = "7";
+            this.SaveState7MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+            // 
+            // SaveState8MenuItem
+            // 
+            this.SaveState8MenuItem.Text = "8";
+            this.SaveState8MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+            // 
+            // SaveState9MenuItem
+            // 
+            this.SaveState9MenuItem.Text = "9";
+            this.SaveState9MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+            // 
+            // SaveState0MenuItem
+            // 
+            this.SaveState0MenuItem.Text = "10";
+            this.SaveState0MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+            // 
+            // SaveNamedStateMenuItem
+            // 
+            this.SaveNamedStateMenuItem.Text = "Save Named State...";
+            this.SaveNamedStateMenuItem.Click += new System.EventHandler(this.SaveNamedStateMenuItem_Click);
+            // 
+            // AutosaveLastSlotMenuItem
+            // 
+            this.AutosaveLastSlotMenuItem.Text = "Autosave Last Slot";
+            this.AutosaveLastSlotMenuItem.Click += new System.EventHandler(this.AutosaveLastSlotMenuItem_Click);
+            // 
+            // LoadStateSubMenu
+            // 
+            this.LoadStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.LoadState1MenuItem,
+            this.LoadState2MenuItem,
+            this.LoadState3MenuItem,
+            this.LoadState4MenuItem,
+            this.LoadState5MenuItem,
+            this.LoadState6MenuItem,
+            this.LoadState7MenuItem,
+            this.LoadState8MenuItem,
+            this.LoadState9MenuItem,
+            this.LoadState0MenuItem,
+            this.toolStripSeparator7,
+            this.LoadNamedStateMenuItem,
+            this.toolStripSeparator21,
+            this.AutoloadLastSlotMenuItem});
+            this.LoadStateSubMenu.Text = "&Load State";
+            this.LoadStateSubMenu.DropDownOpened += new System.EventHandler(this.LoadStateSubMenu_DropDownOpened);
+            // 
+            // LoadState1MenuItem
+            // 
+            this.LoadState1MenuItem.Text = "1";
+            this.LoadState1MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+            // 
+            // LoadState2MenuItem
+            // 
+            this.LoadState2MenuItem.Text = "2";
+            this.LoadState2MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+            // 
+            // LoadState3MenuItem
+            // 
+            this.LoadState3MenuItem.Text = "3";
+            this.LoadState3MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+            // 
+            // LoadState4MenuItem
+            // 
+            this.LoadState4MenuItem.Text = "4";
+            this.LoadState4MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+            // 
+            // LoadState5MenuItem
+            // 
+            this.LoadState5MenuItem.Text = "5";
+            this.LoadState5MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+            // 
+            // LoadState6MenuItem
+            // 
+            this.LoadState6MenuItem.Text = "6";
+            this.LoadState6MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+            // 
+            // LoadState7MenuItem
+            // 
+            this.LoadState7MenuItem.Text = "7";
+            this.LoadState7MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+            // 
+            // LoadState8MenuItem
+            // 
+            this.LoadState8MenuItem.Text = "8";
+            this.LoadState8MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+            // 
+            // LoadState9MenuItem
+            // 
+            this.LoadState9MenuItem.Text = "9";
+            this.LoadState9MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+            // 
+            // LoadState0MenuItem
+            // 
+            this.LoadState0MenuItem.Text = "10";
+            this.LoadState0MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+            // 
+            // LoadNamedStateMenuItem
+            // 
+            this.LoadNamedStateMenuItem.Text = "Load Named State...";
+            this.LoadNamedStateMenuItem.Click += new System.EventHandler(this.LoadNamedStateMenuItem_Click);
+            // 
+            // AutoloadLastSlotMenuItem
+            // 
+            this.AutoloadLastSlotMenuItem.Text = "Autoload Last Slot";
+            this.AutoloadLastSlotMenuItem.Click += new System.EventHandler(this.AutoloadLastSlotMenuItem_Click);
+            // 
+            // SaveSlotSubMenu
+            // 
+            this.SaveSlotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.SelectSlot1MenuItem,
+            this.SelectSlot2MenuItem,
+            this.SelectSlot3MenuItem,
+            this.SelectSlot4MenuItem,
+            this.SelectSlot5MenuItem,
+            this.SelectSlot6MenuItem,
+            this.SelectSlot7MenuItem,
+            this.SelectSlot8MenuItem,
+            this.SelectSlot9MenuItem,
+            this.SelectSlot0MenuItem,
+            this.PreviousSlotMenuItem,
+            this.NextSlotMenuItem,
+            this.toolStripSeparator5,
+            this.SaveToCurrentSlotMenuItem,
+            this.LoadCurrentSlotMenuItem});
+            this.SaveSlotSubMenu.Text = "Save S&lot";
+            this.SaveSlotSubMenu.DropDownOpened += new System.EventHandler(this.SaveSlotSubMenu_DropDownOpened);
+            // 
+            // SelectSlot1MenuItem
+            // 
+            this.SelectSlot1MenuItem.Text = "Select Slot 1";
+            this.SelectSlot1MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+            // 
+            // SelectSlot2MenuItem
+            // 
+            this.SelectSlot2MenuItem.Text = "Select Slot 2";
+            this.SelectSlot2MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+            // 
+            // SelectSlot3MenuItem
+            // 
+            this.SelectSlot3MenuItem.Text = "Select Slot 3";
+            this.SelectSlot3MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+            // 
+            // SelectSlot4MenuItem
+            // 
+            this.SelectSlot4MenuItem.Text = "Select Slot 4";
+            this.SelectSlot4MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+            // 
+            // SelectSlot5MenuItem
+            // 
+            this.SelectSlot5MenuItem.Text = "Select Slot 5";
+            this.SelectSlot5MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+            // 
+            // SelectSlot6MenuItem
+            // 
+            this.SelectSlot6MenuItem.Text = "Select Slot 6";
+            this.SelectSlot6MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+            // 
+            // SelectSlot7MenuItem
+            // 
+            this.SelectSlot7MenuItem.Text = "Select Slot 7";
+            this.SelectSlot7MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+            // 
+            // SelectSlot8MenuItem
+            // 
+            this.SelectSlot8MenuItem.Text = "Select Slot 8";
+            this.SelectSlot8MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+            // 
+            // SelectSlot9MenuItem
+            // 
+            this.SelectSlot9MenuItem.Text = "Select Slot 9";
+            this.SelectSlot9MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+            // 
+            // SelectSlot0MenuItem
+            // 
+            this.SelectSlot0MenuItem.Text = "Select Slot 10";
+            this.SelectSlot0MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+            // 
+            // PreviousSlotMenuItem
+            // 
+            this.PreviousSlotMenuItem.Text = "Previous Slot";
+            this.PreviousSlotMenuItem.Click += new System.EventHandler(this.PreviousSlotMenuItem_Click);
+            // 
+            // NextSlotMenuItem
+            // 
+            this.NextSlotMenuItem.Text = "Next Slot";
+            this.NextSlotMenuItem.Click += new System.EventHandler(this.NextSlotMenuItem_Click);
+            // 
+            // SaveToCurrentSlotMenuItem
+            // 
+            this.SaveToCurrentSlotMenuItem.Text = "Save to Current Slot";
+            this.SaveToCurrentSlotMenuItem.Click += new System.EventHandler(this.SaveToCurrentSlotMenuItem_Click);
+            // 
+            // LoadCurrentSlotMenuItem
+            // 
+            this.LoadCurrentSlotMenuItem.Text = "Load Current Slot";
+            this.LoadCurrentSlotMenuItem.Click += new System.EventHandler(this.LoadCurrentSlotMenuItem_Click);
+            // 
+            // SaveRAMSubMenu
+            // 
+            this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.FlushSaveRAMMenuItem});
+            this.SaveRAMSubMenu.Text = "Save &RAM";
+            this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
+            // 
+            // FlushSaveRAMMenuItem
+            // 
+            this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
+            this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
+            // 
+            // MovieSubMenu
+            // 
+            this.MovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ReadonlyMenuItem,
+            this.toolStripSeparator15,
+            this.RecentMovieSubMenu,
+            this.RecordMovieMenuItem,
+            this.PlayMovieMenuItem,
+            this.StopMovieMenuItem,
+            this.PlayFromBeginningMenuItem,
+            this.ImportMoviesMenuItem,
+            this.SaveMovieMenuItem,
+            this.SaveMovieAsMenuItem,
+            this.StopMovieWithoutSavingMenuItem,
+            this.toolStripSeparator14,
+            this.AutomaticallyBackupMoviesMenuItem,
+            this.FullMovieLoadstatesMenuItem,
+            this.MovieEndSubMenu});
+            this.MovieSubMenu.Text = "&Movie";
+            this.MovieSubMenu.DropDownOpened += new System.EventHandler(this.MovieSubMenu_DropDownOpened);
+            // 
+            // ReadonlyMenuItem
+            // 
+            this.ReadonlyMenuItem.Text = "Read-only";
+            this.ReadonlyMenuItem.Click += new System.EventHandler(this.ReadonlyMenuItem_Click);
+            // 
+            // RecentMovieSubMenu
+            // 
+            this.RecentMovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripSeparator16});
+            this.RecentMovieSubMenu.Text = "Recent";
+            this.RecentMovieSubMenu.DropDownOpened += new System.EventHandler(this.RecentMovieSubMenu_DropDownOpened);
+            // 
+            // RecordMovieMenuItem
+            // 
+            this.RecordMovieMenuItem.Text = "&Record Movie...";
+            this.RecordMovieMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
+            // 
+            // PlayMovieMenuItem
+            // 
+            this.PlayMovieMenuItem.Text = "&Play Movie...";
+            this.PlayMovieMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
+            // 
+            // StopMovieMenuItem
+            // 
+            this.StopMovieMenuItem.Text = "Stop Movie";
+            this.StopMovieMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
+            // 
+            // PlayFromBeginningMenuItem
+            // 
+            this.PlayFromBeginningMenuItem.Text = "Play from Beginning";
+            this.PlayFromBeginningMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
+            // 
+            // ImportMoviesMenuItem
+            // 
+            this.ImportMoviesMenuItem.Text = "Import Movies...";
+            this.ImportMoviesMenuItem.Click += new System.EventHandler(this.ImportMovieMenuItem_Click);
+            // 
+            // SaveMovieMenuItem
+            // 
+            this.SaveMovieMenuItem.Text = "&Save Movie";
+            this.SaveMovieMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
+            // 
+            // SaveMovieAsMenuItem
+            // 
+            this.SaveMovieAsMenuItem.Text = "Save Movie As...";
+            this.SaveMovieAsMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
+            // 
+            // StopMovieWithoutSavingMenuItem
+            // 
+            this.StopMovieWithoutSavingMenuItem.Text = "Stop Movie without Saving";
+            this.StopMovieWithoutSavingMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
+            // 
+            // AutomaticallyBackupMoviesMenuItem
+            // 
+            this.AutomaticallyBackupMoviesMenuItem.Text = "Automatically Backup Movies";
+            this.AutomaticallyBackupMoviesMenuItem.Click += new System.EventHandler(this.AutomaticMovieBackupMenuItem_Click);
+            // 
+            // FullMovieLoadstatesMenuItem
+            // 
+            this.FullMovieLoadstatesMenuItem.Text = "Full Movie Loadstates";
+            this.FullMovieLoadstatesMenuItem.Click += new System.EventHandler(this.FullMovieLoadstatesMenuItem_Click);
+            // 
+            // MovieEndSubMenu
+            // 
+            this.MovieEndSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.MovieEndFinishMenuItem,
+            this.MovieEndRecordMenuItem,
+            this.MovieEndStopMenuItem,
+            this.MovieEndPauseMenuItem});
+            this.MovieEndSubMenu.Text = "On Movie End";
+            this.MovieEndSubMenu.DropDownOpened += new System.EventHandler(this.MovieEndSubMenu_DropDownOpened);
+            // 
+            // MovieEndFinishMenuItem
+            // 
+            this.MovieEndFinishMenuItem.Text = "Switch to Finished";
+            this.MovieEndFinishMenuItem.Click += new System.EventHandler(this.MovieEndFinishMenuItem_Click);
+            // 
+            // MovieEndRecordMenuItem
+            // 
+            this.MovieEndRecordMenuItem.Text = "Switch To Record";
+            this.MovieEndRecordMenuItem.Click += new System.EventHandler(this.MovieEndRecordMenuItem_Click);
+            // 
+            // MovieEndStopMenuItem
+            // 
+            this.MovieEndStopMenuItem.Text = "Stop";
+            this.MovieEndStopMenuItem.Click += new System.EventHandler(this.MovieEndStopMenuItem_Click);
+            // 
+            // MovieEndPauseMenuItem
+            // 
+            this.MovieEndPauseMenuItem.Text = "Pause";
+            this.MovieEndPauseMenuItem.Click += new System.EventHandler(this.MovieEndPauseMenuItem_Click);
+            // 
+            // AVSubMenu
+            // 
+            this.AVSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.RecordAVMenuItem,
+            this.ConfigAndRecordAVMenuItem,
+            this.StopAVIMenuItem,
+            this.toolStripSeparator19,
+            this.CaptureOSDMenuItem,
+            this.CaptureLuaMenuItem,
+            this.SynclessRecordingMenuItem});
+            this.AVSubMenu.Text = "&AVI/WAV";
+            this.AVSubMenu.DropDownOpened += new System.EventHandler(this.AVSubMenu_DropDownOpened);
+            // 
+            // RecordAVMenuItem
+            // 
+            this.RecordAVMenuItem.Text = "&Record AVI/WAV";
+            this.RecordAVMenuItem.Click += new System.EventHandler(this.RecordAVMenuItem_Click);
+            // 
+            // ConfigAndRecordAVMenuItem
+            // 
+            this.ConfigAndRecordAVMenuItem.Text = "Config and Record AVI/WAV...";
+            this.ConfigAndRecordAVMenuItem.Click += new System.EventHandler(this.ConfigAndRecordAVMenuItem_Click);
+            // 
+            // StopAVIMenuItem
+            // 
+            this.StopAVIMenuItem.Text = "&Stop AVI/WAV";
+            this.StopAVIMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
+            // 
+            // CaptureOSDMenuItem
+            // 
+            this.CaptureOSDMenuItem.CheckOnClick = true;
+            this.CaptureOSDMenuItem.Text = "Capture OSD";
+            this.CaptureOSDMenuItem.Click += new System.EventHandler(this.CaptureOSDMenuItem_Click);
+            // 
+            // CaptureLuaMenuItem
+            // 
+            this.CaptureLuaMenuItem.CheckOnClick = true;
+            this.CaptureLuaMenuItem.Name = "CaptureLuaMenuItem";
+            this.CaptureLuaMenuItem.Size = new System.Drawing.Size(288, 26);
+            this.CaptureLuaMenuItem.Text = "Capture Lua";
+            this.CaptureLuaMenuItem.Click += new System.EventHandler(this.CaptureLuaMenuItem_Click);
+            // 
+            // SynclessRecordingMenuItem
+            // 
+            this.SynclessRecordingMenuItem.Text = "S&yncless Recording Tools";
+            // 
+            // ScreenshotSubMenu
+            // 
+            this.ScreenshotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ScreenshotMenuItem,
+            this.ScreenshotAsMenuItem,
+            this.ScreenshotClipboardMenuItem,
+            this.ScreenshotClientClipboardMenuItem,
+            this.toolStripSeparator20,
+            this.ScreenshotCaptureOSDMenuItem1});
+            this.ScreenshotSubMenu.Text = "Scree&nshot";
+            this.ScreenshotSubMenu.DropDownOpening += new System.EventHandler(this.ScreenshotSubMenu_DropDownOpening);
+            // 
+            // ScreenshotMenuItem
+            // 
+            this.ScreenshotMenuItem.Text = "Screenshot";
+            this.ScreenshotMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
+            // 
+            // ScreenshotAsMenuItem
+            // 
+            this.ScreenshotAsMenuItem.Text = "Screenshot As...";
+            this.ScreenshotAsMenuItem.Click += new System.EventHandler(this.ScreenshotAsMenuItem_Click);
+            // 
+            // ScreenshotClipboardMenuItem
+            // 
+            this.ScreenshotClipboardMenuItem.Text = "Screenshot (raw) -> Clipboard";
+            this.ScreenshotClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClipboardMenuItem_Click);
+            // 
+            // ScreenshotClientClipboardMenuItem
+            // 
+            this.ScreenshotClientClipboardMenuItem.Text = "Screenshot (client) -> Clipboard";
+            this.ScreenshotClientClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClientClipboardMenuItem_Click);
+            // 
+            // ScreenshotCaptureOSDMenuItem1
+            // 
+            this.ScreenshotCaptureOSDMenuItem1.Text = "Capture OSD";
+            this.ScreenshotCaptureOSDMenuItem1.Click += new System.EventHandler(this.ScreenshotCaptureOSDMenuItem_Click);
+            // 
+            // ExitMenuItem
+            // 
+            this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
+            this.ExitMenuItem.Text = "E&xit";
+            this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
+            // 
+            // EmulationSubMenu
+            // 
+            this.EmulationSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.PauseMenuItem,
+            this.RebootCoreMenuItem,
+            this.toolStripSeparator1,
+            this.SoftResetMenuItem,
+            this.HardResetMenuItem,
+            this.EmulatorMenuSeparator2,
+            this.LoadedCoreNameMenuItem});
+            this.EmulationSubMenu.Text = "&Emulation";
+            this.EmulationSubMenu.DropDownOpened += new System.EventHandler(this.EmulationMenuItem_DropDownOpened);
+            // 
+            // PauseMenuItem
+            // 
+            this.PauseMenuItem.Text = "&Pause";
+            this.PauseMenuItem.Click += new System.EventHandler(this.PauseMenuItem_Click);
+            // 
+            // RebootCoreMenuItem
+            // 
+            this.RebootCoreMenuItem.Text = "&Reboot Core";
+            this.RebootCoreMenuItem.Click += new System.EventHandler(this.PowerMenuItem_Click);
+            // 
+            // SoftResetMenuItem
+            // 
+            this.SoftResetMenuItem.Text = "&Soft Reset";
+            this.SoftResetMenuItem.Click += new System.EventHandler(this.SoftResetMenuItem_Click);
+            // 
+            // HardResetMenuItem
+            // 
+            this.HardResetMenuItem.Text = "&Hard Reset";
+            this.HardResetMenuItem.Click += new System.EventHandler(this.HardResetMenuItem_Click);
+            // 
+            // LoadedCoreNameMenuItem
+            // 
+            this.LoadedCoreNameMenuItem.Enabled = false;
+            this.LoadedCoreNameMenuItem.Text = "Loaded core: <core name> (sysID)";
+            // 
+            // ViewSubMenu
+            // 
+            this.ViewSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.WindowSizeSubMenu,
+            this.SwitchToFullscreenMenuItem,
+            this.toolStripSeparator2,
+            this.DisplayFPSMenuItem,
+            this.DisplayFrameCounterMenuItem,
+            this.DisplayLagCounterMenuItem,
+            this.DisplayInputMenuItem,
+            this.DisplayRerecordCountMenuItem,
+            this.DisplaySubtitlesMenuItem,
+            this.toolStripMenuItem4,
+            this.DisplayStatusBarMenuItem,
+            this.DisplayMessagesMenuItem,
+            this.toolStripSeparator8,
+            this.DisplayLogWindowMenuItem});
+            this.ViewSubMenu.Text = "&View";
+            this.ViewSubMenu.DropDownOpened += new System.EventHandler(this.ViewSubMenu_DropDownOpened);
+            // 
+            // WindowSizeSubMenu
+            // 
+            this.WindowSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.x1MenuItem,
+            this.x2MenuItem,
+            this.x3MenuItem,
+            this.x4MenuItem,
+            this.x5MenuItem,
+            this.x6MenuItem,
+            this.x7MenuItem,
+            this.x8MenuItem,
+            this.x9MenuItem,
+            this.mzMenuItem});
+            this.WindowSizeSubMenu.Text = "&Window Size";
+            this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
+            // 
+            // x1MenuItem
+            // 
+            this.x1MenuItem.Text = "&1x";
+            this.x1MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+            // 
+            // x2MenuItem
+            // 
+            this.x2MenuItem.Text = "&2x";
+            this.x2MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+            // 
+            // x3MenuItem
+            // 
+            this.x3MenuItem.Text = "&3x";
+            this.x3MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+            // 
+            // x4MenuItem
+            // 
+            this.x4MenuItem.Text = "&4x";
+            this.x4MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+            // 
+            // x5MenuItem
+            // 
+            this.x5MenuItem.Text = "&5x";
+            this.x5MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+            // 
+            // x6MenuItem
+            // 
+            this.x6MenuItem.Text = "&6x";
+            this.x6MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+            // 
+            // x7MenuItem
+            // 
+            this.x7MenuItem.Text = "&7x";
+            this.x7MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+            // 
+            // x8MenuItem
+            // 
+            this.x8MenuItem.Text = "&8x";
+            this.x8MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+            // 
+            // x9MenuItem
+            // 
+            this.x9MenuItem.Text = "&9x";
+            this.x9MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+            // 
+            // mzMenuItem
+            // 
+            this.mzMenuItem.Text = "1&0x";
+            this.mzMenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+            // 
+            // SwitchToFullscreenMenuItem
+            // 
+            this.SwitchToFullscreenMenuItem.Text = "Switch to Fullscreen";
+            this.SwitchToFullscreenMenuItem.Click += new System.EventHandler(this.SwitchToFullscreenMenuItem_Click);
+            // 
+            // DisplayFPSMenuItem
+            // 
+            this.DisplayFPSMenuItem.Text = "Display FPS";
+            this.DisplayFPSMenuItem.Click += new System.EventHandler(this.DisplayFpsMenuItem_Click);
+            // 
+            // DisplayFrameCounterMenuItem
+            // 
+            this.DisplayFrameCounterMenuItem.Text = "Display Frame Count";
+            this.DisplayFrameCounterMenuItem.Click += new System.EventHandler(this.DisplayFrameCounterMenuItem_Click);
+            // 
+            // DisplayLagCounterMenuItem
+            // 
+            this.DisplayLagCounterMenuItem.Text = "Display Lag Frame Count";
+            this.DisplayLagCounterMenuItem.Click += new System.EventHandler(this.DisplayLagCounterMenuItem_Click);
+            // 
+            // DisplayInputMenuItem
+            // 
+            this.DisplayInputMenuItem.Text = "Display Input";
+            this.DisplayInputMenuItem.Click += new System.EventHandler(this.DisplayInputMenuItem_Click);
+            // 
+            // DisplayRerecordCountMenuItem
+            // 
+            this.DisplayRerecordCountMenuItem.Text = "Display Rerecord Count";
+            this.DisplayRerecordCountMenuItem.Click += new System.EventHandler(this.DisplayRerecordsMenuItem_Click);
+            // 
+            // DisplaySubtitlesMenuItem
+            // 
+            this.DisplaySubtitlesMenuItem.Text = "Display Subtitles";
+            this.DisplaySubtitlesMenuItem.Click += new System.EventHandler(this.DisplaySubtitlesMenuItem_Click);
+            // 
+            // DisplayStatusBarMenuItem
+            // 
+            this.DisplayStatusBarMenuItem.Text = "Display Status Bar";
+            this.DisplayStatusBarMenuItem.Click += new System.EventHandler(this.DisplayStatusBarMenuItem_Click);
+            // 
+            // DisplayMessagesMenuItem
+            // 
+            this.DisplayMessagesMenuItem.Text = "Display Messages";
+            this.DisplayMessagesMenuItem.Click += new System.EventHandler(this.DisplayMessagesMenuItem_Click);
+            // 
+            // DisplayLogWindowMenuItem
+            // 
+            this.DisplayLogWindowMenuItem.Text = "Open &Log Window...";
+            this.DisplayLogWindowMenuItem.Click += new System.EventHandler(this.DisplayLogWindowMenuItem_Click);
+            // 
+            // ConfigSubMenu
+            // 
+            this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ControllersMenuItem,
+            this.HotkeysMenuItem,
+            this.DisplayConfigMenuItem,
+            this.SoundMenuItem,
+            this.PathsMenuItem,
+            this.FirmwaresMenuItem,
+            this.MessagesMenuItem,
+            this.AutofireMenuItem,
+            this.RewindOptionsMenuItem,
+            this.extensionsToolStripMenuItem,
+            this.ClientOptionsMenuItem,
+            this.ProfilesMenuItem,
+            this.toolStripSeparator9,
+            this.SpeedSkipSubMenu,
+            this.KeyPrioritySubMenu,
+            this.CoresSubMenu,
+            this.toolStripSeparator10,
+            this.SaveConfigMenuItem,
+            this.SaveConfigAsMenuItem,
+            this.LoadConfigMenuItem,
+            this.LoadConfigFromMenuItem});
+            this.ConfigSubMenu.Text = "&Config";
+            this.ConfigSubMenu.DropDownOpened += new System.EventHandler(this.ConfigSubMenu_DropDownOpened);
+            // 
+            // ControllersMenuItem
+            // 
+            this.ControllersMenuItem.Text = "&Controllers...";
+            this.ControllersMenuItem.Click += new System.EventHandler(this.ControllersMenuItem_Click);
+            // 
+            // HotkeysMenuItem
+            // 
+            this.HotkeysMenuItem.Text = "&Hotkeys...";
+            this.HotkeysMenuItem.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
+            // 
+            // DisplayConfigMenuItem
+            // 
+            this.DisplayConfigMenuItem.Text = "Display...";
+            this.DisplayConfigMenuItem.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
+            // 
+            // SoundMenuItem
+            // 
+            this.SoundMenuItem.Text = "&Sound...";
+            this.SoundMenuItem.Click += new System.EventHandler(this.SoundMenuItem_Click);
+            // 
+            // PathsMenuItem
+            // 
+            this.PathsMenuItem.Text = "Paths...";
+            this.PathsMenuItem.Click += new System.EventHandler(this.PathsMenuItem_Click);
+            // 
+            // FirmwaresMenuItem
+            // 
+            this.FirmwaresMenuItem.Text = "&Firmwares...";
+            this.FirmwaresMenuItem.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
+            // 
+            // MessagesMenuItem
+            // 
+            this.MessagesMenuItem.Text = "&Messages...";
+            this.MessagesMenuItem.Click += new System.EventHandler(this.MessagesMenuItem_Click);
+            // 
+            // AutofireMenuItem
+            // 
+            this.AutofireMenuItem.Text = "&Autofire...";
+            this.AutofireMenuItem.Click += new System.EventHandler(this.AutofireMenuItem_Click);
+            // 
+            // RewindOptionsMenuItem
+            // 
+            this.RewindOptionsMenuItem.Text = "&Rewind && States...";
+            this.RewindOptionsMenuItem.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
+            // 
+            // extensionsToolStripMenuItem
+            // 
+            this.extensionsToolStripMenuItem.Text = "File Extensions...";
+            this.extensionsToolStripMenuItem.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
+            // 
+            // ClientOptionsMenuItem
+            // 
+            this.ClientOptionsMenuItem.Text = "&Customize...";
+            this.ClientOptionsMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
+            // 
+            // ProfilesMenuItem
+            // 
+            this.ProfilesMenuItem.Text = "&Profiles...";
+            this.ProfilesMenuItem.Click += new System.EventHandler(this.ProfilesMenuItem_Click);
+            // 
+            // SpeedSkipSubMenu
+            // 
+            this.SpeedSkipSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ClockThrottleMenuItem,
+            this.AudioThrottleMenuItem,
+            this.VsyncThrottleMenuItem,
+            this.toolStripSeparator27,
+            this.VsyncEnabledMenuItem,
+            this.toolStripMenuItem3,
+            this.miUnthrottled,
+            this.MinimizeSkippingMenuItem,
+            this.NeverSkipMenuItem,
+            this.toolStripMenuItem17,
+            this.toolStripMenuItem5,
+            this.Speed50MenuItem,
+            this.Speed75MenuItem,
+            this.Speed100MenuItem,
+            this.Speed150MenuItem,
+            this.Speed200MenuItem,
+            this.Speed400MenuItem});
+            this.SpeedSkipSubMenu.Text = "Speed/Skip";
+            this.SpeedSkipSubMenu.DropDownOpened += new System.EventHandler(this.FrameSkipMenuItem_DropDownOpened);
+            // 
+            // ClockThrottleMenuItem
+            // 
+            this.ClockThrottleMenuItem.Text = "Clock Throttle";
+            this.ClockThrottleMenuItem.Click += new System.EventHandler(this.ClockThrottleMenuItem_Click);
+            // 
+            // AudioThrottleMenuItem
+            // 
+            this.AudioThrottleMenuItem.Text = "Audio Throttle";
+            this.AudioThrottleMenuItem.Click += new System.EventHandler(this.AudioThrottleMenuItem_Click);
+            // 
+            // VsyncThrottleMenuItem
+            // 
+            this.VsyncThrottleMenuItem.Text = "VSync Throttle";
+            this.VsyncThrottleMenuItem.Click += new System.EventHandler(this.VsyncThrottleMenuItem_Click);
+            // 
+            // VsyncEnabledMenuItem
+            // 
+            this.VsyncEnabledMenuItem.Text = "VSync Enabled";
+            this.VsyncEnabledMenuItem.Click += new System.EventHandler(this.VsyncEnabledMenuItem_Click);
+            // 
+            // miUnthrottled
+            // 
+            this.miUnthrottled.Text = "Unthrottled";
+            this.miUnthrottled.Click += new System.EventHandler(this.UnthrottledMenuItem_Click);
+            // 
+            // MinimizeSkippingMenuItem
+            // 
+            this.MinimizeSkippingMenuItem.Text = "Auto-minimize skipping";
+            this.MinimizeSkippingMenuItem.Click += new System.EventHandler(this.MinimizeSkippingMenuItem_Click);
+            // 
+            // NeverSkipMenuItem
+            // 
+            this.NeverSkipMenuItem.Text = "Skip 0 (never)";
+            this.NeverSkipMenuItem.Click += new System.EventHandler(this.NeverSkipMenuItem_Click);
+            // 
+            // toolStripMenuItem17
+            // 
+            this.toolStripMenuItem17.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.Frameskip1MenuItem,
+            this.Frameskip2MenuItem,
+            this.Frameskip3MenuItem,
+            this.Frameskip4MenuItem,
+            this.Frameskip5MenuItem,
+            this.Frameskip6MenuItem,
+            this.Frameskip7MenuItem,
+            this.Frameskip8MenuItem,
+            this.Frameskip9MenuItem});
+            this.toolStripMenuItem17.Text = "Skip 1..9";
+            // 
+            // Frameskip1MenuItem
+            // 
+            this.Frameskip1MenuItem.Text = "1";
+            this.Frameskip1MenuItem.Click += new System.EventHandler(this.Frameskip1MenuItem_Click);
+            // 
+            // Frameskip2MenuItem
+            // 
+            this.Frameskip2MenuItem.Text = "2";
+            this.Frameskip2MenuItem.Click += new System.EventHandler(this.Frameskip2MenuItem_Click);
+            // 
+            // Frameskip3MenuItem
+            // 
+            this.Frameskip3MenuItem.Text = "3";
+            this.Frameskip3MenuItem.Click += new System.EventHandler(this.Frameskip3MenuItem_Click);
+            // 
+            // Frameskip4MenuItem
+            // 
+            this.Frameskip4MenuItem.Text = "4";
+            this.Frameskip4MenuItem.Click += new System.EventHandler(this.Frameskip4MenuItem_Click);
+            // 
+            // Frameskip5MenuItem
+            // 
+            this.Frameskip5MenuItem.Text = "5";
+            this.Frameskip5MenuItem.Click += new System.EventHandler(this.Frameskip5MenuItem_Click);
+            // 
+            // Frameskip6MenuItem
+            // 
+            this.Frameskip6MenuItem.Text = "6";
+            this.Frameskip6MenuItem.Click += new System.EventHandler(this.Frameskip6MenuItem_Click);
+            // 
+            // Frameskip7MenuItem
+            // 
+            this.Frameskip7MenuItem.Text = "7";
+            this.Frameskip7MenuItem.Click += new System.EventHandler(this.Frameskip7MenuItem_Click);
+            // 
+            // Frameskip8MenuItem
+            // 
+            this.Frameskip8MenuItem.Text = "8";
+            this.Frameskip8MenuItem.Click += new System.EventHandler(this.Frameskip8MenuItem_Click);
+            // 
+            // Frameskip9MenuItem
+            // 
+            this.Frameskip9MenuItem.Text = "9";
+            this.Frameskip9MenuItem.Click += new System.EventHandler(this.Frameskip9MenuItem_Click);
+            // 
+            // Speed50MenuItem
+            // 
+            this.Speed50MenuItem.Text = "Speed 50%";
+            this.Speed50MenuItem.Click += new System.EventHandler(this.Speed50MenuItem_Click);
+            // 
+            // Speed75MenuItem
+            // 
+            this.Speed75MenuItem.Text = "Speed 75%";
+            this.Speed75MenuItem.Click += new System.EventHandler(this.Speed75MenuItem_Click);
+            // 
+            // Speed100MenuItem
+            // 
+            this.Speed100MenuItem.Text = "Speed 100%";
+            this.Speed100MenuItem.Click += new System.EventHandler(this.Speed100MenuItem_Click);
+            // 
+            // Speed150MenuItem
+            // 
+            this.Speed150MenuItem.Text = "Speed 150%";
+            this.Speed150MenuItem.Click += new System.EventHandler(this.Speed150MenuItem_Click);
+            // 
+            // Speed200MenuItem
+            // 
+            this.Speed200MenuItem.Text = "Speed 200%";
+            this.Speed200MenuItem.Click += new System.EventHandler(this.Speed200MenuItem_Click);
+            // 
+            // Speed400MenuItem
+            // 
+            this.Speed400MenuItem.Text = "Speed 400%";
+            this.Speed400MenuItem.Click += new System.EventHandler(this.Speed400MenuItem_Click);
+            // 
+            // KeyPrioritySubMenu
+            // 
+            this.KeyPrioritySubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.BothHkAndControllerMenuItem,
+            this.InputOverHkMenuItem,
+            this.HkOverInputMenuItem});
+            this.KeyPrioritySubMenu.Text = "Key Priority";
+            this.KeyPrioritySubMenu.DropDownOpened += new System.EventHandler(this.KeyPriorityMenuItem_DropDownOpened);
+            // 
+            // BothHkAndControllerMenuItem
+            // 
+            this.BothHkAndControllerMenuItem.Text = "Both Hotkeys and Controllers";
+            this.BothHkAndControllerMenuItem.Click += new System.EventHandler(this.BothHkAndControllerMenuItem_Click);
+            // 
+            // InputOverHkMenuItem
+            // 
+            this.InputOverHkMenuItem.Text = "Input overrides Hotkeys";
+            this.InputOverHkMenuItem.Click += new System.EventHandler(this.InputOverHkMenuItem_Click);
+            // 
+            // HkOverInputMenuItem
+            // 
+            this.HkOverInputMenuItem.Text = "Hotkeys override Input";
+            this.HkOverInputMenuItem.Click += new System.EventHandler(this.HkOverInputMenuItem_Click);
+            // 
+            // CoresSubMenu
+            // 
+            this.CoresSubMenu.Text = "Preferred Cores";
+            // 
+            // SaveConfigMenuItem
+            // 
+            this.SaveConfigMenuItem.Text = "Save Config";
+            this.SaveConfigMenuItem.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
+            // 
+            // SaveConfigAsMenuItem
+            // 
+            this.SaveConfigAsMenuItem.Text = "Save Config As...";
+            this.SaveConfigAsMenuItem.Click += new System.EventHandler(this.SaveConfigAsMenuItem_Click);
+            // 
+            // LoadConfigMenuItem
+            // 
+            this.LoadConfigMenuItem.Text = "Load Config";
+            this.LoadConfigMenuItem.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
+            // 
+            // LoadConfigFromMenuItem
+            // 
+            this.LoadConfigFromMenuItem.Text = "Load Config From...";
+            this.LoadConfigFromMenuItem.Click += new System.EventHandler(this.LoadConfigFromMenuItem_Click);
+            // 
+            // ToolsSubMenu
+            // 
+            this.ToolsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ToolBoxMenuItem,
+            this.toolStripSeparator12,
+            this.RamWatchMenuItem,
+            this.RamSearchMenuItem,
+            this.LuaConsoleMenuItem,
+            this.TAStudioMenuItem,
+            this.HexEditorMenuItem,
+            this.TraceLoggerMenuItem,
+            this.DebuggerMenuItem,
+            this.CodeDataLoggerMenuItem,
+            this.MacroToolMenuItem,
+            this.VirtualPadMenuItem,
+            this.BasicBotMenuItem,
+            this.toolStripSeparator11,
+            this.CheatsMenuItem,
+            this.GameSharkConverterMenuItem,
+            this.toolStripSeparator29,
+            this.MultiDiskBundlerFileMenuItem,
+            this.BatchRunnerMenuItem,
+            this.ExternalToolMenuItem,
+            this.RetroAchievementsMenuItem});
+            this.ToolsSubMenu.Text = "&Tools";
+            this.ToolsSubMenu.DropDownOpened += new System.EventHandler(this.ToolsSubMenu_DropDownOpened);
+            // 
+            // ToolBoxMenuItem
+            // 
+            this.ToolBoxMenuItem.Text = "&Tool Box";
+            this.ToolBoxMenuItem.Click += new System.EventHandler(this.ToolBoxMenuItem_Click);
+            // 
+            // RamWatchMenuItem
+            // 
+            this.RamWatchMenuItem.Text = "RAM &Watch";
+            this.RamWatchMenuItem.Click += new System.EventHandler(this.RamWatchMenuItem_Click);
+            // 
+            // RamSearchMenuItem
+            // 
+            this.RamSearchMenuItem.Text = "RAM &Search";
+            this.RamSearchMenuItem.Click += new System.EventHandler(this.RamSearchMenuItem_Click);
+            // 
+            // LuaConsoleMenuItem
+            // 
+            this.LuaConsoleMenuItem.Text = "Lua Console";
+            this.LuaConsoleMenuItem.Click += new System.EventHandler(this.LuaConsoleMenuItem_Click);
+            // 
+            // TAStudioMenuItem
+            // 
+            this.TAStudioMenuItem.Text = "&TAStudio";
+            this.TAStudioMenuItem.Click += new System.EventHandler(this.TAStudioMenuItem_Click);
+            // 
+            // HexEditorMenuItem
+            // 
+            this.HexEditorMenuItem.Text = "&Hex Editor";
+            this.HexEditorMenuItem.Click += new System.EventHandler(this.HexEditorMenuItem_Click);
+            // 
+            // TraceLoggerMenuItem
+            // 
+            this.TraceLoggerMenuItem.Text = "Trace &Logger";
+            this.TraceLoggerMenuItem.Click += new System.EventHandler(this.TraceLoggerMenuItem_Click);
+            // 
+            // DebuggerMenuItem
+            // 
+            this.DebuggerMenuItem.Text = "&Debugger";
+            this.DebuggerMenuItem.Click += new System.EventHandler(this.DebuggerMenuItem_Click);
+            // 
+            // CodeDataLoggerMenuItem
+            // 
+            this.CodeDataLoggerMenuItem.Text = "Code-Data Logger";
+            this.CodeDataLoggerMenuItem.Click += new System.EventHandler(this.CodeDataLoggerMenuItem_Click);
+            // 
+            // MacroToolMenuItem
+            // 
+            this.MacroToolMenuItem.Text = "&Macro Tool";
+            this.MacroToolMenuItem.Click += new System.EventHandler(this.MacroToolMenuItem_Click);
+            // 
+            // VirtualPadMenuItem
+            // 
+            this.VirtualPadMenuItem.Text = "Virtual Pad";
+            this.VirtualPadMenuItem.Click += new System.EventHandler(this.VirtualPadMenuItem_Click);
+            // 
+            // BasicBotMenuItem
+            // 
+            this.BasicBotMenuItem.Text = "Basic Bot";
+            this.BasicBotMenuItem.Click += new System.EventHandler(this.BasicBotMenuItem_Click);
+            // 
+            // CheatsMenuItem
+            // 
+            this.CheatsMenuItem.Text = "Cheats";
+            this.CheatsMenuItem.Click += new System.EventHandler(this.CheatsMenuItem_Click);
+            // 
+            // GameSharkConverterMenuItem
+            // 
+            this.GameSharkConverterMenuItem.Text = "Cheat Code Converter";
+            this.GameSharkConverterMenuItem.Click += new System.EventHandler(this.CheatCodeConverterMenuItem_Click);
+            // 
+            // MultiDiskBundlerFileMenuItem
+            // 
+            this.MultiDiskBundlerFileMenuItem.Text = "Multi-disk Bundler";
+            this.MultiDiskBundlerFileMenuItem.Click += new System.EventHandler(this.MultidiskBundlerMenuItem_Click);
+            // 
+            // BatchRunnerMenuItem
+            // 
+            this.BatchRunnerMenuItem.Text = "Batch Runner...";
+            this.BatchRunnerMenuItem.Visible = false;
+            this.BatchRunnerMenuItem.Click += new System.EventHandler(this.BatchRunnerMenuItem_Click);
+            // 
+            // ExternalToolMenuItem
+            // 
+            this.ExternalToolMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.dummyExternalTool});
+            this.ExternalToolMenuItem.Text = "External Tool";
+            this.ExternalToolMenuItem.DropDownOpening += new System.EventHandler(this.ExternalToolMenuItem_DropDownOpening);
+            // 
+            // dummyExternalTool
+            // 
+            this.dummyExternalTool.Text = "None";
+            // 
+            // RetroAchievementsMenuItem
+            // 
+            this.RetroAchievementsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.StartRetroAchievementsMenuItem});
+            this.RetroAchievementsMenuItem.Text = "&RetroAchievements";
+            // 
+            // StartRetroAchievementsMenuItem
+            // 
+            this.StartRetroAchievementsMenuItem.Text = "&Start RetroAchievements";
+            this.StartRetroAchievementsMenuItem.Click += new System.EventHandler(this.StartRetroAchievementsMenuItem_Click);
+            // 
+            // NESSubMenu
+            // 
+            this.NESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.NESPPUViewerMenuItem,
+            this.NESNametableViewerMenuItem,
+            this.MusicRipperMenuItem,
+            this.toolStripSeparator17,
+            this.NesControllerSettingsMenuItem,
+            this.NESGraphicSettingsMenuItem,
+            this.NESSoundChannelsMenuItem,
+            this.VSSettingsMenuItem,
+            this.MovieSettingsMenuItem,
+            this.toolStripSeparator22,
+            this.FDSControlsMenuItem,
+            this.VSControlsMenuItem,
+            this.BarcodeReaderMenuItem});
+            this.NESSubMenu.Text = "&NES";
+            this.NESSubMenu.DropDownOpened += new System.EventHandler(this.NesSubMenu_DropDownOpened);
+            // 
+            // NESPPUViewerMenuItem
+            // 
+            this.NESPPUViewerMenuItem.Text = "&PPU Viewer";
+            this.NESPPUViewerMenuItem.Click += new System.EventHandler(this.NesPpuViewerMenuItem_Click);
+            // 
+            // NESNametableViewerMenuItem
+            // 
+            this.NESNametableViewerMenuItem.Text = "&Nametable Viewer";
+            this.NESNametableViewerMenuItem.Click += new System.EventHandler(this.NesNametableViewerMenuItem_Click);
+            // 
+            // MusicRipperMenuItem
+            // 
+            this.MusicRipperMenuItem.Text = "Music Ripper";
+            this.MusicRipperMenuItem.Click += new System.EventHandler(this.MusicRipperMenuItem_Click);
+            // 
+            // NesControllerSettingsMenuItem
+            // 
+            this.NesControllerSettingsMenuItem.Text = "Controller Settings...";
+            this.NesControllerSettingsMenuItem.Click += new System.EventHandler(this.NesControllerSettingsMenuItem_Click);
+            // 
+            // NESGraphicSettingsMenuItem
+            // 
+            this.NESGraphicSettingsMenuItem.Text = "Graphics Settings...";
+            this.NESGraphicSettingsMenuItem.Click += new System.EventHandler(this.NesGraphicSettingsMenuItem_Click);
+            // 
+            // NESSoundChannelsMenuItem
+            // 
+            this.NESSoundChannelsMenuItem.Text = "Sound Channels...";
+            this.NESSoundChannelsMenuItem.Click += new System.EventHandler(this.NesSoundChannelsMenuItem_Click);
+            // 
+            // VSSettingsMenuItem
+            // 
+            this.VSSettingsMenuItem.Text = "VS Settings...";
+            this.VSSettingsMenuItem.Click += new System.EventHandler(this.VsSettingsMenuItem_Click);
+            // 
+            // MovieSettingsMenuItem
+            // 
+            this.MovieSettingsMenuItem.Text = "Advanced Settings...";
+            this.MovieSettingsMenuItem.Click += new System.EventHandler(this.MovieSettingsMenuItem_Click);
+            // 
+            // FDSControlsMenuItem
+            // 
+            this.FDSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.FdsEjectDiskMenuItem});
+            this.FDSControlsMenuItem.Text = "FDS Controls";
+            this.FDSControlsMenuItem.DropDownOpened += new System.EventHandler(this.FdsControlsMenuItem_DropDownOpened);
+            // 
+            // FdsEjectDiskMenuItem
+            // 
+            this.FdsEjectDiskMenuItem.Text = "&Eject Disk";
+            this.FdsEjectDiskMenuItem.Click += new System.EventHandler(this.FdsEjectDiskMenuItem_Click);
+            // 
+            // VSControlsMenuItem
+            // 
+            this.VSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.VSInsertCoinP1MenuItem,
+            this.VSInsertCoinP2MenuItem,
+            this.VSServiceSwitchMenuItem});
+            this.VSControlsMenuItem.Text = "VS Controls";
+            // 
+            // VSInsertCoinP1MenuItem
+            // 
+            this.VSInsertCoinP1MenuItem.Text = "Insert Coin P1";
+            this.VSInsertCoinP1MenuItem.Click += new System.EventHandler(this.VsInsertCoinP1MenuItem_Click);
+            // 
+            // VSInsertCoinP2MenuItem
+            // 
+            this.VSInsertCoinP2MenuItem.Text = "Insert Coin P2";
+            this.VSInsertCoinP2MenuItem.Click += new System.EventHandler(this.VsInsertCoinP2MenuItem_Click);
+            // 
+            // VSServiceSwitchMenuItem
+            // 
+            this.VSServiceSwitchMenuItem.Text = "Service Switch";
+            this.VSServiceSwitchMenuItem.Click += new System.EventHandler(this.VsServiceSwitchMenuItem_Click);
+            // 
+            // BarcodeReaderMenuItem
+            // 
+            this.BarcodeReaderMenuItem.Text = "Barcode Reader";
+            this.BarcodeReaderMenuItem.Click += new System.EventHandler(this.BarcodeReaderMenuItem_Click);
+            // 
+            // TI83SubMenu
+            // 
+            this.TI83SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.KeypadMenuItem,
+            this.LoadTIFileMenuItem,
+            this.toolStripSeparator13,
+            this.paletteToolStripMenuItem});
+            this.TI83SubMenu.Text = "TI83";
+            // 
+            // KeypadMenuItem
+            // 
+            this.KeypadMenuItem.Text = "Keypad";
+            this.KeypadMenuItem.Click += new System.EventHandler(this.Ti83KeypadMenuItem_Click);
+            // 
+            // LoadTIFileMenuItem
+            // 
+            this.LoadTIFileMenuItem.Text = "Load TI-83 File...";
+            this.LoadTIFileMenuItem.Click += new System.EventHandler(this.Ti83LoadTIFileMenuItem_Click);
+            // 
+            // paletteToolStripMenuItem
+            // 
+            this.paletteToolStripMenuItem.Text = "Palette...";
+            this.paletteToolStripMenuItem.Click += new System.EventHandler(this.Ti83PaletteMenuItem_Click);
+            // 
+            // A7800SubMenu
+            // 
+            this.A7800SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.A7800ControllerSettingsMenuItem,
+            this.A7800FilterSettingsMenuItem});
+            this.A7800SubMenu.Text = "&A7800";
+            this.A7800SubMenu.DropDownOpened += new System.EventHandler(this.A7800SubMenu_DropDownOpened);
+            // 
+            // A7800ControllerSettingsMenuItem
+            // 
+            this.A7800ControllerSettingsMenuItem.Text = "Controller Settings";
+            this.A7800ControllerSettingsMenuItem.Click += new System.EventHandler(this.A7800ControllerSettingsMenuItem_Click);
+            // 
+            // A7800FilterSettingsMenuItem
+            // 
+            this.A7800FilterSettingsMenuItem.Text = "Filter Settings";
+            this.A7800FilterSettingsMenuItem.Click += new System.EventHandler(this.A7800FilterSettingsMenuItem_Click);
+            // 
+            // GBSubMenu
+            // 
+            this.GBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.GBcoreSettingsToolStripMenuItem,
+            this.SameBoyColorChooserMenuItem,
+            this.toolStripSeparator28,
+            this.GBGPUViewerMenuItem,
+            this.GBPrinterViewerMenuItem});
+            this.GBSubMenu.Text = "&GB";
+            // 
+            // GBcoreSettingsToolStripMenuItem
+            // 
+            this.GBcoreSettingsToolStripMenuItem.Text = "Settings...";
+            this.GBcoreSettingsToolStripMenuItem.Click += new System.EventHandler(this.GbCoreSettingsMenuItem_Click);
+            // 
+            // SameBoyColorChooserMenuItem
+            // 
+            this.SameBoyColorChooserMenuItem.Text = "&Choose Custom Palette...";
+            this.SameBoyColorChooserMenuItem.Click += new System.EventHandler(this.SameboyColorChooserMenuItem_Click);
+            // 
+            // GBGPUViewerMenuItem
+            // 
+            this.GBGPUViewerMenuItem.Text = "GPU Viewer";
+            this.GBGPUViewerMenuItem.Click += new System.EventHandler(this.GbGpuViewerMenuItem_Click);
+            // 
+            // GBPrinterViewerMenuItem
+            // 
+            this.GBPrinterViewerMenuItem.Text = "&Printer Viewer";
+            this.GBPrinterViewerMenuItem.Click += new System.EventHandler(this.GbPrinterViewerMenuItem_Click);
+            // 
+            // PSXSubMenu
+            // 
+            this.PSXSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.PSXControllerSettingsMenuItem,
+            this.PSXOptionsMenuItem,
+            this.PSXDiscControlsMenuItem,
+            this.PSXHashDiscsToolStripMenuItem});
+            this.PSXSubMenu.Text = "PSX";
+            this.PSXSubMenu.DropDownOpened += new System.EventHandler(this.PsxSubMenu_DropDownOpened);
+            // 
+            // PSXControllerSettingsMenuItem
+            // 
+            this.PSXControllerSettingsMenuItem.Text = "Controller / Memcard Settings";
+            this.PSXControllerSettingsMenuItem.Click += new System.EventHandler(this.PsxControllerSettingsMenuItem_Click);
+            // 
+            // PSXOptionsMenuItem
+            // 
+            this.PSXOptionsMenuItem.Text = "&Options";
+            this.PSXOptionsMenuItem.Click += new System.EventHandler(this.PsxOptionsMenuItem_Click);
+            // 
+            // PSXDiscControlsMenuItem
+            // 
+            this.PSXDiscControlsMenuItem.Text = "&Disc Controls";
+            this.PSXDiscControlsMenuItem.Click += new System.EventHandler(this.PsxDiscControlsMenuItem_Click);
+            // 
+            // PSXHashDiscsToolStripMenuItem
+            // 
+            this.PSXHashDiscsToolStripMenuItem.Text = "&Hash Discs";
+            this.PSXHashDiscsToolStripMenuItem.Click += new System.EventHandler(this.PsxHashDiscsMenuItem_Click);
+            // 
+            // SNESSubMenu
+            // 
+            this.SNESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.SNESControllerConfigurationMenuItem,
+            this.toolStripSeparator18,
+            this.SnesGfxDebuggerMenuItem,
+            this.SnesOptionsMenuItem});
+            this.SNESSubMenu.Text = "&SNES";
+            this.SNESSubMenu.DropDownOpened += new System.EventHandler(this.SnesSubMenu_DropDownOpened);
+            // 
+            // SNESControllerConfigurationMenuItem
+            // 
+            this.SNESControllerConfigurationMenuItem.Text = "Controller Configuration";
+            this.SNESControllerConfigurationMenuItem.Click += new System.EventHandler(this.SNESControllerConfigurationMenuItem_Click);
+            // 
+            // SnesGfxDebuggerMenuItem
+            // 
+            this.SnesGfxDebuggerMenuItem.Text = "Graphics Debugger";
+            this.SnesGfxDebuggerMenuItem.Click += new System.EventHandler(this.SnesGfxDebuggerMenuItem_Click);
+            // 
+            // SnesOptionsMenuItem
+            // 
+            this.SnesOptionsMenuItem.Text = "&Options";
+            this.SnesOptionsMenuItem.Click += new System.EventHandler(this.SnesOptionsMenuItem_Click);
+            // 
+            // ColecoSubMenu
+            // 
+            this.ColecoSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ColecoControllerSettingsMenuItem,
+            this.toolStripSeparator35,
+            this.ColecoSkipBiosMenuItem,
+            this.ColecoUseSGMMenuItem});
+            this.ColecoSubMenu.Text = "&Coleco";
+            this.ColecoSubMenu.DropDownOpened += new System.EventHandler(this.ColecoSubMenu_DropDownOpened);
+            // 
+            // ColecoControllerSettingsMenuItem
+            // 
+            this.ColecoControllerSettingsMenuItem.Text = "&Controller Settings...";
+            this.ColecoControllerSettingsMenuItem.Click += new System.EventHandler(this.ColecoControllerSettingsMenuItem_Click);
+            // 
+            // ColecoSkipBiosMenuItem
+            // 
+            this.ColecoSkipBiosMenuItem.Text = "&Skip BIOS intro (When Applicable)";
+            this.ColecoSkipBiosMenuItem.Click += new System.EventHandler(this.ColecoSkipBiosMenuItem_Click);
+            // 
+            // ColecoUseSGMMenuItem
+            // 
+            this.ColecoUseSGMMenuItem.Text = "&Use the Super Game Module";
+            this.ColecoUseSGMMenuItem.Click += new System.EventHandler(this.ColecoUseSGMMenuItem_Click);
+            // 
+            // N64SubMenu
+            // 
+            this.N64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.N64PluginSettingsMenuItem,
+            this.N64ControllerSettingsMenuItem,
+            this.toolStripSeparator23,
+            this.N64CircularAnalogRangeMenuItem,
+            this.MupenStyleLagMenuItem,
+            this.N64ExpansionSlotMenuItem});
+            this.N64SubMenu.Text = "N64";
+            this.N64SubMenu.DropDownOpened += new System.EventHandler(this.N64SubMenu_DropDownOpened);
+            // 
+            // N64PluginSettingsMenuItem
+            // 
+            this.N64PluginSettingsMenuItem.Text = "Plugins";
+            this.N64PluginSettingsMenuItem.Click += new System.EventHandler(this.N64PluginSettingsMenuItem_Click);
+            // 
+            // N64ControllerSettingsMenuItem
+            // 
+            this.N64ControllerSettingsMenuItem.Text = "Controller Settings...";
+            this.N64ControllerSettingsMenuItem.Click += new System.EventHandler(this.N64ControllerSettingsMenuItem_Click);
+            // 
+            // N64CircularAnalogRangeMenuItem
+            // 
+            this.N64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
+            this.N64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
+            // 
+            // MupenStyleLagMenuItem
+            // 
+            this.MupenStyleLagMenuItem.Text = "&Mupen Style Lag Frames";
+            this.MupenStyleLagMenuItem.Click += new System.EventHandler(this.MupenStyleLagMenuItem_Click);
+            // 
+            // N64ExpansionSlotMenuItem
+            // 
+            this.N64ExpansionSlotMenuItem.Text = "&Use Expansion Slot";
+            this.N64ExpansionSlotMenuItem.Click += new System.EventHandler(this.N64ExpansionSlotMenuItem_Click);
+            // 
+            // Ares64SubMenu
+            // 
+            this.Ares64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.Ares64SettingsMenuItem,
+            this.Ares64CircularAnalogRangeMenuItem});
+            this.Ares64SubMenu.Text = "N64";
+            this.Ares64SubMenu.DropDownOpened += new System.EventHandler(this.Ares64SubMenu_DropDownOpened);
+            // 
+            // Ares64SettingsMenuItem
+            // 
+            this.Ares64SettingsMenuItem.Text = "Settings...";
+            this.Ares64SettingsMenuItem.Click += new System.EventHandler(this.Ares64SettingsMenuItem_Click);
+            // 
+            // Ares64CircularAnalogRangeMenuItem
+            // 
+            this.Ares64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
+            this.Ares64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
+            // 
+            // GBLSubMenu
+            // 
+            this.GBLSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.GBLsettingsToolStripMenuItem});
+            this.GBLSubMenu.Text = "&GB Link";
+            // 
+            // GBLsettingsToolStripMenuItem
+            // 
+            this.GBLsettingsToolStripMenuItem.Text = "Settings...";
+            this.GBLsettingsToolStripMenuItem.Click += new System.EventHandler(this.GblSettingsMenuItem_Click);
+            // 
+            // AppleSubMenu
+            // 
+            this.AppleSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.AppleDisksSubMenu,
+            this.settingsToolStripMenuItem1});
+            this.AppleSubMenu.Text = "Apple";
+            this.AppleSubMenu.DropDownOpened += new System.EventHandler(this.AppleSubMenu_DropDownOpened);
+            // 
+            // AppleDisksSubMenu
+            // 
+            this.AppleDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripSeparator31});
+            this.AppleDisksSubMenu.Text = "Disks";
+            this.AppleDisksSubMenu.DropDownOpened += new System.EventHandler(this.AppleDisksSubMenu_DropDownOpened);
+            // 
+            // settingsToolStripMenuItem1
+            // 
+            this.settingsToolStripMenuItem1.Text = "&Settings...";
+            this.settingsToolStripMenuItem1.Click += new System.EventHandler(this.AppleIISettingsMenuItem_Click);
+            // 
+            // C64SubMenu
+            // 
+            this.C64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.C64DisksSubMenu,
+            this.C64SettingsMenuItem});
+            this.C64SubMenu.Text = "&C64";
+            this.C64SubMenu.DropDownOpened += new System.EventHandler(this.C64SubMenu_DropDownOpened);
+            // 
+            // C64DisksSubMenu
+            // 
+            this.C64DisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripSeparator36});
+            this.C64DisksSubMenu.Text = "Disks";
+            this.C64DisksSubMenu.DropDownOpened += new System.EventHandler(this.C64DisksSubMenu_DropDownOpened);
+            // 
+            // C64SettingsMenuItem
+            // 
+            this.C64SettingsMenuItem.Text = "&Settings...";
+            this.C64SettingsMenuItem.Click += new System.EventHandler(this.C64SettingsMenuItem_Click);
+            // 
+            // IntvSubMenu
+            // 
+            this.IntvSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.IntVControllerSettingsMenuItem});
+            this.IntvSubMenu.Text = "&Intv";
+            this.IntvSubMenu.DropDownOpened += new System.EventHandler(this.IntVSubMenu_DropDownOpened);
+            // 
+            // IntVControllerSettingsMenuItem
+            // 
+            this.IntVControllerSettingsMenuItem.Text = "Controller Settings...";
+            this.IntVControllerSettingsMenuItem.Click += new System.EventHandler(this.IntVControllerSettingsMenuItem_Click);
+            // 
+            // zXSpectrumToolStripMenuItem
+            // 
+            this.zXSpectrumToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ZXSpectrumCoreEmulationSettingsMenuItem,
+            this.ZXSpectrumControllerConfigurationMenuItem,
+            this.ZXSpectrumAudioSettingsMenuItem,
+            this.ZXSpectrumNonSyncSettingsMenuItem,
+            this.ZXSpectrumMediaMenuItem});
+            this.zXSpectrumToolStripMenuItem.Text = "ZX Spectrum";
+            // 
+            // ZXSpectrumCoreEmulationSettingsMenuItem
+            // 
+            this.ZXSpectrumCoreEmulationSettingsMenuItem.Text = "Core Emulation Settings";
+            this.ZXSpectrumCoreEmulationSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumCoreEmulationSettingsMenuItem_Click);
+            // 
+            // ZXSpectrumControllerConfigurationMenuItem
+            // 
+            this.ZXSpectrumControllerConfigurationMenuItem.Text = "Joystick Configuration";
+            this.ZXSpectrumControllerConfigurationMenuItem.Click += new System.EventHandler(this.ZXSpectrumControllerConfigurationMenuItem_Click);
+            // 
+            // ZXSpectrumAudioSettingsMenuItem
+            // 
+            this.ZXSpectrumAudioSettingsMenuItem.Text = "Audio Settings";
+            this.ZXSpectrumAudioSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumAudioSettingsMenuItem_Click);
+            // 
+            // ZXSpectrumNonSyncSettingsMenuItem
+            // 
+            this.ZXSpectrumNonSyncSettingsMenuItem.Text = "Non-Sync Settings";
+            this.ZXSpectrumNonSyncSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumNonSyncSettingsMenuItem_Click);
+            // 
+            // ZXSpectrumMediaMenuItem
+            // 
+            this.ZXSpectrumMediaMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ZXSpectrumTapesSubMenu,
+            this.ZXSpectrumDisksSubMenu,
+            this.ZXSpectrumExportSnapshotMenuItemMenuItem});
+            this.ZXSpectrumMediaMenuItem.Text = "Media";
+            this.ZXSpectrumMediaMenuItem.DropDownOpened += new System.EventHandler(this.ZXSpectrumMediaMenuItem_DropDownOpened);
+            // 
+            // ZXSpectrumTapesSubMenu
+            // 
+            this.ZXSpectrumTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.zxt1ToolStripMenuItem});
+            this.ZXSpectrumTapesSubMenu.Text = "Tapes";
+            this.ZXSpectrumTapesSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumTapesSubMenu_DropDownOpened);
+            // 
+            // zxt1ToolStripMenuItem
+            // 
+            this.zxt1ToolStripMenuItem.Text = "zxt1";
+            // 
+            // ZXSpectrumDisksSubMenu
+            // 
+            this.ZXSpectrumDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.zxt2ToolStripMenuItem});
+            this.ZXSpectrumDisksSubMenu.Text = "Disks";
+            this.ZXSpectrumDisksSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumDisksSubMenu_DropDownOpened);
+            // 
+            // zxt2ToolStripMenuItem
+            // 
+            this.zxt2ToolStripMenuItem.Text = "zxt2";
+            // 
+            // ZXSpectrumExportSnapshotMenuItemMenuItem
+            // 
+            this.ZXSpectrumExportSnapshotMenuItemMenuItem.Text = "Export Snapshot";
+            this.ZXSpectrumExportSnapshotMenuItemMenuItem.Click += new System.EventHandler(this.ZXSpectrumExportSnapshotMenuItemMenuItem_Click);
+            // 
+            // GenericCoreSubMenu
+            // 
+            this.GenericCoreSubMenu.Text = "&Core";
+            // 
+            // amstradCPCToolStripMenuItem
+            // 
+            this.amstradCPCToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.amstradCPCCoreEmulationSettingsToolStripMenuItem,
+            this.AmstradCPCAudioSettingsToolStripMenuItem,
+            this.AmstradCPCNonSyncSettingsToolStripMenuItem,
+            this.AmstradCPCMediaToolStripMenuItem});
+            this.amstradCPCToolStripMenuItem.Text = "Amstrad CPC";
+            // 
+            // amstradCPCCoreEmulationSettingsToolStripMenuItem
+            // 
+            this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Text = "Core Emulation Settings";
+            this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcCoreEmulationSettingsMenuItem_Click);
+            // 
+            // AmstradCPCAudioSettingsToolStripMenuItem
+            // 
+            this.AmstradCPCAudioSettingsToolStripMenuItem.Text = "Audio Settings";
+            this.AmstradCPCAudioSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcAudioSettingsMenuItem_Click);
+            // 
+            // AmstradCPCNonSyncSettingsToolStripMenuItem
+            // 
+            this.AmstradCPCNonSyncSettingsToolStripMenuItem.Text = "Non-Sync Settings";
+            this.AmstradCPCNonSyncSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcNonSyncSettingsMenuItem_Click);
+            // 
+            // AmstradCPCMediaToolStripMenuItem
+            // 
+            this.AmstradCPCMediaToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.AmstradCPCTapesSubMenu,
+            this.AmstradCPCDisksSubMenu});
+            this.AmstradCPCMediaToolStripMenuItem.Text = "Media";
+            this.AmstradCPCMediaToolStripMenuItem.DropDownOpened += new System.EventHandler(this.AmstradCpcMediaMenuItem_DropDownOpened);
+            // 
+            // AmstradCPCTapesSubMenu
+            // 
+            this.AmstradCPCTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cpct1ToolStripMenuItem});
+            this.AmstradCPCTapesSubMenu.Text = "Tapes";
+            this.AmstradCPCTapesSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcTapesSubMenu_DropDownOpened);
+            // 
+            // cpct1ToolStripMenuItem
+            // 
+            this.cpct1ToolStripMenuItem.Text = "cpct1";
+            // 
+            // AmstradCPCDisksSubMenu
+            // 
+            this.AmstradCPCDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cpcd1ToolStripMenuItem});
+            this.AmstradCPCDisksSubMenu.Text = "Disks";
+            this.AmstradCPCDisksSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcDisksSubMenu_DropDownOpened);
+            // 
+            // cpcd1ToolStripMenuItem
+            // 
+            this.cpcd1ToolStripMenuItem.Text = "cpcd1";
+            // 
+            // HelpSubMenu
+            // 
+            this.HelpSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.OnlineHelpMenuItem,
+            this.ForumsMenuItem,
+            this.FeaturesMenuItem,
+            this.AboutMenuItem});
+            this.HelpSubMenu.Text = "&Help";
+            this.HelpSubMenu.DropDownOpened += new System.EventHandler(this.HelpSubMenu_DropDownOpened);
+            // 
+            // OnlineHelpMenuItem
+            // 
+            this.OnlineHelpMenuItem.Text = "Open TASVideos Wiki in Browser";
+            this.OnlineHelpMenuItem.Click += new System.EventHandler(this.OnlineHelpMenuItem_Click);
+            // 
+            // ForumsMenuItem
+            // 
+            this.ForumsMenuItem.Text = "Open Forums in Browser";
+            this.ForumsMenuItem.Click += new System.EventHandler(this.ForumsMenuItem_Click);
+            // 
+            // FeaturesMenuItem
+            // 
+            this.FeaturesMenuItem.Text = "&Features";
+            this.FeaturesMenuItem.Click += new System.EventHandler(this.FeaturesMenuItem_Click);
+            // 
+            // AboutMenuItem
+            // 
+            this.AboutMenuItem.Text = "&About...";
+            this.AboutMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
+            // 
+            // A7800HawkCoreMenuItem
+            // 
+            this.A7800HawkCoreMenuItem.Text = "A7800Hawk";
+            // 
+            // MainStatusBar
+            // 
+            this.MainStatusBar.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.MainStatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.DumpStatusButton,
+            this.EmuStatus,
+            this.PlayRecordStatusButton,
+            this.PauseStatusButton,
+            this.RebootStatusBarIcon,
+            this.AVIStatusLabel,
+            this.LedLightStatusLabel,
+            this.SaveSlotsStatusLabel,
+            this.Slot1StatusButton,
+            this.Slot2StatusButton,
+            this.Slot3StatusButton,
+            this.Slot4StatusButton,
+            this.Slot5StatusButton,
+            this.Slot6StatusButton,
+            this.Slot7StatusButton,
+            this.Slot8StatusButton,
+            this.Slot9StatusButton,
+            this.Slot0StatusButton,
+            this.CheatStatusButton,
+            this.KeyPriorityStatusLabel,
+            this.CoreNameStatusBarButton,
+            this.ProfileFirstBootLabel,
+            this.LinkConnectStatusBarButton,
+            this.UpdateNotification});
+            this.MainStatusBar.Location = new System.Drawing.Point(0, 382);
+            this.MainStatusBar.Name = "MainStatusBar";
+            this.MainStatusBar.ShowItemToolTips = true;
+            this.MainStatusBar.SizingGrip = false;
+            this.MainStatusBar.TabIndex = 1;
+            // 
+            // DumpStatusButton
+            // 
+            this.DumpStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.DumpStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.DumpStatusButton.Name = "DumpStatusButton";
+            this.DumpStatusButton.ShowDropDownArrow = false;
+            this.DumpStatusButton.Size = new System.Drawing.Size(4, 24);
+            this.DumpStatusButton.Text = "No ROM loaded";
+            this.DumpStatusButton.Click += new System.EventHandler(this.DumpStatusButton_Click);
+            // 
+            // PlayRecordStatusButton
+            // 
+            this.PlayRecordStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.PlayRecordStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.PlayRecordStatusButton.Name = "PlayRecordStatusButton";
+            this.PlayRecordStatusButton.ShowDropDownArrow = false;
+            this.PlayRecordStatusButton.Size = new System.Drawing.Size(4, 24);
+            this.PlayRecordStatusButton.Text = "No movie is active";
+            // 
+            // PauseStatusButton
+            // 
+            this.PauseStatusButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.PauseStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.PauseStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.PauseStatusButton.Name = "PauseStatusButton";
+            this.PauseStatusButton.ShowDropDownArrow = false;
+            this.PauseStatusButton.Size = new System.Drawing.Size(4, 24);
+            this.PauseStatusButton.Text = "toolStripDropDownButton1";
+            this.PauseStatusButton.ToolTipText = "Emulator is paused";
+            this.PauseStatusButton.Click += new System.EventHandler(this.PauseMenuItem_Click);
+            // 
+            // RebootStatusBarIcon
+            // 
+            this.RebootStatusBarIcon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.RebootStatusBarIcon.RightToLeft = System.Windows.Forms.RightToLeft.No;
+            this.RebootStatusBarIcon.Text = "Reboot";
+            this.RebootStatusBarIcon.ToolTipText = "A reboot of the core is needed for a setting change to take effect";
+            this.RebootStatusBarIcon.Click += new System.EventHandler(this.PowerMenuItem_Click);
+            // 
+            // AVIStatusLabel
+            // 
+            this.AVIStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.AVIStatusLabel.Text = "AVI Capture";
+            // 
+            // LedLightStatusLabel
+            // 
+            this.LedLightStatusLabel.ToolTipText = "Disk Drive LED Light";
+            // 
+            // SaveSlotsStatusLabel
+            // 
+            this.SaveSlotsStatusLabel.BackColor = System.Drawing.SystemColors.Control;
+            this.SaveSlotsStatusLabel.Text = "Save slots";
+            // 
+            // Slot1StatusButton
+            // 
+            this.Slot1StatusButton.Text = "1";
+            this.Slot1StatusButton.ToolTipText = "Save slot 1";
+            this.Slot1StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+            // 
+            // Slot2StatusButton
+            // 
+            this.Slot2StatusButton.Text = "2";
+            this.Slot2StatusButton.ToolTipText = "Save slot 2";
+            this.Slot2StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+            // 
+            // Slot3StatusButton
+            // 
+            this.Slot3StatusButton.Text = "3";
+            this.Slot3StatusButton.ToolTipText = "Save slot 3";
+            this.Slot3StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+            // 
+            // Slot4StatusButton
+            // 
+            this.Slot4StatusButton.Text = "4";
+            this.Slot4StatusButton.ToolTipText = "Save slot 4";
+            this.Slot4StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+            // 
+            // Slot5StatusButton
+            // 
+            this.Slot5StatusButton.Text = "5";
+            this.Slot5StatusButton.ToolTipText = "Save slot 5";
+            this.Slot5StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+            // 
+            // Slot6StatusButton
+            // 
+            this.Slot6StatusButton.Text = "6";
+            this.Slot6StatusButton.ToolTipText = "Save slot 6";
+            this.Slot6StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+            // 
+            // Slot7StatusButton
+            // 
+            this.Slot7StatusButton.Text = "7";
+            this.Slot7StatusButton.ToolTipText = "Save slot 7";
+            this.Slot7StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+            // 
+            // Slot8StatusButton
+            // 
+            this.Slot8StatusButton.Text = "8";
+            this.Slot8StatusButton.ToolTipText = "Save slot 8";
+            this.Slot8StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+            // 
+            // Slot9StatusButton
+            // 
+            this.Slot9StatusButton.Text = "9";
+            this.Slot9StatusButton.ToolTipText = "Save slot 9";
+            this.Slot9StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+            // 
+            // Slot0StatusButton
+            // 
+            this.Slot0StatusButton.Text = "0";
+            this.Slot0StatusButton.ToolTipText = "Save slot 10";
+            this.Slot0StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+            // 
+            // CheatStatusButton
+            // 
+            this.CheatStatusButton.Click += new System.EventHandler(this.FreezeStatus_Click);
+            // 
+            // KeyPriorityStatusLabel
+            // 
+            this.KeyPriorityStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.KeyPriorityStatusLabel.Margin = new System.Windows.Forms.Padding(5, 3, 5, 0);
+            this.KeyPriorityStatusLabel.Text = "KeyPriority";
+            this.KeyPriorityStatusLabel.Click += new System.EventHandler(this.KeyPriorityStatusLabel_Click);
+            // 
+            // CoreNameStatusBarButton
+            // 
+            this.CoreNameStatusBarButton.Text = "<core name>";
+            // 
+            // ProfileFirstBootLabel
+            // 
+            this.ProfileFirstBootLabel.AutoToolTip = true;
+            this.ProfileFirstBootLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.ProfileFirstBootLabel.Text = "ProfileFirstBootLabel";
+            this.ProfileFirstBootLabel.ToolTipText = "Set up your profile before use";
+            this.ProfileFirstBootLabel.Visible = false;
+            this.ProfileFirstBootLabel.Click += new System.EventHandler(this.ProfileFirstBootLabel_Click);
+            // 
+            // LinkConnectStatusBarButton
+            // 
+            this.LinkConnectStatusBarButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.LinkConnectStatusBarButton.Text = "Link connection is currently enabled";
+            this.LinkConnectStatusBarButton.ToolTipText = "Link connection is currently enabled";
+            this.LinkConnectStatusBarButton.Click += new System.EventHandler(this.LinkConnectStatusBarButton_Click);
+            // 
+            // UpdateNotification
+            // 
+            this.UpdateNotification.IsLink = true;
+            this.UpdateNotification.LinkColor = System.Drawing.Color.Red;
+            this.UpdateNotification.Spring = true;
+            this.UpdateNotification.Text = "New version available!";
+            this.UpdateNotification.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.UpdateNotification.Click += new System.EventHandler(this.UpdateNotification_Click);
+            // 
+            // MainFormContextMenu
+            // 
+            this.MainFormContextMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.MainFormContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.OpenRomContextMenuItem,
+            this.LoadLastRomContextMenuItem,
+            this.StopAVContextMenuItem,
+            this.ContextSeparator_AfterROM,
+            this.RecordMovieContextMenuItem,
+            this.PlayMovieContextMenuItem,
+            this.RestartMovieContextMenuItem,
+            this.StopMovieContextMenuItem,
+            this.LoadLastMovieContextMenuItem,
+            this.BackupMovieContextMenuItem,
+            this.StopNoSaveContextMenuItem,
+            this.ViewSubtitlesContextMenuItem,
+            this.AddSubtitleContextMenuItem,
+            this.ViewCommentsContextMenuItem,
+            this.SaveMovieContextMenuItem,
+            this.SaveMovieAsContextMenuItem,
+            this.ContextSeparator_AfterMovie,
+            this.UndoSavestateContextMenuItem,
+            this.ContextSeparator_AfterUndo,
+            this.ConfigContextMenuItem,
+            this.ScreenshotContextMenuItem,
+            this.CloseRomContextMenuItem,
+            this.ClearSRAMContextMenuItem,
+            this.ShowMenuContextMenuSeparator,
+            this.ShowMenuContextMenuItem});
+            this.MainFormContextMenu.Name = "contextMenuStrip1";
+            this.MainFormContextMenu.Size = new System.Drawing.Size(257, 532);
+            this.MainFormContextMenu.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.MainFormContextMenu_Closing);
+            this.MainFormContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.MainFormContextMenu_Opening);
+            // 
+            // OpenRomContextMenuItem
+            // 
+            this.OpenRomContextMenuItem.Text = "Open Rom";
+            this.OpenRomContextMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
+            // 
+            // LoadLastRomContextMenuItem
+            // 
+            this.LoadLastRomContextMenuItem.Text = "Load Last ROM";
+            this.LoadLastRomContextMenuItem.Click += new System.EventHandler(this.LoadLastRomContextMenuItem_Click);
+            // 
+            // StopAVContextMenuItem
+            // 
+            this.StopAVContextMenuItem.Text = "Stop AVI/WAV";
+            this.StopAVContextMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
+            // 
+            // RecordMovieContextMenuItem
+            // 
+            this.RecordMovieContextMenuItem.Text = "Record Movie";
+            this.RecordMovieContextMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
+            // 
+            // PlayMovieContextMenuItem
+            // 
+            this.PlayMovieContextMenuItem.Text = "Play Movie";
+            this.PlayMovieContextMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
+            // 
+            // RestartMovieContextMenuItem
+            // 
+            this.RestartMovieContextMenuItem.Text = "Restart Movie";
+            this.RestartMovieContextMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
+            // 
+            // StopMovieContextMenuItem
+            // 
+            this.StopMovieContextMenuItem.Text = "Stop Movie";
+            this.StopMovieContextMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
+            // 
+            // LoadLastMovieContextMenuItem
+            // 
+            this.LoadLastMovieContextMenuItem.Text = "Load Last Movie";
+            this.LoadLastMovieContextMenuItem.Click += new System.EventHandler(this.LoadLastMovieContextMenuItem_Click);
+            // 
+            // BackupMovieContextMenuItem
+            // 
+            this.BackupMovieContextMenuItem.Text = "Backup Movie";
+            this.BackupMovieContextMenuItem.Click += new System.EventHandler(this.BackupMovieContextMenuItem_Click);
+            // 
+            // StopNoSaveContextMenuItem
+            // 
+            this.StopNoSaveContextMenuItem.Text = "Stop Movie without Saving";
+            this.StopNoSaveContextMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
+            // 
+            // ViewSubtitlesContextMenuItem
+            // 
+            this.ViewSubtitlesContextMenuItem.Text = "View Subtitles";
+            this.ViewSubtitlesContextMenuItem.Click += new System.EventHandler(this.ViewSubtitlesContextMenuItem_Click);
+            // 
+            // AddSubtitleContextMenuItem
+            // 
+            this.AddSubtitleContextMenuItem.Text = "Add Subtitle";
+            this.AddSubtitleContextMenuItem.Click += new System.EventHandler(this.AddSubtitleContextMenuItem_Click);
+            // 
+            // ViewCommentsContextMenuItem
+            // 
+            this.ViewCommentsContextMenuItem.Text = "View Comments";
+            this.ViewCommentsContextMenuItem.Click += new System.EventHandler(this.ViewCommentsContextMenuItem_Click);
+            // 
+            // SaveMovieContextMenuItem
+            // 
+            this.SaveMovieContextMenuItem.Text = "Save Movie";
+            this.SaveMovieContextMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
+            // 
+            // SaveMovieAsContextMenuItem
+            // 
+            this.SaveMovieAsContextMenuItem.Text = "Save Movie As...";
+            this.SaveMovieAsContextMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
+            // 
+            // UndoSavestateContextMenuItem
+            // 
+            this.UndoSavestateContextMenuItem.Text = "Undo Savestate";
+            this.UndoSavestateContextMenuItem.Click += new System.EventHandler(this.UndoSavestateContextMenuItem_Click);
+            // 
+            // ConfigContextMenuItem
+            // 
+            this.ConfigContextMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem6,
+            this.toolStripMenuItem7,
+            this.toolStripMenuItem8,
+            this.toolStripMenuItem9,
+            this.toolStripMenuItem10,
+            this.toolStripMenuItem11,
+            this.toolStripMenuItem12,
+            this.toolStripMenuItem13,
+            this.toolStripMenuItem14,
+            this.toolStripMenuItem15,
+            this.customizeToolStripMenuItem,
+            this.toolStripSeparator30,
+            this.toolStripMenuItem66,
+            this.toolStripMenuItem67});
+            this.ConfigContextMenuItem.Text = "Config";
+            // 
+            // toolStripMenuItem6
+            // 
+            this.toolStripMenuItem6.Text = "&Controllers...";
+            this.toolStripMenuItem6.Click += new System.EventHandler(this.ControllersMenuItem_Click);
+            // 
+            // toolStripMenuItem7
+            // 
+            this.toolStripMenuItem7.Text = "&Hotkeys...";
+            this.toolStripMenuItem7.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
+            // 
+            // toolStripMenuItem8
+            // 
+            this.toolStripMenuItem8.Text = "Display...";
+            this.toolStripMenuItem8.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
+            // 
+            // toolStripMenuItem9
+            // 
+            this.toolStripMenuItem9.Text = "&Sound...";
+            this.toolStripMenuItem9.Click += new System.EventHandler(this.SoundMenuItem_Click);
+            // 
+            // toolStripMenuItem10
+            // 
+            this.toolStripMenuItem10.Text = "Paths...";
+            this.toolStripMenuItem10.Click += new System.EventHandler(this.PathsMenuItem_Click);
+            // 
+            // toolStripMenuItem11
+            // 
+            this.toolStripMenuItem11.Text = "&Firmwares...";
+            this.toolStripMenuItem11.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
+            // 
+            // toolStripMenuItem12
+            // 
+            this.toolStripMenuItem12.Text = "&Messages...";
+            this.toolStripMenuItem12.Click += new System.EventHandler(this.MessagesMenuItem_Click);
+            // 
+            // toolStripMenuItem13
+            // 
+            this.toolStripMenuItem13.Text = "&Autofire...";
+            this.toolStripMenuItem13.Click += new System.EventHandler(this.AutofireMenuItem_Click);
+            // 
+            // toolStripMenuItem14
+            // 
+            this.toolStripMenuItem14.Text = "&Rewind...";
+            this.toolStripMenuItem14.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
+            // 
+            // toolStripMenuItem15
+            // 
+            this.toolStripMenuItem15.Text = "File Extensions...";
+            this.toolStripMenuItem15.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
+            // 
+            // customizeToolStripMenuItem
+            // 
+            this.customizeToolStripMenuItem.Text = "Customize...";
+            this.customizeToolStripMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
+            // 
+            // toolStripMenuItem66
+            // 
+            this.toolStripMenuItem66.Text = "Save Config";
+            this.toolStripMenuItem66.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
+            // 
+            // toolStripMenuItem67
+            // 
+            this.toolStripMenuItem67.Text = "Load Config";
+            this.toolStripMenuItem67.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
+            // 
+            // ScreenshotContextMenuItem
+            // 
+            this.ScreenshotContextMenuItem.Text = "Screenshot";
+            this.ScreenshotContextMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
+            // 
+            // CloseRomContextMenuItem
+            // 
+            this.CloseRomContextMenuItem.Text = "Close ROM";
+            this.CloseRomContextMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
+            // 
+            // ClearSRAMContextMenuItem
+            // 
+            this.ClearSRAMContextMenuItem.Text = "Close and Clear SRAM";
+            this.ClearSRAMContextMenuItem.Click += new System.EventHandler(this.ClearSramContextMenuItem_Click);
+            // 
+            // ShowMenuContextMenuItem
+            // 
+            this.ShowMenuContextMenuItem.Text = "Show Menu";
+            this.ShowMenuContextMenuItem.Click += new System.EventHandler(this.ShowMenuContextMenuItem_Click);
+            // 
+            // timerMouseIdle
+            // 
+            this.timerMouseIdle.Enabled = true;
+            this.timerMouseIdle.Interval = 2000;
+            this.timerMouseIdle.Tick += new System.EventHandler(this.TimerMouseIdle_Tick);
+            // 
+            // MainForm
+            // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            this.ClientSize = new System.Drawing.Size(470, 408);
+            this.Controls.Add(this.MainStatusBar);
+            this.Controls.Add(this.MainformMenu);
+            this.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.MainMenuStrip = this.MainformMenu;
+            this.Name = "MainForm";
+            this.Activated += new System.EventHandler(this.MainForm_Activated);
+            this.Deactivate += new System.EventHandler(this.MainForm_Deactivate);
+            this.Load += new System.EventHandler(this.MainForm_Load);
+            this.Shown += new System.EventHandler(this.MainForm_Shown);
+            this.Enter += new System.EventHandler(this.MainForm_Enter);
+            this.Resize += new System.EventHandler(this.MainForm_Resize);
+            this.MainformMenu.ResumeLayout(false);
+            this.MainformMenu.PerformLayout();
+            this.MainStatusBar.ResumeLayout(false);
+            this.MainStatusBar.PerformLayout();
+            this.MainFormContextMenu.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -2529,6 +2559,10 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x3MenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x4MenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x5MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x6MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x7MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x8MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x9MenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx mzMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MovieSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentMovieSubMenu;
@@ -2807,7 +2841,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AmstradCPCNonSyncSettingsToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator8;
 		private System.Windows.Forms.ToolStripMenuItem CaptureLuaMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutosaveLastSlotMenuItem;
 		private ToolStripSeparatorEx toolStripSeparator24;
+		private ToolStripMenuItemEx AutosaveLastSlotMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -17,2462 +17,2462 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		private void InitializeComponent()
 		{
-            this.components = new System.ComponentModel.Container();
-            this.MainformMenu = new BizHawk.WinForms.Controls.MenuStripEx();
-            this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.OpenRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.RecentRomSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.OpenAdvancedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.CloseRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.SaveStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.SaveNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator24 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.AutosaveLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.LoadNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator21 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.AutoloadLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveSlotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SelectSlot1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SelectSlot2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SelectSlot3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SelectSlot4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SelectSlot5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SelectSlot6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SelectSlot7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SelectSlot8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SelectSlot9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SelectSlot0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PreviousSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.NextSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.SaveToCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveRAMSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.FlushSaveRAMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.MovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ReadonlyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator15 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.RecentMovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator16 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.RecordMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PlayMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.StopMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PlayFromBeginningMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ImportMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveMovieAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.StopMovieWithoutSavingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator14 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.AutomaticallyBackupMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.FullMovieLoadstatesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MovieEndSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MovieEndFinishMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MovieEndRecordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MovieEndStopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MovieEndPauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AVSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.RecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ConfigAndRecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.StopAVIMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator19 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.CaptureOSDMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.CaptureLuaMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.SynclessRecordingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ScreenshotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ScreenshotAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ScreenshotClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ScreenshotClientClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator20 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.ScreenshotCaptureOSDMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.EmulationSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.RebootCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.SoftResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.HardResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.EmulatorMenuSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.LoadedCoreNameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ViewSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.WindowSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.x1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.x2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.x3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.x4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.x5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.x6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.x7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.x8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.x9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.mzMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SwitchToFullscreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.DisplayFPSMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.DisplayFrameCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.DisplayLagCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.DisplayInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.DisplayRerecordCountMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.DisplaySubtitlesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.DisplayStatusBarMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.DisplayMessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.DisplayLogWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ControllersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.HotkeysMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.DisplayConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SoundMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PathsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.FirmwaresMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AutofireMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.RewindOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.extensionsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ClientOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ProfilesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator9 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.SpeedSkipSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ClockThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AudioThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.VsyncThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator27 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.VsyncEnabledMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.miUnthrottled = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MinimizeSkippingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.NeverSkipMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem17 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Frameskip1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Frameskip2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Frameskip3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Frameskip4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Frameskip5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Frameskip6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Frameskip7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Frameskip8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Frameskip9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.Speed50MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Speed75MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Speed100MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Speed150MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Speed200MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Speed400MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.KeyPrioritySubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.BothHkAndControllerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.InputOverHkMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.HkOverInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.CoresSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator10 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.SaveConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveConfigAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadConfigFromMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ToolsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ToolBoxMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator12 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.RamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.RamSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LuaConsoleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.TAStudioMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.HexEditorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.TraceLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.DebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.CodeDataLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MacroToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.VirtualPadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.BasicBotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator11 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.CheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.GameSharkConverterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator29 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.MultiDiskBundlerFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.BatchRunnerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ExternalToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.dummyExternalTool = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.RetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.StartRetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.NESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.NESPPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.NESNametableViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MusicRipperMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator17 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.NesControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.NESGraphicSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.NESSoundChannelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.VSSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MovieSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator22 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.FDSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.FdsEjectDiskMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.VSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.VSInsertCoinP1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.VSInsertCoinP2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.VSServiceSwitchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.BarcodeReaderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.TI83SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.KeypadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadTIFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator13 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.paletteToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.A7800SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.A7800ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.A7800FilterSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.GBSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.GBcoreSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SameBoyColorChooserMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator28 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.GBGPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.GBPrinterViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PSXSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PSXControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PSXOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PSXDiscControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PSXHashDiscsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SNESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SNESControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator18 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.SnesGfxDebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SnesOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ColecoSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ColecoControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator35 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.ColecoSkipBiosMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ColecoUseSGMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.N64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.N64PluginSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.N64ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator23 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.N64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MupenStyleLagMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.N64ExpansionSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Ares64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Ares64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Ares64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.GBLSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.GBLsettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AppleSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AppleDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator31 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.settingsToolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.C64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.C64DisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator36 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.C64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.IntvSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.IntVControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.zXSpectrumToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ZXSpectrumCoreEmulationSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ZXSpectrumControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ZXSpectrumAudioSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ZXSpectrumNonSyncSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ZXSpectrumMediaMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ZXSpectrumTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.zxt1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ZXSpectrumDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.zxt2ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ZXSpectrumExportSnapshotMenuItemMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.GenericCoreSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.amstradCPCToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.amstradCPCCoreEmulationSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AmstradCPCAudioSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AmstradCPCNonSyncSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AmstradCPCMediaToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AmstradCPCTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.cpct1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AmstradCPCDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.cpcd1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.HelpSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.OnlineHelpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ForumsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.FeaturesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AboutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.A7800HawkCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.MainStatusBar = new BizHawk.WinForms.Controls.StatusStripEx();
-            this.DumpStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-            this.EmuStatus = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.PlayRecordStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-            this.PauseStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-            this.RebootStatusBarIcon = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.AVIStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.LedLightStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.SaveSlotsStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.Slot1StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.Slot2StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.Slot3StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.Slot4StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.Slot5StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.Slot6StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.Slot7StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.Slot8StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.Slot9StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.Slot0StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.CheatStatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.KeyPriorityStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.CoreNameStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.ProfileFirstBootLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.LinkConnectStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.UpdateNotification = new BizHawk.WinForms.Controls.StatusLabelEx();
-            this.MainFormContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.OpenRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadLastRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.StopAVContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ContextSeparator_AfterROM = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.RecordMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.PlayMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.RestartMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.StopMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.LoadLastMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.BackupMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.StopNoSaveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ViewSubtitlesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.AddSubtitleContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ViewCommentsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.SaveMovieAsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ContextSeparator_AfterMovie = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.UndoSavestateContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ContextSeparator_AfterUndo = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.ConfigContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem6 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem7 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem8 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem9 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem10 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem11 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem12 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem13 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem14 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem15 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.customizeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator30 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.toolStripMenuItem66 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripMenuItem67 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ScreenshotContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.CloseRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ClearSRAMContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.ShowMenuContextMenuSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
-            this.ShowMenuContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
-            this.MainformMenu.SuspendLayout();
-            this.MainStatusBar.SuspendLayout();
-            this.MainFormContextMenu.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // MainformMenu
-            // 
-            this.MainformMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.MainformMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.FileSubMenu,
-            this.EmulationSubMenu,
-            this.ViewSubMenu,
-            this.ConfigSubMenu,
-            this.ToolsSubMenu,
-            this.NESSubMenu,
-            this.TI83SubMenu,
-            this.A7800SubMenu,
-            this.GBSubMenu,
-            this.PSXSubMenu,
-            this.SNESSubMenu,
-            this.ColecoSubMenu,
-            this.N64SubMenu,
-            this.Ares64SubMenu,
-            this.GBLSubMenu,
-            this.AppleSubMenu,
-            this.C64SubMenu,
-            this.IntvSubMenu,
-            this.zXSpectrumToolStripMenuItem,
-            this.GenericCoreSubMenu,
-            this.amstradCPCToolStripMenuItem,
-            this.HelpSubMenu});
-            this.MainformMenu.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
-            this.MainformMenu.TabIndex = 0;
-            this.MainformMenu.MenuActivate += new System.EventHandler(this.MainformMenu_MenuActivate);
-            this.MainformMenu.MenuDeactivate += new System.EventHandler(this.MainformMenu_MenuDeactivate);
-            // 
-            // FileSubMenu
-            // 
-            this.FileSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.OpenRomMenuItem,
-            this.RecentRomSubMenu,
-            this.OpenAdvancedMenuItem,
-            this.CloseRomMenuItem,
-            this.toolStripMenuItem1,
-            this.SaveStateSubMenu,
-            this.LoadStateSubMenu,
-            this.SaveSlotSubMenu,
-            this.SaveRAMSubMenu,
-            this.toolStripMenuItem2,
-            this.MovieSubMenu,
-            this.AVSubMenu,
-            this.ScreenshotSubMenu,
-            this.toolStripSeparator4,
-            this.ExitMenuItem});
-            this.FileSubMenu.Text = "&File";
-            this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
-            // 
-            // OpenRomMenuItem
-            // 
-            this.OpenRomMenuItem.Text = "&Open ROM...";
-            this.OpenRomMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
-            // 
-            // RecentRomSubMenu
-            // 
-            this.RecentRomSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripSeparator3});
-            this.RecentRomSubMenu.Text = "&Recent ROM";
-            this.RecentRomSubMenu.DropDownOpened += new System.EventHandler(this.RecentRomMenuItem_DropDownOpened);
-            // 
-            // OpenAdvancedMenuItem
-            // 
-            this.OpenAdvancedMenuItem.Text = "Open Ad&vanced...";
-            this.OpenAdvancedMenuItem.Click += new System.EventHandler(this.OpenAdvancedMenuItem_Click);
-            // 
-            // CloseRomMenuItem
-            // 
-            this.CloseRomMenuItem.Text = "&Close ROM";
-            this.CloseRomMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
-            // 
-            // SaveStateSubMenu
-            // 
-            this.SaveStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.SaveState1MenuItem,
-            this.SaveState2MenuItem,
-            this.SaveState3MenuItem,
-            this.SaveState4MenuItem,
-            this.SaveState5MenuItem,
-            this.SaveState6MenuItem,
-            this.SaveState7MenuItem,
-            this.SaveState8MenuItem,
-            this.SaveState9MenuItem,
-            this.SaveState0MenuItem,
-            this.toolStripSeparator6,
-            this.SaveNamedStateMenuItem,
-            this.toolStripSeparator24,
-            this.AutosaveLastSlotMenuItem});
-            this.SaveStateSubMenu.Text = "&Save State";
-            this.SaveStateSubMenu.DropDownOpened += new System.EventHandler(this.SaveStateSubMenu_DropDownOpened);
-            // 
-            // SaveState1MenuItem
-            // 
-            this.SaveState1MenuItem.Text = "1";
-            this.SaveState1MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-            // 
-            // SaveState2MenuItem
-            // 
-            this.SaveState2MenuItem.Text = "2";
-            this.SaveState2MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-            // 
-            // SaveState3MenuItem
-            // 
-            this.SaveState3MenuItem.Text = "3";
-            this.SaveState3MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-            // 
-            // SaveState4MenuItem
-            // 
-            this.SaveState4MenuItem.Text = "4";
-            this.SaveState4MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-            // 
-            // SaveState5MenuItem
-            // 
-            this.SaveState5MenuItem.Text = "5";
-            this.SaveState5MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-            // 
-            // SaveState6MenuItem
-            // 
-            this.SaveState6MenuItem.Text = "6";
-            this.SaveState6MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-            // 
-            // SaveState7MenuItem
-            // 
-            this.SaveState7MenuItem.Text = "7";
-            this.SaveState7MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-            // 
-            // SaveState8MenuItem
-            // 
-            this.SaveState8MenuItem.Text = "8";
-            this.SaveState8MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-            // 
-            // SaveState9MenuItem
-            // 
-            this.SaveState9MenuItem.Text = "9";
-            this.SaveState9MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-            // 
-            // SaveState0MenuItem
-            // 
-            this.SaveState0MenuItem.Text = "10";
-            this.SaveState0MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
-            // 
-            // SaveNamedStateMenuItem
-            // 
-            this.SaveNamedStateMenuItem.Text = "Save Named State...";
-            this.SaveNamedStateMenuItem.Click += new System.EventHandler(this.SaveNamedStateMenuItem_Click);
-            // 
-            // AutosaveLastSlotMenuItem
-            // 
-            this.AutosaveLastSlotMenuItem.Text = "Autosave Last Slot";
-            this.AutosaveLastSlotMenuItem.Click += new System.EventHandler(this.AutosaveLastSlotMenuItem_Click);
-            // 
-            // LoadStateSubMenu
-            // 
-            this.LoadStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.LoadState1MenuItem,
-            this.LoadState2MenuItem,
-            this.LoadState3MenuItem,
-            this.LoadState4MenuItem,
-            this.LoadState5MenuItem,
-            this.LoadState6MenuItem,
-            this.LoadState7MenuItem,
-            this.LoadState8MenuItem,
-            this.LoadState9MenuItem,
-            this.LoadState0MenuItem,
-            this.toolStripSeparator7,
-            this.LoadNamedStateMenuItem,
-            this.toolStripSeparator21,
-            this.AutoloadLastSlotMenuItem});
-            this.LoadStateSubMenu.Text = "&Load State";
-            this.LoadStateSubMenu.DropDownOpened += new System.EventHandler(this.LoadStateSubMenu_DropDownOpened);
-            // 
-            // LoadState1MenuItem
-            // 
-            this.LoadState1MenuItem.Text = "1";
-            this.LoadState1MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-            // 
-            // LoadState2MenuItem
-            // 
-            this.LoadState2MenuItem.Text = "2";
-            this.LoadState2MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-            // 
-            // LoadState3MenuItem
-            // 
-            this.LoadState3MenuItem.Text = "3";
-            this.LoadState3MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-            // 
-            // LoadState4MenuItem
-            // 
-            this.LoadState4MenuItem.Text = "4";
-            this.LoadState4MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-            // 
-            // LoadState5MenuItem
-            // 
-            this.LoadState5MenuItem.Text = "5";
-            this.LoadState5MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-            // 
-            // LoadState6MenuItem
-            // 
-            this.LoadState6MenuItem.Text = "6";
-            this.LoadState6MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-            // 
-            // LoadState7MenuItem
-            // 
-            this.LoadState7MenuItem.Text = "7";
-            this.LoadState7MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-            // 
-            // LoadState8MenuItem
-            // 
-            this.LoadState8MenuItem.Text = "8";
-            this.LoadState8MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-            // 
-            // LoadState9MenuItem
-            // 
-            this.LoadState9MenuItem.Text = "9";
-            this.LoadState9MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-            // 
-            // LoadState0MenuItem
-            // 
-            this.LoadState0MenuItem.Text = "10";
-            this.LoadState0MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
-            // 
-            // LoadNamedStateMenuItem
-            // 
-            this.LoadNamedStateMenuItem.Text = "Load Named State...";
-            this.LoadNamedStateMenuItem.Click += new System.EventHandler(this.LoadNamedStateMenuItem_Click);
-            // 
-            // AutoloadLastSlotMenuItem
-            // 
-            this.AutoloadLastSlotMenuItem.Text = "Autoload Last Slot";
-            this.AutoloadLastSlotMenuItem.Click += new System.EventHandler(this.AutoloadLastSlotMenuItem_Click);
-            // 
-            // SaveSlotSubMenu
-            // 
-            this.SaveSlotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.SelectSlot1MenuItem,
-            this.SelectSlot2MenuItem,
-            this.SelectSlot3MenuItem,
-            this.SelectSlot4MenuItem,
-            this.SelectSlot5MenuItem,
-            this.SelectSlot6MenuItem,
-            this.SelectSlot7MenuItem,
-            this.SelectSlot8MenuItem,
-            this.SelectSlot9MenuItem,
-            this.SelectSlot0MenuItem,
-            this.PreviousSlotMenuItem,
-            this.NextSlotMenuItem,
-            this.toolStripSeparator5,
-            this.SaveToCurrentSlotMenuItem,
-            this.LoadCurrentSlotMenuItem});
-            this.SaveSlotSubMenu.Text = "Save S&lot";
-            this.SaveSlotSubMenu.DropDownOpened += new System.EventHandler(this.SaveSlotSubMenu_DropDownOpened);
-            // 
-            // SelectSlot1MenuItem
-            // 
-            this.SelectSlot1MenuItem.Text = "Select Slot 1";
-            this.SelectSlot1MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-            // 
-            // SelectSlot2MenuItem
-            // 
-            this.SelectSlot2MenuItem.Text = "Select Slot 2";
-            this.SelectSlot2MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-            // 
-            // SelectSlot3MenuItem
-            // 
-            this.SelectSlot3MenuItem.Text = "Select Slot 3";
-            this.SelectSlot3MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-            // 
-            // SelectSlot4MenuItem
-            // 
-            this.SelectSlot4MenuItem.Text = "Select Slot 4";
-            this.SelectSlot4MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-            // 
-            // SelectSlot5MenuItem
-            // 
-            this.SelectSlot5MenuItem.Text = "Select Slot 5";
-            this.SelectSlot5MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-            // 
-            // SelectSlot6MenuItem
-            // 
-            this.SelectSlot6MenuItem.Text = "Select Slot 6";
-            this.SelectSlot6MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-            // 
-            // SelectSlot7MenuItem
-            // 
-            this.SelectSlot7MenuItem.Text = "Select Slot 7";
-            this.SelectSlot7MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-            // 
-            // SelectSlot8MenuItem
-            // 
-            this.SelectSlot8MenuItem.Text = "Select Slot 8";
-            this.SelectSlot8MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-            // 
-            // SelectSlot9MenuItem
-            // 
-            this.SelectSlot9MenuItem.Text = "Select Slot 9";
-            this.SelectSlot9MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-            // 
-            // SelectSlot0MenuItem
-            // 
-            this.SelectSlot0MenuItem.Text = "Select Slot 10";
-            this.SelectSlot0MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
-            // 
-            // PreviousSlotMenuItem
-            // 
-            this.PreviousSlotMenuItem.Text = "Previous Slot";
-            this.PreviousSlotMenuItem.Click += new System.EventHandler(this.PreviousSlotMenuItem_Click);
-            // 
-            // NextSlotMenuItem
-            // 
-            this.NextSlotMenuItem.Text = "Next Slot";
-            this.NextSlotMenuItem.Click += new System.EventHandler(this.NextSlotMenuItem_Click);
-            // 
-            // SaveToCurrentSlotMenuItem
-            // 
-            this.SaveToCurrentSlotMenuItem.Text = "Save to Current Slot";
-            this.SaveToCurrentSlotMenuItem.Click += new System.EventHandler(this.SaveToCurrentSlotMenuItem_Click);
-            // 
-            // LoadCurrentSlotMenuItem
-            // 
-            this.LoadCurrentSlotMenuItem.Text = "Load Current Slot";
-            this.LoadCurrentSlotMenuItem.Click += new System.EventHandler(this.LoadCurrentSlotMenuItem_Click);
-            // 
-            // SaveRAMSubMenu
-            // 
-            this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.FlushSaveRAMMenuItem});
-            this.SaveRAMSubMenu.Text = "Save &RAM";
-            this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
-            // 
-            // FlushSaveRAMMenuItem
-            // 
-            this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
-            this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
-            // 
-            // MovieSubMenu
-            // 
-            this.MovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ReadonlyMenuItem,
-            this.toolStripSeparator15,
-            this.RecentMovieSubMenu,
-            this.RecordMovieMenuItem,
-            this.PlayMovieMenuItem,
-            this.StopMovieMenuItem,
-            this.PlayFromBeginningMenuItem,
-            this.ImportMoviesMenuItem,
-            this.SaveMovieMenuItem,
-            this.SaveMovieAsMenuItem,
-            this.StopMovieWithoutSavingMenuItem,
-            this.toolStripSeparator14,
-            this.AutomaticallyBackupMoviesMenuItem,
-            this.FullMovieLoadstatesMenuItem,
-            this.MovieEndSubMenu});
-            this.MovieSubMenu.Text = "&Movie";
-            this.MovieSubMenu.DropDownOpened += new System.EventHandler(this.MovieSubMenu_DropDownOpened);
-            // 
-            // ReadonlyMenuItem
-            // 
-            this.ReadonlyMenuItem.Text = "Read-only";
-            this.ReadonlyMenuItem.Click += new System.EventHandler(this.ReadonlyMenuItem_Click);
-            // 
-            // RecentMovieSubMenu
-            // 
-            this.RecentMovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripSeparator16});
-            this.RecentMovieSubMenu.Text = "Recent";
-            this.RecentMovieSubMenu.DropDownOpened += new System.EventHandler(this.RecentMovieSubMenu_DropDownOpened);
-            // 
-            // RecordMovieMenuItem
-            // 
-            this.RecordMovieMenuItem.Text = "&Record Movie...";
-            this.RecordMovieMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
-            // 
-            // PlayMovieMenuItem
-            // 
-            this.PlayMovieMenuItem.Text = "&Play Movie...";
-            this.PlayMovieMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
-            // 
-            // StopMovieMenuItem
-            // 
-            this.StopMovieMenuItem.Text = "Stop Movie";
-            this.StopMovieMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
-            // 
-            // PlayFromBeginningMenuItem
-            // 
-            this.PlayFromBeginningMenuItem.Text = "Play from Beginning";
-            this.PlayFromBeginningMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
-            // 
-            // ImportMoviesMenuItem
-            // 
-            this.ImportMoviesMenuItem.Text = "Import Movies...";
-            this.ImportMoviesMenuItem.Click += new System.EventHandler(this.ImportMovieMenuItem_Click);
-            // 
-            // SaveMovieMenuItem
-            // 
-            this.SaveMovieMenuItem.Text = "&Save Movie";
-            this.SaveMovieMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
-            // 
-            // SaveMovieAsMenuItem
-            // 
-            this.SaveMovieAsMenuItem.Text = "Save Movie As...";
-            this.SaveMovieAsMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
-            // 
-            // StopMovieWithoutSavingMenuItem
-            // 
-            this.StopMovieWithoutSavingMenuItem.Text = "Stop Movie without Saving";
-            this.StopMovieWithoutSavingMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
-            // 
-            // AutomaticallyBackupMoviesMenuItem
-            // 
-            this.AutomaticallyBackupMoviesMenuItem.Text = "Automatically Backup Movies";
-            this.AutomaticallyBackupMoviesMenuItem.Click += new System.EventHandler(this.AutomaticMovieBackupMenuItem_Click);
-            // 
-            // FullMovieLoadstatesMenuItem
-            // 
-            this.FullMovieLoadstatesMenuItem.Text = "Full Movie Loadstates";
-            this.FullMovieLoadstatesMenuItem.Click += new System.EventHandler(this.FullMovieLoadstatesMenuItem_Click);
-            // 
-            // MovieEndSubMenu
-            // 
-            this.MovieEndSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.MovieEndFinishMenuItem,
-            this.MovieEndRecordMenuItem,
-            this.MovieEndStopMenuItem,
-            this.MovieEndPauseMenuItem});
-            this.MovieEndSubMenu.Text = "On Movie End";
-            this.MovieEndSubMenu.DropDownOpened += new System.EventHandler(this.MovieEndSubMenu_DropDownOpened);
-            // 
-            // MovieEndFinishMenuItem
-            // 
-            this.MovieEndFinishMenuItem.Text = "Switch to Finished";
-            this.MovieEndFinishMenuItem.Click += new System.EventHandler(this.MovieEndFinishMenuItem_Click);
-            // 
-            // MovieEndRecordMenuItem
-            // 
-            this.MovieEndRecordMenuItem.Text = "Switch To Record";
-            this.MovieEndRecordMenuItem.Click += new System.EventHandler(this.MovieEndRecordMenuItem_Click);
-            // 
-            // MovieEndStopMenuItem
-            // 
-            this.MovieEndStopMenuItem.Text = "Stop";
-            this.MovieEndStopMenuItem.Click += new System.EventHandler(this.MovieEndStopMenuItem_Click);
-            // 
-            // MovieEndPauseMenuItem
-            // 
-            this.MovieEndPauseMenuItem.Text = "Pause";
-            this.MovieEndPauseMenuItem.Click += new System.EventHandler(this.MovieEndPauseMenuItem_Click);
-            // 
-            // AVSubMenu
-            // 
-            this.AVSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.RecordAVMenuItem,
-            this.ConfigAndRecordAVMenuItem,
-            this.StopAVIMenuItem,
-            this.toolStripSeparator19,
-            this.CaptureOSDMenuItem,
-            this.CaptureLuaMenuItem,
-            this.SynclessRecordingMenuItem});
-            this.AVSubMenu.Text = "&AVI/WAV";
-            this.AVSubMenu.DropDownOpened += new System.EventHandler(this.AVSubMenu_DropDownOpened);
-            // 
-            // RecordAVMenuItem
-            // 
-            this.RecordAVMenuItem.Text = "&Record AVI/WAV";
-            this.RecordAVMenuItem.Click += new System.EventHandler(this.RecordAVMenuItem_Click);
-            // 
-            // ConfigAndRecordAVMenuItem
-            // 
-            this.ConfigAndRecordAVMenuItem.Text = "Config and Record AVI/WAV...";
-            this.ConfigAndRecordAVMenuItem.Click += new System.EventHandler(this.ConfigAndRecordAVMenuItem_Click);
-            // 
-            // StopAVIMenuItem
-            // 
-            this.StopAVIMenuItem.Text = "&Stop AVI/WAV";
-            this.StopAVIMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
-            // 
-            // CaptureOSDMenuItem
-            // 
-            this.CaptureOSDMenuItem.CheckOnClick = true;
-            this.CaptureOSDMenuItem.Text = "Capture OSD";
-            this.CaptureOSDMenuItem.Click += new System.EventHandler(this.CaptureOSDMenuItem_Click);
-            // 
-            // CaptureLuaMenuItem
-            // 
-            this.CaptureLuaMenuItem.CheckOnClick = true;
-            this.CaptureLuaMenuItem.Name = "CaptureLuaMenuItem";
-            this.CaptureLuaMenuItem.Size = new System.Drawing.Size(288, 26);
-            this.CaptureLuaMenuItem.Text = "Capture Lua";
-            this.CaptureLuaMenuItem.Click += new System.EventHandler(this.CaptureLuaMenuItem_Click);
-            // 
-            // SynclessRecordingMenuItem
-            // 
-            this.SynclessRecordingMenuItem.Text = "S&yncless Recording Tools";
-            // 
-            // ScreenshotSubMenu
-            // 
-            this.ScreenshotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ScreenshotMenuItem,
-            this.ScreenshotAsMenuItem,
-            this.ScreenshotClipboardMenuItem,
-            this.ScreenshotClientClipboardMenuItem,
-            this.toolStripSeparator20,
-            this.ScreenshotCaptureOSDMenuItem1});
-            this.ScreenshotSubMenu.Text = "Scree&nshot";
-            this.ScreenshotSubMenu.DropDownOpening += new System.EventHandler(this.ScreenshotSubMenu_DropDownOpening);
-            // 
-            // ScreenshotMenuItem
-            // 
-            this.ScreenshotMenuItem.Text = "Screenshot";
-            this.ScreenshotMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
-            // 
-            // ScreenshotAsMenuItem
-            // 
-            this.ScreenshotAsMenuItem.Text = "Screenshot As...";
-            this.ScreenshotAsMenuItem.Click += new System.EventHandler(this.ScreenshotAsMenuItem_Click);
-            // 
-            // ScreenshotClipboardMenuItem
-            // 
-            this.ScreenshotClipboardMenuItem.Text = "Screenshot (raw) -> Clipboard";
-            this.ScreenshotClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClipboardMenuItem_Click);
-            // 
-            // ScreenshotClientClipboardMenuItem
-            // 
-            this.ScreenshotClientClipboardMenuItem.Text = "Screenshot (client) -> Clipboard";
-            this.ScreenshotClientClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClientClipboardMenuItem_Click);
-            // 
-            // ScreenshotCaptureOSDMenuItem1
-            // 
-            this.ScreenshotCaptureOSDMenuItem1.Text = "Capture OSD";
-            this.ScreenshotCaptureOSDMenuItem1.Click += new System.EventHandler(this.ScreenshotCaptureOSDMenuItem_Click);
-            // 
-            // ExitMenuItem
-            // 
-            this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-            this.ExitMenuItem.Text = "E&xit";
-            this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
-            // 
-            // EmulationSubMenu
-            // 
-            this.EmulationSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.PauseMenuItem,
-            this.RebootCoreMenuItem,
-            this.toolStripSeparator1,
-            this.SoftResetMenuItem,
-            this.HardResetMenuItem,
-            this.EmulatorMenuSeparator2,
-            this.LoadedCoreNameMenuItem});
-            this.EmulationSubMenu.Text = "&Emulation";
-            this.EmulationSubMenu.DropDownOpened += new System.EventHandler(this.EmulationMenuItem_DropDownOpened);
-            // 
-            // PauseMenuItem
-            // 
-            this.PauseMenuItem.Text = "&Pause";
-            this.PauseMenuItem.Click += new System.EventHandler(this.PauseMenuItem_Click);
-            // 
-            // RebootCoreMenuItem
-            // 
-            this.RebootCoreMenuItem.Text = "&Reboot Core";
-            this.RebootCoreMenuItem.Click += new System.EventHandler(this.PowerMenuItem_Click);
-            // 
-            // SoftResetMenuItem
-            // 
-            this.SoftResetMenuItem.Text = "&Soft Reset";
-            this.SoftResetMenuItem.Click += new System.EventHandler(this.SoftResetMenuItem_Click);
-            // 
-            // HardResetMenuItem
-            // 
-            this.HardResetMenuItem.Text = "&Hard Reset";
-            this.HardResetMenuItem.Click += new System.EventHandler(this.HardResetMenuItem_Click);
-            // 
-            // LoadedCoreNameMenuItem
-            // 
-            this.LoadedCoreNameMenuItem.Enabled = false;
-            this.LoadedCoreNameMenuItem.Text = "Loaded core: <core name> (sysID)";
-            // 
-            // ViewSubMenu
-            // 
-            this.ViewSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.WindowSizeSubMenu,
-            this.SwitchToFullscreenMenuItem,
-            this.toolStripSeparator2,
-            this.DisplayFPSMenuItem,
-            this.DisplayFrameCounterMenuItem,
-            this.DisplayLagCounterMenuItem,
-            this.DisplayInputMenuItem,
-            this.DisplayRerecordCountMenuItem,
-            this.DisplaySubtitlesMenuItem,
-            this.toolStripMenuItem4,
-            this.DisplayStatusBarMenuItem,
-            this.DisplayMessagesMenuItem,
-            this.toolStripSeparator8,
-            this.DisplayLogWindowMenuItem});
-            this.ViewSubMenu.Text = "&View";
-            this.ViewSubMenu.DropDownOpened += new System.EventHandler(this.ViewSubMenu_DropDownOpened);
-            // 
-            // WindowSizeSubMenu
-            // 
-            this.WindowSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.x1MenuItem,
-            this.x2MenuItem,
-            this.x3MenuItem,
-            this.x4MenuItem,
-            this.x5MenuItem,
-            this.x6MenuItem,
-            this.x7MenuItem,
-            this.x8MenuItem,
-            this.x9MenuItem,
-            this.mzMenuItem});
-            this.WindowSizeSubMenu.Text = "&Window Size";
-            this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
-            // 
-            // x1MenuItem
-            // 
-            this.x1MenuItem.Text = "&1x";
-            this.x1MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-            // 
-            // x2MenuItem
-            // 
-            this.x2MenuItem.Text = "&2x";
-            this.x2MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-            // 
-            // x3MenuItem
-            // 
-            this.x3MenuItem.Text = "&3x";
-            this.x3MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-            // 
-            // x4MenuItem
-            // 
-            this.x4MenuItem.Text = "&4x";
-            this.x4MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-            // 
-            // x5MenuItem
-            // 
-            this.x5MenuItem.Text = "&5x";
-            this.x5MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-            // 
-            // x6MenuItem
-            // 
-            this.x6MenuItem.Text = "&6x";
-            this.x6MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-            // 
-            // x7MenuItem
-            // 
-            this.x7MenuItem.Text = "&7x";
-            this.x7MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-            // 
-            // x8MenuItem
-            // 
-            this.x8MenuItem.Text = "&8x";
-            this.x8MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-            // 
-            // x9MenuItem
-            // 
-            this.x9MenuItem.Text = "&9x";
-            this.x9MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-            // 
-            // mzMenuItem
-            // 
-            this.mzMenuItem.Text = "1&0x";
-            this.mzMenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-            // 
-            // SwitchToFullscreenMenuItem
-            // 
-            this.SwitchToFullscreenMenuItem.Text = "Switch to Fullscreen";
-            this.SwitchToFullscreenMenuItem.Click += new System.EventHandler(this.SwitchToFullscreenMenuItem_Click);
-            // 
-            // DisplayFPSMenuItem
-            // 
-            this.DisplayFPSMenuItem.Text = "Display FPS";
-            this.DisplayFPSMenuItem.Click += new System.EventHandler(this.DisplayFpsMenuItem_Click);
-            // 
-            // DisplayFrameCounterMenuItem
-            // 
-            this.DisplayFrameCounterMenuItem.Text = "Display Frame Count";
-            this.DisplayFrameCounterMenuItem.Click += new System.EventHandler(this.DisplayFrameCounterMenuItem_Click);
-            // 
-            // DisplayLagCounterMenuItem
-            // 
-            this.DisplayLagCounterMenuItem.Text = "Display Lag Frame Count";
-            this.DisplayLagCounterMenuItem.Click += new System.EventHandler(this.DisplayLagCounterMenuItem_Click);
-            // 
-            // DisplayInputMenuItem
-            // 
-            this.DisplayInputMenuItem.Text = "Display Input";
-            this.DisplayInputMenuItem.Click += new System.EventHandler(this.DisplayInputMenuItem_Click);
-            // 
-            // DisplayRerecordCountMenuItem
-            // 
-            this.DisplayRerecordCountMenuItem.Text = "Display Rerecord Count";
-            this.DisplayRerecordCountMenuItem.Click += new System.EventHandler(this.DisplayRerecordsMenuItem_Click);
-            // 
-            // DisplaySubtitlesMenuItem
-            // 
-            this.DisplaySubtitlesMenuItem.Text = "Display Subtitles";
-            this.DisplaySubtitlesMenuItem.Click += new System.EventHandler(this.DisplaySubtitlesMenuItem_Click);
-            // 
-            // DisplayStatusBarMenuItem
-            // 
-            this.DisplayStatusBarMenuItem.Text = "Display Status Bar";
-            this.DisplayStatusBarMenuItem.Click += new System.EventHandler(this.DisplayStatusBarMenuItem_Click);
-            // 
-            // DisplayMessagesMenuItem
-            // 
-            this.DisplayMessagesMenuItem.Text = "Display Messages";
-            this.DisplayMessagesMenuItem.Click += new System.EventHandler(this.DisplayMessagesMenuItem_Click);
-            // 
-            // DisplayLogWindowMenuItem
-            // 
-            this.DisplayLogWindowMenuItem.Text = "Open &Log Window...";
-            this.DisplayLogWindowMenuItem.Click += new System.EventHandler(this.DisplayLogWindowMenuItem_Click);
-            // 
-            // ConfigSubMenu
-            // 
-            this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ControllersMenuItem,
-            this.HotkeysMenuItem,
-            this.DisplayConfigMenuItem,
-            this.SoundMenuItem,
-            this.PathsMenuItem,
-            this.FirmwaresMenuItem,
-            this.MessagesMenuItem,
-            this.AutofireMenuItem,
-            this.RewindOptionsMenuItem,
-            this.extensionsToolStripMenuItem,
-            this.ClientOptionsMenuItem,
-            this.ProfilesMenuItem,
-            this.toolStripSeparator9,
-            this.SpeedSkipSubMenu,
-            this.KeyPrioritySubMenu,
-            this.CoresSubMenu,
-            this.toolStripSeparator10,
-            this.SaveConfigMenuItem,
-            this.SaveConfigAsMenuItem,
-            this.LoadConfigMenuItem,
-            this.LoadConfigFromMenuItem});
-            this.ConfigSubMenu.Text = "&Config";
-            this.ConfigSubMenu.DropDownOpened += new System.EventHandler(this.ConfigSubMenu_DropDownOpened);
-            // 
-            // ControllersMenuItem
-            // 
-            this.ControllersMenuItem.Text = "&Controllers...";
-            this.ControllersMenuItem.Click += new System.EventHandler(this.ControllersMenuItem_Click);
-            // 
-            // HotkeysMenuItem
-            // 
-            this.HotkeysMenuItem.Text = "&Hotkeys...";
-            this.HotkeysMenuItem.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
-            // 
-            // DisplayConfigMenuItem
-            // 
-            this.DisplayConfigMenuItem.Text = "Display...";
-            this.DisplayConfigMenuItem.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
-            // 
-            // SoundMenuItem
-            // 
-            this.SoundMenuItem.Text = "&Sound...";
-            this.SoundMenuItem.Click += new System.EventHandler(this.SoundMenuItem_Click);
-            // 
-            // PathsMenuItem
-            // 
-            this.PathsMenuItem.Text = "Paths...";
-            this.PathsMenuItem.Click += new System.EventHandler(this.PathsMenuItem_Click);
-            // 
-            // FirmwaresMenuItem
-            // 
-            this.FirmwaresMenuItem.Text = "&Firmwares...";
-            this.FirmwaresMenuItem.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
-            // 
-            // MessagesMenuItem
-            // 
-            this.MessagesMenuItem.Text = "&Messages...";
-            this.MessagesMenuItem.Click += new System.EventHandler(this.MessagesMenuItem_Click);
-            // 
-            // AutofireMenuItem
-            // 
-            this.AutofireMenuItem.Text = "&Autofire...";
-            this.AutofireMenuItem.Click += new System.EventHandler(this.AutofireMenuItem_Click);
-            // 
-            // RewindOptionsMenuItem
-            // 
-            this.RewindOptionsMenuItem.Text = "&Rewind && States...";
-            this.RewindOptionsMenuItem.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
-            // 
-            // extensionsToolStripMenuItem
-            // 
-            this.extensionsToolStripMenuItem.Text = "File Extensions...";
-            this.extensionsToolStripMenuItem.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
-            // 
-            // ClientOptionsMenuItem
-            // 
-            this.ClientOptionsMenuItem.Text = "&Customize...";
-            this.ClientOptionsMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
-            // 
-            // ProfilesMenuItem
-            // 
-            this.ProfilesMenuItem.Text = "&Profiles...";
-            this.ProfilesMenuItem.Click += new System.EventHandler(this.ProfilesMenuItem_Click);
-            // 
-            // SpeedSkipSubMenu
-            // 
-            this.SpeedSkipSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ClockThrottleMenuItem,
-            this.AudioThrottleMenuItem,
-            this.VsyncThrottleMenuItem,
-            this.toolStripSeparator27,
-            this.VsyncEnabledMenuItem,
-            this.toolStripMenuItem3,
-            this.miUnthrottled,
-            this.MinimizeSkippingMenuItem,
-            this.NeverSkipMenuItem,
-            this.toolStripMenuItem17,
-            this.toolStripMenuItem5,
-            this.Speed50MenuItem,
-            this.Speed75MenuItem,
-            this.Speed100MenuItem,
-            this.Speed150MenuItem,
-            this.Speed200MenuItem,
-            this.Speed400MenuItem});
-            this.SpeedSkipSubMenu.Text = "Speed/Skip";
-            this.SpeedSkipSubMenu.DropDownOpened += new System.EventHandler(this.FrameSkipMenuItem_DropDownOpened);
-            // 
-            // ClockThrottleMenuItem
-            // 
-            this.ClockThrottleMenuItem.Text = "Clock Throttle";
-            this.ClockThrottleMenuItem.Click += new System.EventHandler(this.ClockThrottleMenuItem_Click);
-            // 
-            // AudioThrottleMenuItem
-            // 
-            this.AudioThrottleMenuItem.Text = "Audio Throttle";
-            this.AudioThrottleMenuItem.Click += new System.EventHandler(this.AudioThrottleMenuItem_Click);
-            // 
-            // VsyncThrottleMenuItem
-            // 
-            this.VsyncThrottleMenuItem.Text = "VSync Throttle";
-            this.VsyncThrottleMenuItem.Click += new System.EventHandler(this.VsyncThrottleMenuItem_Click);
-            // 
-            // VsyncEnabledMenuItem
-            // 
-            this.VsyncEnabledMenuItem.Text = "VSync Enabled";
-            this.VsyncEnabledMenuItem.Click += new System.EventHandler(this.VsyncEnabledMenuItem_Click);
-            // 
-            // miUnthrottled
-            // 
-            this.miUnthrottled.Text = "Unthrottled";
-            this.miUnthrottled.Click += new System.EventHandler(this.UnthrottledMenuItem_Click);
-            // 
-            // MinimizeSkippingMenuItem
-            // 
-            this.MinimizeSkippingMenuItem.Text = "Auto-minimize skipping";
-            this.MinimizeSkippingMenuItem.Click += new System.EventHandler(this.MinimizeSkippingMenuItem_Click);
-            // 
-            // NeverSkipMenuItem
-            // 
-            this.NeverSkipMenuItem.Text = "Skip 0 (never)";
-            this.NeverSkipMenuItem.Click += new System.EventHandler(this.NeverSkipMenuItem_Click);
-            // 
-            // toolStripMenuItem17
-            // 
-            this.toolStripMenuItem17.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.Frameskip1MenuItem,
-            this.Frameskip2MenuItem,
-            this.Frameskip3MenuItem,
-            this.Frameskip4MenuItem,
-            this.Frameskip5MenuItem,
-            this.Frameskip6MenuItem,
-            this.Frameskip7MenuItem,
-            this.Frameskip8MenuItem,
-            this.Frameskip9MenuItem});
-            this.toolStripMenuItem17.Text = "Skip 1..9";
-            // 
-            // Frameskip1MenuItem
-            // 
-            this.Frameskip1MenuItem.Text = "1";
-            this.Frameskip1MenuItem.Click += new System.EventHandler(this.Frameskip1MenuItem_Click);
-            // 
-            // Frameskip2MenuItem
-            // 
-            this.Frameskip2MenuItem.Text = "2";
-            this.Frameskip2MenuItem.Click += new System.EventHandler(this.Frameskip2MenuItem_Click);
-            // 
-            // Frameskip3MenuItem
-            // 
-            this.Frameskip3MenuItem.Text = "3";
-            this.Frameskip3MenuItem.Click += new System.EventHandler(this.Frameskip3MenuItem_Click);
-            // 
-            // Frameskip4MenuItem
-            // 
-            this.Frameskip4MenuItem.Text = "4";
-            this.Frameskip4MenuItem.Click += new System.EventHandler(this.Frameskip4MenuItem_Click);
-            // 
-            // Frameskip5MenuItem
-            // 
-            this.Frameskip5MenuItem.Text = "5";
-            this.Frameskip5MenuItem.Click += new System.EventHandler(this.Frameskip5MenuItem_Click);
-            // 
-            // Frameskip6MenuItem
-            // 
-            this.Frameskip6MenuItem.Text = "6";
-            this.Frameskip6MenuItem.Click += new System.EventHandler(this.Frameskip6MenuItem_Click);
-            // 
-            // Frameskip7MenuItem
-            // 
-            this.Frameskip7MenuItem.Text = "7";
-            this.Frameskip7MenuItem.Click += new System.EventHandler(this.Frameskip7MenuItem_Click);
-            // 
-            // Frameskip8MenuItem
-            // 
-            this.Frameskip8MenuItem.Text = "8";
-            this.Frameskip8MenuItem.Click += new System.EventHandler(this.Frameskip8MenuItem_Click);
-            // 
-            // Frameskip9MenuItem
-            // 
-            this.Frameskip9MenuItem.Text = "9";
-            this.Frameskip9MenuItem.Click += new System.EventHandler(this.Frameskip9MenuItem_Click);
-            // 
-            // Speed50MenuItem
-            // 
-            this.Speed50MenuItem.Text = "Speed 50%";
-            this.Speed50MenuItem.Click += new System.EventHandler(this.Speed50MenuItem_Click);
-            // 
-            // Speed75MenuItem
-            // 
-            this.Speed75MenuItem.Text = "Speed 75%";
-            this.Speed75MenuItem.Click += new System.EventHandler(this.Speed75MenuItem_Click);
-            // 
-            // Speed100MenuItem
-            // 
-            this.Speed100MenuItem.Text = "Speed 100%";
-            this.Speed100MenuItem.Click += new System.EventHandler(this.Speed100MenuItem_Click);
-            // 
-            // Speed150MenuItem
-            // 
-            this.Speed150MenuItem.Text = "Speed 150%";
-            this.Speed150MenuItem.Click += new System.EventHandler(this.Speed150MenuItem_Click);
-            // 
-            // Speed200MenuItem
-            // 
-            this.Speed200MenuItem.Text = "Speed 200%";
-            this.Speed200MenuItem.Click += new System.EventHandler(this.Speed200MenuItem_Click);
-            // 
-            // Speed400MenuItem
-            // 
-            this.Speed400MenuItem.Text = "Speed 400%";
-            this.Speed400MenuItem.Click += new System.EventHandler(this.Speed400MenuItem_Click);
-            // 
-            // KeyPrioritySubMenu
-            // 
-            this.KeyPrioritySubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.BothHkAndControllerMenuItem,
-            this.InputOverHkMenuItem,
-            this.HkOverInputMenuItem});
-            this.KeyPrioritySubMenu.Text = "Key Priority";
-            this.KeyPrioritySubMenu.DropDownOpened += new System.EventHandler(this.KeyPriorityMenuItem_DropDownOpened);
-            // 
-            // BothHkAndControllerMenuItem
-            // 
-            this.BothHkAndControllerMenuItem.Text = "Both Hotkeys and Controllers";
-            this.BothHkAndControllerMenuItem.Click += new System.EventHandler(this.BothHkAndControllerMenuItem_Click);
-            // 
-            // InputOverHkMenuItem
-            // 
-            this.InputOverHkMenuItem.Text = "Input overrides Hotkeys";
-            this.InputOverHkMenuItem.Click += new System.EventHandler(this.InputOverHkMenuItem_Click);
-            // 
-            // HkOverInputMenuItem
-            // 
-            this.HkOverInputMenuItem.Text = "Hotkeys override Input";
-            this.HkOverInputMenuItem.Click += new System.EventHandler(this.HkOverInputMenuItem_Click);
-            // 
-            // CoresSubMenu
-            // 
-            this.CoresSubMenu.Text = "Preferred Cores";
-            // 
-            // SaveConfigMenuItem
-            // 
-            this.SaveConfigMenuItem.Text = "Save Config";
-            this.SaveConfigMenuItem.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
-            // 
-            // SaveConfigAsMenuItem
-            // 
-            this.SaveConfigAsMenuItem.Text = "Save Config As...";
-            this.SaveConfigAsMenuItem.Click += new System.EventHandler(this.SaveConfigAsMenuItem_Click);
-            // 
-            // LoadConfigMenuItem
-            // 
-            this.LoadConfigMenuItem.Text = "Load Config";
-            this.LoadConfigMenuItem.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
-            // 
-            // LoadConfigFromMenuItem
-            // 
-            this.LoadConfigFromMenuItem.Text = "Load Config From...";
-            this.LoadConfigFromMenuItem.Click += new System.EventHandler(this.LoadConfigFromMenuItem_Click);
-            // 
-            // ToolsSubMenu
-            // 
-            this.ToolsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ToolBoxMenuItem,
-            this.toolStripSeparator12,
-            this.RamWatchMenuItem,
-            this.RamSearchMenuItem,
-            this.LuaConsoleMenuItem,
-            this.TAStudioMenuItem,
-            this.HexEditorMenuItem,
-            this.TraceLoggerMenuItem,
-            this.DebuggerMenuItem,
-            this.CodeDataLoggerMenuItem,
-            this.MacroToolMenuItem,
-            this.VirtualPadMenuItem,
-            this.BasicBotMenuItem,
-            this.toolStripSeparator11,
-            this.CheatsMenuItem,
-            this.GameSharkConverterMenuItem,
-            this.toolStripSeparator29,
-            this.MultiDiskBundlerFileMenuItem,
-            this.BatchRunnerMenuItem,
-            this.ExternalToolMenuItem,
-            this.RetroAchievementsMenuItem});
-            this.ToolsSubMenu.Text = "&Tools";
-            this.ToolsSubMenu.DropDownOpened += new System.EventHandler(this.ToolsSubMenu_DropDownOpened);
-            // 
-            // ToolBoxMenuItem
-            // 
-            this.ToolBoxMenuItem.Text = "&Tool Box";
-            this.ToolBoxMenuItem.Click += new System.EventHandler(this.ToolBoxMenuItem_Click);
-            // 
-            // RamWatchMenuItem
-            // 
-            this.RamWatchMenuItem.Text = "RAM &Watch";
-            this.RamWatchMenuItem.Click += new System.EventHandler(this.RamWatchMenuItem_Click);
-            // 
-            // RamSearchMenuItem
-            // 
-            this.RamSearchMenuItem.Text = "RAM &Search";
-            this.RamSearchMenuItem.Click += new System.EventHandler(this.RamSearchMenuItem_Click);
-            // 
-            // LuaConsoleMenuItem
-            // 
-            this.LuaConsoleMenuItem.Text = "Lua Console";
-            this.LuaConsoleMenuItem.Click += new System.EventHandler(this.LuaConsoleMenuItem_Click);
-            // 
-            // TAStudioMenuItem
-            // 
-            this.TAStudioMenuItem.Text = "&TAStudio";
-            this.TAStudioMenuItem.Click += new System.EventHandler(this.TAStudioMenuItem_Click);
-            // 
-            // HexEditorMenuItem
-            // 
-            this.HexEditorMenuItem.Text = "&Hex Editor";
-            this.HexEditorMenuItem.Click += new System.EventHandler(this.HexEditorMenuItem_Click);
-            // 
-            // TraceLoggerMenuItem
-            // 
-            this.TraceLoggerMenuItem.Text = "Trace &Logger";
-            this.TraceLoggerMenuItem.Click += new System.EventHandler(this.TraceLoggerMenuItem_Click);
-            // 
-            // DebuggerMenuItem
-            // 
-            this.DebuggerMenuItem.Text = "&Debugger";
-            this.DebuggerMenuItem.Click += new System.EventHandler(this.DebuggerMenuItem_Click);
-            // 
-            // CodeDataLoggerMenuItem
-            // 
-            this.CodeDataLoggerMenuItem.Text = "Code-Data Logger";
-            this.CodeDataLoggerMenuItem.Click += new System.EventHandler(this.CodeDataLoggerMenuItem_Click);
-            // 
-            // MacroToolMenuItem
-            // 
-            this.MacroToolMenuItem.Text = "&Macro Tool";
-            this.MacroToolMenuItem.Click += new System.EventHandler(this.MacroToolMenuItem_Click);
-            // 
-            // VirtualPadMenuItem
-            // 
-            this.VirtualPadMenuItem.Text = "Virtual Pad";
-            this.VirtualPadMenuItem.Click += new System.EventHandler(this.VirtualPadMenuItem_Click);
-            // 
-            // BasicBotMenuItem
-            // 
-            this.BasicBotMenuItem.Text = "Basic Bot";
-            this.BasicBotMenuItem.Click += new System.EventHandler(this.BasicBotMenuItem_Click);
-            // 
-            // CheatsMenuItem
-            // 
-            this.CheatsMenuItem.Text = "Cheats";
-            this.CheatsMenuItem.Click += new System.EventHandler(this.CheatsMenuItem_Click);
-            // 
-            // GameSharkConverterMenuItem
-            // 
-            this.GameSharkConverterMenuItem.Text = "Cheat Code Converter";
-            this.GameSharkConverterMenuItem.Click += new System.EventHandler(this.CheatCodeConverterMenuItem_Click);
-            // 
-            // MultiDiskBundlerFileMenuItem
-            // 
-            this.MultiDiskBundlerFileMenuItem.Text = "Multi-disk Bundler";
-            this.MultiDiskBundlerFileMenuItem.Click += new System.EventHandler(this.MultidiskBundlerMenuItem_Click);
-            // 
-            // BatchRunnerMenuItem
-            // 
-            this.BatchRunnerMenuItem.Text = "Batch Runner...";
-            this.BatchRunnerMenuItem.Visible = false;
-            this.BatchRunnerMenuItem.Click += new System.EventHandler(this.BatchRunnerMenuItem_Click);
-            // 
-            // ExternalToolMenuItem
-            // 
-            this.ExternalToolMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.dummyExternalTool});
-            this.ExternalToolMenuItem.Text = "External Tool";
-            this.ExternalToolMenuItem.DropDownOpening += new System.EventHandler(this.ExternalToolMenuItem_DropDownOpening);
-            // 
-            // dummyExternalTool
-            // 
-            this.dummyExternalTool.Text = "None";
-            // 
-            // RetroAchievementsMenuItem
-            // 
-            this.RetroAchievementsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.StartRetroAchievementsMenuItem});
-            this.RetroAchievementsMenuItem.Text = "&RetroAchievements";
-            // 
-            // StartRetroAchievementsMenuItem
-            // 
-            this.StartRetroAchievementsMenuItem.Text = "&Start RetroAchievements";
-            this.StartRetroAchievementsMenuItem.Click += new System.EventHandler(this.StartRetroAchievementsMenuItem_Click);
-            // 
-            // NESSubMenu
-            // 
-            this.NESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.NESPPUViewerMenuItem,
-            this.NESNametableViewerMenuItem,
-            this.MusicRipperMenuItem,
-            this.toolStripSeparator17,
-            this.NesControllerSettingsMenuItem,
-            this.NESGraphicSettingsMenuItem,
-            this.NESSoundChannelsMenuItem,
-            this.VSSettingsMenuItem,
-            this.MovieSettingsMenuItem,
-            this.toolStripSeparator22,
-            this.FDSControlsMenuItem,
-            this.VSControlsMenuItem,
-            this.BarcodeReaderMenuItem});
-            this.NESSubMenu.Text = "&NES";
-            this.NESSubMenu.DropDownOpened += new System.EventHandler(this.NesSubMenu_DropDownOpened);
-            // 
-            // NESPPUViewerMenuItem
-            // 
-            this.NESPPUViewerMenuItem.Text = "&PPU Viewer";
-            this.NESPPUViewerMenuItem.Click += new System.EventHandler(this.NesPpuViewerMenuItem_Click);
-            // 
-            // NESNametableViewerMenuItem
-            // 
-            this.NESNametableViewerMenuItem.Text = "&Nametable Viewer";
-            this.NESNametableViewerMenuItem.Click += new System.EventHandler(this.NesNametableViewerMenuItem_Click);
-            // 
-            // MusicRipperMenuItem
-            // 
-            this.MusicRipperMenuItem.Text = "Music Ripper";
-            this.MusicRipperMenuItem.Click += new System.EventHandler(this.MusicRipperMenuItem_Click);
-            // 
-            // NesControllerSettingsMenuItem
-            // 
-            this.NesControllerSettingsMenuItem.Text = "Controller Settings...";
-            this.NesControllerSettingsMenuItem.Click += new System.EventHandler(this.NesControllerSettingsMenuItem_Click);
-            // 
-            // NESGraphicSettingsMenuItem
-            // 
-            this.NESGraphicSettingsMenuItem.Text = "Graphics Settings...";
-            this.NESGraphicSettingsMenuItem.Click += new System.EventHandler(this.NesGraphicSettingsMenuItem_Click);
-            // 
-            // NESSoundChannelsMenuItem
-            // 
-            this.NESSoundChannelsMenuItem.Text = "Sound Channels...";
-            this.NESSoundChannelsMenuItem.Click += new System.EventHandler(this.NesSoundChannelsMenuItem_Click);
-            // 
-            // VSSettingsMenuItem
-            // 
-            this.VSSettingsMenuItem.Text = "VS Settings...";
-            this.VSSettingsMenuItem.Click += new System.EventHandler(this.VsSettingsMenuItem_Click);
-            // 
-            // MovieSettingsMenuItem
-            // 
-            this.MovieSettingsMenuItem.Text = "Advanced Settings...";
-            this.MovieSettingsMenuItem.Click += new System.EventHandler(this.MovieSettingsMenuItem_Click);
-            // 
-            // FDSControlsMenuItem
-            // 
-            this.FDSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.FdsEjectDiskMenuItem});
-            this.FDSControlsMenuItem.Text = "FDS Controls";
-            this.FDSControlsMenuItem.DropDownOpened += new System.EventHandler(this.FdsControlsMenuItem_DropDownOpened);
-            // 
-            // FdsEjectDiskMenuItem
-            // 
-            this.FdsEjectDiskMenuItem.Text = "&Eject Disk";
-            this.FdsEjectDiskMenuItem.Click += new System.EventHandler(this.FdsEjectDiskMenuItem_Click);
-            // 
-            // VSControlsMenuItem
-            // 
-            this.VSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.VSInsertCoinP1MenuItem,
-            this.VSInsertCoinP2MenuItem,
-            this.VSServiceSwitchMenuItem});
-            this.VSControlsMenuItem.Text = "VS Controls";
-            // 
-            // VSInsertCoinP1MenuItem
-            // 
-            this.VSInsertCoinP1MenuItem.Text = "Insert Coin P1";
-            this.VSInsertCoinP1MenuItem.Click += new System.EventHandler(this.VsInsertCoinP1MenuItem_Click);
-            // 
-            // VSInsertCoinP2MenuItem
-            // 
-            this.VSInsertCoinP2MenuItem.Text = "Insert Coin P2";
-            this.VSInsertCoinP2MenuItem.Click += new System.EventHandler(this.VsInsertCoinP2MenuItem_Click);
-            // 
-            // VSServiceSwitchMenuItem
-            // 
-            this.VSServiceSwitchMenuItem.Text = "Service Switch";
-            this.VSServiceSwitchMenuItem.Click += new System.EventHandler(this.VsServiceSwitchMenuItem_Click);
-            // 
-            // BarcodeReaderMenuItem
-            // 
-            this.BarcodeReaderMenuItem.Text = "Barcode Reader";
-            this.BarcodeReaderMenuItem.Click += new System.EventHandler(this.BarcodeReaderMenuItem_Click);
-            // 
-            // TI83SubMenu
-            // 
-            this.TI83SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.KeypadMenuItem,
-            this.LoadTIFileMenuItem,
-            this.toolStripSeparator13,
-            this.paletteToolStripMenuItem});
-            this.TI83SubMenu.Text = "TI83";
-            // 
-            // KeypadMenuItem
-            // 
-            this.KeypadMenuItem.Text = "Keypad";
-            this.KeypadMenuItem.Click += new System.EventHandler(this.Ti83KeypadMenuItem_Click);
-            // 
-            // LoadTIFileMenuItem
-            // 
-            this.LoadTIFileMenuItem.Text = "Load TI-83 File...";
-            this.LoadTIFileMenuItem.Click += new System.EventHandler(this.Ti83LoadTIFileMenuItem_Click);
-            // 
-            // paletteToolStripMenuItem
-            // 
-            this.paletteToolStripMenuItem.Text = "Palette...";
-            this.paletteToolStripMenuItem.Click += new System.EventHandler(this.Ti83PaletteMenuItem_Click);
-            // 
-            // A7800SubMenu
-            // 
-            this.A7800SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.A7800ControllerSettingsMenuItem,
-            this.A7800FilterSettingsMenuItem});
-            this.A7800SubMenu.Text = "&A7800";
-            this.A7800SubMenu.DropDownOpened += new System.EventHandler(this.A7800SubMenu_DropDownOpened);
-            // 
-            // A7800ControllerSettingsMenuItem
-            // 
-            this.A7800ControllerSettingsMenuItem.Text = "Controller Settings";
-            this.A7800ControllerSettingsMenuItem.Click += new System.EventHandler(this.A7800ControllerSettingsMenuItem_Click);
-            // 
-            // A7800FilterSettingsMenuItem
-            // 
-            this.A7800FilterSettingsMenuItem.Text = "Filter Settings";
-            this.A7800FilterSettingsMenuItem.Click += new System.EventHandler(this.A7800FilterSettingsMenuItem_Click);
-            // 
-            // GBSubMenu
-            // 
-            this.GBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.GBcoreSettingsToolStripMenuItem,
-            this.SameBoyColorChooserMenuItem,
-            this.toolStripSeparator28,
-            this.GBGPUViewerMenuItem,
-            this.GBPrinterViewerMenuItem});
-            this.GBSubMenu.Text = "&GB";
-            // 
-            // GBcoreSettingsToolStripMenuItem
-            // 
-            this.GBcoreSettingsToolStripMenuItem.Text = "Settings...";
-            this.GBcoreSettingsToolStripMenuItem.Click += new System.EventHandler(this.GbCoreSettingsMenuItem_Click);
-            // 
-            // SameBoyColorChooserMenuItem
-            // 
-            this.SameBoyColorChooserMenuItem.Text = "&Choose Custom Palette...";
-            this.SameBoyColorChooserMenuItem.Click += new System.EventHandler(this.SameboyColorChooserMenuItem_Click);
-            // 
-            // GBGPUViewerMenuItem
-            // 
-            this.GBGPUViewerMenuItem.Text = "GPU Viewer";
-            this.GBGPUViewerMenuItem.Click += new System.EventHandler(this.GbGpuViewerMenuItem_Click);
-            // 
-            // GBPrinterViewerMenuItem
-            // 
-            this.GBPrinterViewerMenuItem.Text = "&Printer Viewer";
-            this.GBPrinterViewerMenuItem.Click += new System.EventHandler(this.GbPrinterViewerMenuItem_Click);
-            // 
-            // PSXSubMenu
-            // 
-            this.PSXSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.PSXControllerSettingsMenuItem,
-            this.PSXOptionsMenuItem,
-            this.PSXDiscControlsMenuItem,
-            this.PSXHashDiscsToolStripMenuItem});
-            this.PSXSubMenu.Text = "PSX";
-            this.PSXSubMenu.DropDownOpened += new System.EventHandler(this.PsxSubMenu_DropDownOpened);
-            // 
-            // PSXControllerSettingsMenuItem
-            // 
-            this.PSXControllerSettingsMenuItem.Text = "Controller / Memcard Settings";
-            this.PSXControllerSettingsMenuItem.Click += new System.EventHandler(this.PsxControllerSettingsMenuItem_Click);
-            // 
-            // PSXOptionsMenuItem
-            // 
-            this.PSXOptionsMenuItem.Text = "&Options";
-            this.PSXOptionsMenuItem.Click += new System.EventHandler(this.PsxOptionsMenuItem_Click);
-            // 
-            // PSXDiscControlsMenuItem
-            // 
-            this.PSXDiscControlsMenuItem.Text = "&Disc Controls";
-            this.PSXDiscControlsMenuItem.Click += new System.EventHandler(this.PsxDiscControlsMenuItem_Click);
-            // 
-            // PSXHashDiscsToolStripMenuItem
-            // 
-            this.PSXHashDiscsToolStripMenuItem.Text = "&Hash Discs";
-            this.PSXHashDiscsToolStripMenuItem.Click += new System.EventHandler(this.PsxHashDiscsMenuItem_Click);
-            // 
-            // SNESSubMenu
-            // 
-            this.SNESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.SNESControllerConfigurationMenuItem,
-            this.toolStripSeparator18,
-            this.SnesGfxDebuggerMenuItem,
-            this.SnesOptionsMenuItem});
-            this.SNESSubMenu.Text = "&SNES";
-            this.SNESSubMenu.DropDownOpened += new System.EventHandler(this.SnesSubMenu_DropDownOpened);
-            // 
-            // SNESControllerConfigurationMenuItem
-            // 
-            this.SNESControllerConfigurationMenuItem.Text = "Controller Configuration";
-            this.SNESControllerConfigurationMenuItem.Click += new System.EventHandler(this.SNESControllerConfigurationMenuItem_Click);
-            // 
-            // SnesGfxDebuggerMenuItem
-            // 
-            this.SnesGfxDebuggerMenuItem.Text = "Graphics Debugger";
-            this.SnesGfxDebuggerMenuItem.Click += new System.EventHandler(this.SnesGfxDebuggerMenuItem_Click);
-            // 
-            // SnesOptionsMenuItem
-            // 
-            this.SnesOptionsMenuItem.Text = "&Options";
-            this.SnesOptionsMenuItem.Click += new System.EventHandler(this.SnesOptionsMenuItem_Click);
-            // 
-            // ColecoSubMenu
-            // 
-            this.ColecoSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ColecoControllerSettingsMenuItem,
-            this.toolStripSeparator35,
-            this.ColecoSkipBiosMenuItem,
-            this.ColecoUseSGMMenuItem});
-            this.ColecoSubMenu.Text = "&Coleco";
-            this.ColecoSubMenu.DropDownOpened += new System.EventHandler(this.ColecoSubMenu_DropDownOpened);
-            // 
-            // ColecoControllerSettingsMenuItem
-            // 
-            this.ColecoControllerSettingsMenuItem.Text = "&Controller Settings...";
-            this.ColecoControllerSettingsMenuItem.Click += new System.EventHandler(this.ColecoControllerSettingsMenuItem_Click);
-            // 
-            // ColecoSkipBiosMenuItem
-            // 
-            this.ColecoSkipBiosMenuItem.Text = "&Skip BIOS intro (When Applicable)";
-            this.ColecoSkipBiosMenuItem.Click += new System.EventHandler(this.ColecoSkipBiosMenuItem_Click);
-            // 
-            // ColecoUseSGMMenuItem
-            // 
-            this.ColecoUseSGMMenuItem.Text = "&Use the Super Game Module";
-            this.ColecoUseSGMMenuItem.Click += new System.EventHandler(this.ColecoUseSGMMenuItem_Click);
-            // 
-            // N64SubMenu
-            // 
-            this.N64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.N64PluginSettingsMenuItem,
-            this.N64ControllerSettingsMenuItem,
-            this.toolStripSeparator23,
-            this.N64CircularAnalogRangeMenuItem,
-            this.MupenStyleLagMenuItem,
-            this.N64ExpansionSlotMenuItem});
-            this.N64SubMenu.Text = "N64";
-            this.N64SubMenu.DropDownOpened += new System.EventHandler(this.N64SubMenu_DropDownOpened);
-            // 
-            // N64PluginSettingsMenuItem
-            // 
-            this.N64PluginSettingsMenuItem.Text = "Plugins";
-            this.N64PluginSettingsMenuItem.Click += new System.EventHandler(this.N64PluginSettingsMenuItem_Click);
-            // 
-            // N64ControllerSettingsMenuItem
-            // 
-            this.N64ControllerSettingsMenuItem.Text = "Controller Settings...";
-            this.N64ControllerSettingsMenuItem.Click += new System.EventHandler(this.N64ControllerSettingsMenuItem_Click);
-            // 
-            // N64CircularAnalogRangeMenuItem
-            // 
-            this.N64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
-            this.N64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
-            // 
-            // MupenStyleLagMenuItem
-            // 
-            this.MupenStyleLagMenuItem.Text = "&Mupen Style Lag Frames";
-            this.MupenStyleLagMenuItem.Click += new System.EventHandler(this.MupenStyleLagMenuItem_Click);
-            // 
-            // N64ExpansionSlotMenuItem
-            // 
-            this.N64ExpansionSlotMenuItem.Text = "&Use Expansion Slot";
-            this.N64ExpansionSlotMenuItem.Click += new System.EventHandler(this.N64ExpansionSlotMenuItem_Click);
-            // 
-            // Ares64SubMenu
-            // 
-            this.Ares64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.Ares64SettingsMenuItem,
-            this.Ares64CircularAnalogRangeMenuItem});
-            this.Ares64SubMenu.Text = "N64";
-            this.Ares64SubMenu.DropDownOpened += new System.EventHandler(this.Ares64SubMenu_DropDownOpened);
-            // 
-            // Ares64SettingsMenuItem
-            // 
-            this.Ares64SettingsMenuItem.Text = "Settings...";
-            this.Ares64SettingsMenuItem.Click += new System.EventHandler(this.Ares64SettingsMenuItem_Click);
-            // 
-            // Ares64CircularAnalogRangeMenuItem
-            // 
-            this.Ares64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
-            this.Ares64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
-            // 
-            // GBLSubMenu
-            // 
-            this.GBLSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.GBLsettingsToolStripMenuItem});
-            this.GBLSubMenu.Text = "&GB Link";
-            // 
-            // GBLsettingsToolStripMenuItem
-            // 
-            this.GBLsettingsToolStripMenuItem.Text = "Settings...";
-            this.GBLsettingsToolStripMenuItem.Click += new System.EventHandler(this.GblSettingsMenuItem_Click);
-            // 
-            // AppleSubMenu
-            // 
-            this.AppleSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.AppleDisksSubMenu,
-            this.settingsToolStripMenuItem1});
-            this.AppleSubMenu.Text = "Apple";
-            this.AppleSubMenu.DropDownOpened += new System.EventHandler(this.AppleSubMenu_DropDownOpened);
-            // 
-            // AppleDisksSubMenu
-            // 
-            this.AppleDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripSeparator31});
-            this.AppleDisksSubMenu.Text = "Disks";
-            this.AppleDisksSubMenu.DropDownOpened += new System.EventHandler(this.AppleDisksSubMenu_DropDownOpened);
-            // 
-            // settingsToolStripMenuItem1
-            // 
-            this.settingsToolStripMenuItem1.Text = "&Settings...";
-            this.settingsToolStripMenuItem1.Click += new System.EventHandler(this.AppleIISettingsMenuItem_Click);
-            // 
-            // C64SubMenu
-            // 
-            this.C64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.C64DisksSubMenu,
-            this.C64SettingsMenuItem});
-            this.C64SubMenu.Text = "&C64";
-            this.C64SubMenu.DropDownOpened += new System.EventHandler(this.C64SubMenu_DropDownOpened);
-            // 
-            // C64DisksSubMenu
-            // 
-            this.C64DisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripSeparator36});
-            this.C64DisksSubMenu.Text = "Disks";
-            this.C64DisksSubMenu.DropDownOpened += new System.EventHandler(this.C64DisksSubMenu_DropDownOpened);
-            // 
-            // C64SettingsMenuItem
-            // 
-            this.C64SettingsMenuItem.Text = "&Settings...";
-            this.C64SettingsMenuItem.Click += new System.EventHandler(this.C64SettingsMenuItem_Click);
-            // 
-            // IntvSubMenu
-            // 
-            this.IntvSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.IntVControllerSettingsMenuItem});
-            this.IntvSubMenu.Text = "&Intv";
-            this.IntvSubMenu.DropDownOpened += new System.EventHandler(this.IntVSubMenu_DropDownOpened);
-            // 
-            // IntVControllerSettingsMenuItem
-            // 
-            this.IntVControllerSettingsMenuItem.Text = "Controller Settings...";
-            this.IntVControllerSettingsMenuItem.Click += new System.EventHandler(this.IntVControllerSettingsMenuItem_Click);
-            // 
-            // zXSpectrumToolStripMenuItem
-            // 
-            this.zXSpectrumToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ZXSpectrumCoreEmulationSettingsMenuItem,
-            this.ZXSpectrumControllerConfigurationMenuItem,
-            this.ZXSpectrumAudioSettingsMenuItem,
-            this.ZXSpectrumNonSyncSettingsMenuItem,
-            this.ZXSpectrumMediaMenuItem});
-            this.zXSpectrumToolStripMenuItem.Text = "ZX Spectrum";
-            // 
-            // ZXSpectrumCoreEmulationSettingsMenuItem
-            // 
-            this.ZXSpectrumCoreEmulationSettingsMenuItem.Text = "Core Emulation Settings";
-            this.ZXSpectrumCoreEmulationSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumCoreEmulationSettingsMenuItem_Click);
-            // 
-            // ZXSpectrumControllerConfigurationMenuItem
-            // 
-            this.ZXSpectrumControllerConfigurationMenuItem.Text = "Joystick Configuration";
-            this.ZXSpectrumControllerConfigurationMenuItem.Click += new System.EventHandler(this.ZXSpectrumControllerConfigurationMenuItem_Click);
-            // 
-            // ZXSpectrumAudioSettingsMenuItem
-            // 
-            this.ZXSpectrumAudioSettingsMenuItem.Text = "Audio Settings";
-            this.ZXSpectrumAudioSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumAudioSettingsMenuItem_Click);
-            // 
-            // ZXSpectrumNonSyncSettingsMenuItem
-            // 
-            this.ZXSpectrumNonSyncSettingsMenuItem.Text = "Non-Sync Settings";
-            this.ZXSpectrumNonSyncSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumNonSyncSettingsMenuItem_Click);
-            // 
-            // ZXSpectrumMediaMenuItem
-            // 
-            this.ZXSpectrumMediaMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ZXSpectrumTapesSubMenu,
-            this.ZXSpectrumDisksSubMenu,
-            this.ZXSpectrumExportSnapshotMenuItemMenuItem});
-            this.ZXSpectrumMediaMenuItem.Text = "Media";
-            this.ZXSpectrumMediaMenuItem.DropDownOpened += new System.EventHandler(this.ZXSpectrumMediaMenuItem_DropDownOpened);
-            // 
-            // ZXSpectrumTapesSubMenu
-            // 
-            this.ZXSpectrumTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.zxt1ToolStripMenuItem});
-            this.ZXSpectrumTapesSubMenu.Text = "Tapes";
-            this.ZXSpectrumTapesSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumTapesSubMenu_DropDownOpened);
-            // 
-            // zxt1ToolStripMenuItem
-            // 
-            this.zxt1ToolStripMenuItem.Text = "zxt1";
-            // 
-            // ZXSpectrumDisksSubMenu
-            // 
-            this.ZXSpectrumDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.zxt2ToolStripMenuItem});
-            this.ZXSpectrumDisksSubMenu.Text = "Disks";
-            this.ZXSpectrumDisksSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumDisksSubMenu_DropDownOpened);
-            // 
-            // zxt2ToolStripMenuItem
-            // 
-            this.zxt2ToolStripMenuItem.Text = "zxt2";
-            // 
-            // ZXSpectrumExportSnapshotMenuItemMenuItem
-            // 
-            this.ZXSpectrumExportSnapshotMenuItemMenuItem.Text = "Export Snapshot";
-            this.ZXSpectrumExportSnapshotMenuItemMenuItem.Click += new System.EventHandler(this.ZXSpectrumExportSnapshotMenuItemMenuItem_Click);
-            // 
-            // GenericCoreSubMenu
-            // 
-            this.GenericCoreSubMenu.Text = "&Core";
-            // 
-            // amstradCPCToolStripMenuItem
-            // 
-            this.amstradCPCToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.amstradCPCCoreEmulationSettingsToolStripMenuItem,
-            this.AmstradCPCAudioSettingsToolStripMenuItem,
-            this.AmstradCPCNonSyncSettingsToolStripMenuItem,
-            this.AmstradCPCMediaToolStripMenuItem});
-            this.amstradCPCToolStripMenuItem.Text = "Amstrad CPC";
-            // 
-            // amstradCPCCoreEmulationSettingsToolStripMenuItem
-            // 
-            this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Text = "Core Emulation Settings";
-            this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcCoreEmulationSettingsMenuItem_Click);
-            // 
-            // AmstradCPCAudioSettingsToolStripMenuItem
-            // 
-            this.AmstradCPCAudioSettingsToolStripMenuItem.Text = "Audio Settings";
-            this.AmstradCPCAudioSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcAudioSettingsMenuItem_Click);
-            // 
-            // AmstradCPCNonSyncSettingsToolStripMenuItem
-            // 
-            this.AmstradCPCNonSyncSettingsToolStripMenuItem.Text = "Non-Sync Settings";
-            this.AmstradCPCNonSyncSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcNonSyncSettingsMenuItem_Click);
-            // 
-            // AmstradCPCMediaToolStripMenuItem
-            // 
-            this.AmstradCPCMediaToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.AmstradCPCTapesSubMenu,
-            this.AmstradCPCDisksSubMenu});
-            this.AmstradCPCMediaToolStripMenuItem.Text = "Media";
-            this.AmstradCPCMediaToolStripMenuItem.DropDownOpened += new System.EventHandler(this.AmstradCpcMediaMenuItem_DropDownOpened);
-            // 
-            // AmstradCPCTapesSubMenu
-            // 
-            this.AmstradCPCTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.cpct1ToolStripMenuItem});
-            this.AmstradCPCTapesSubMenu.Text = "Tapes";
-            this.AmstradCPCTapesSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcTapesSubMenu_DropDownOpened);
-            // 
-            // cpct1ToolStripMenuItem
-            // 
-            this.cpct1ToolStripMenuItem.Text = "cpct1";
-            // 
-            // AmstradCPCDisksSubMenu
-            // 
-            this.AmstradCPCDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.cpcd1ToolStripMenuItem});
-            this.AmstradCPCDisksSubMenu.Text = "Disks";
-            this.AmstradCPCDisksSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcDisksSubMenu_DropDownOpened);
-            // 
-            // cpcd1ToolStripMenuItem
-            // 
-            this.cpcd1ToolStripMenuItem.Text = "cpcd1";
-            // 
-            // HelpSubMenu
-            // 
-            this.HelpSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.OnlineHelpMenuItem,
-            this.ForumsMenuItem,
-            this.FeaturesMenuItem,
-            this.AboutMenuItem});
-            this.HelpSubMenu.Text = "&Help";
-            this.HelpSubMenu.DropDownOpened += new System.EventHandler(this.HelpSubMenu_DropDownOpened);
-            // 
-            // OnlineHelpMenuItem
-            // 
-            this.OnlineHelpMenuItem.Text = "Open TASVideos Wiki in Browser";
-            this.OnlineHelpMenuItem.Click += new System.EventHandler(this.OnlineHelpMenuItem_Click);
-            // 
-            // ForumsMenuItem
-            // 
-            this.ForumsMenuItem.Text = "Open Forums in Browser";
-            this.ForumsMenuItem.Click += new System.EventHandler(this.ForumsMenuItem_Click);
-            // 
-            // FeaturesMenuItem
-            // 
-            this.FeaturesMenuItem.Text = "&Features";
-            this.FeaturesMenuItem.Click += new System.EventHandler(this.FeaturesMenuItem_Click);
-            // 
-            // AboutMenuItem
-            // 
-            this.AboutMenuItem.Text = "&About...";
-            this.AboutMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
-            // 
-            // A7800HawkCoreMenuItem
-            // 
-            this.A7800HawkCoreMenuItem.Text = "A7800Hawk";
-            // 
-            // MainStatusBar
-            // 
-            this.MainStatusBar.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.MainStatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.DumpStatusButton,
-            this.EmuStatus,
-            this.PlayRecordStatusButton,
-            this.PauseStatusButton,
-            this.RebootStatusBarIcon,
-            this.AVIStatusLabel,
-            this.LedLightStatusLabel,
-            this.SaveSlotsStatusLabel,
-            this.Slot1StatusButton,
-            this.Slot2StatusButton,
-            this.Slot3StatusButton,
-            this.Slot4StatusButton,
-            this.Slot5StatusButton,
-            this.Slot6StatusButton,
-            this.Slot7StatusButton,
-            this.Slot8StatusButton,
-            this.Slot9StatusButton,
-            this.Slot0StatusButton,
-            this.CheatStatusButton,
-            this.KeyPriorityStatusLabel,
-            this.CoreNameStatusBarButton,
-            this.ProfileFirstBootLabel,
-            this.LinkConnectStatusBarButton,
-            this.UpdateNotification});
-            this.MainStatusBar.Location = new System.Drawing.Point(0, 382);
-            this.MainStatusBar.Name = "MainStatusBar";
-            this.MainStatusBar.ShowItemToolTips = true;
-            this.MainStatusBar.SizingGrip = false;
-            this.MainStatusBar.TabIndex = 1;
-            // 
-            // DumpStatusButton
-            // 
-            this.DumpStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.DumpStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.DumpStatusButton.Name = "DumpStatusButton";
-            this.DumpStatusButton.ShowDropDownArrow = false;
-            this.DumpStatusButton.Size = new System.Drawing.Size(4, 24);
-            this.DumpStatusButton.Text = "No ROM loaded";
-            this.DumpStatusButton.Click += new System.EventHandler(this.DumpStatusButton_Click);
-            // 
-            // PlayRecordStatusButton
-            // 
-            this.PlayRecordStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.PlayRecordStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.PlayRecordStatusButton.Name = "PlayRecordStatusButton";
-            this.PlayRecordStatusButton.ShowDropDownArrow = false;
-            this.PlayRecordStatusButton.Size = new System.Drawing.Size(4, 24);
-            this.PlayRecordStatusButton.Text = "No movie is active";
-            // 
-            // PauseStatusButton
-            // 
-            this.PauseStatusButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.PauseStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.PauseStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.PauseStatusButton.Name = "PauseStatusButton";
-            this.PauseStatusButton.ShowDropDownArrow = false;
-            this.PauseStatusButton.Size = new System.Drawing.Size(4, 24);
-            this.PauseStatusButton.Text = "toolStripDropDownButton1";
-            this.PauseStatusButton.ToolTipText = "Emulator is paused";
-            this.PauseStatusButton.Click += new System.EventHandler(this.PauseMenuItem_Click);
-            // 
-            // RebootStatusBarIcon
-            // 
-            this.RebootStatusBarIcon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.RebootStatusBarIcon.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.RebootStatusBarIcon.Text = "Reboot";
-            this.RebootStatusBarIcon.ToolTipText = "A reboot of the core is needed for a setting change to take effect";
-            this.RebootStatusBarIcon.Click += new System.EventHandler(this.PowerMenuItem_Click);
-            // 
-            // AVIStatusLabel
-            // 
-            this.AVIStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.AVIStatusLabel.Text = "AVI Capture";
-            // 
-            // LedLightStatusLabel
-            // 
-            this.LedLightStatusLabel.ToolTipText = "Disk Drive LED Light";
-            // 
-            // SaveSlotsStatusLabel
-            // 
-            this.SaveSlotsStatusLabel.BackColor = System.Drawing.SystemColors.Control;
-            this.SaveSlotsStatusLabel.Text = "Save slots";
-            // 
-            // Slot1StatusButton
-            // 
-            this.Slot1StatusButton.Text = "1";
-            this.Slot1StatusButton.ToolTipText = "Save slot 1";
-            this.Slot1StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-            // 
-            // Slot2StatusButton
-            // 
-            this.Slot2StatusButton.Text = "2";
-            this.Slot2StatusButton.ToolTipText = "Save slot 2";
-            this.Slot2StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-            // 
-            // Slot3StatusButton
-            // 
-            this.Slot3StatusButton.Text = "3";
-            this.Slot3StatusButton.ToolTipText = "Save slot 3";
-            this.Slot3StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-            // 
-            // Slot4StatusButton
-            // 
-            this.Slot4StatusButton.Text = "4";
-            this.Slot4StatusButton.ToolTipText = "Save slot 4";
-            this.Slot4StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-            // 
-            // Slot5StatusButton
-            // 
-            this.Slot5StatusButton.Text = "5";
-            this.Slot5StatusButton.ToolTipText = "Save slot 5";
-            this.Slot5StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-            // 
-            // Slot6StatusButton
-            // 
-            this.Slot6StatusButton.Text = "6";
-            this.Slot6StatusButton.ToolTipText = "Save slot 6";
-            this.Slot6StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-            // 
-            // Slot7StatusButton
-            // 
-            this.Slot7StatusButton.Text = "7";
-            this.Slot7StatusButton.ToolTipText = "Save slot 7";
-            this.Slot7StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-            // 
-            // Slot8StatusButton
-            // 
-            this.Slot8StatusButton.Text = "8";
-            this.Slot8StatusButton.ToolTipText = "Save slot 8";
-            this.Slot8StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-            // 
-            // Slot9StatusButton
-            // 
-            this.Slot9StatusButton.Text = "9";
-            this.Slot9StatusButton.ToolTipText = "Save slot 9";
-            this.Slot9StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-            // 
-            // Slot0StatusButton
-            // 
-            this.Slot0StatusButton.Text = "0";
-            this.Slot0StatusButton.ToolTipText = "Save slot 10";
-            this.Slot0StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
-            // 
-            // CheatStatusButton
-            // 
-            this.CheatStatusButton.Click += new System.EventHandler(this.FreezeStatus_Click);
-            // 
-            // KeyPriorityStatusLabel
-            // 
-            this.KeyPriorityStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.KeyPriorityStatusLabel.Margin = new System.Windows.Forms.Padding(5, 3, 5, 0);
-            this.KeyPriorityStatusLabel.Text = "KeyPriority";
-            this.KeyPriorityStatusLabel.Click += new System.EventHandler(this.KeyPriorityStatusLabel_Click);
-            // 
-            // CoreNameStatusBarButton
-            // 
-            this.CoreNameStatusBarButton.Text = "<core name>";
-            // 
-            // ProfileFirstBootLabel
-            // 
-            this.ProfileFirstBootLabel.AutoToolTip = true;
-            this.ProfileFirstBootLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.ProfileFirstBootLabel.Text = "ProfileFirstBootLabel";
-            this.ProfileFirstBootLabel.ToolTipText = "Set up your profile before use";
-            this.ProfileFirstBootLabel.Visible = false;
-            this.ProfileFirstBootLabel.Click += new System.EventHandler(this.ProfileFirstBootLabel_Click);
-            // 
-            // LinkConnectStatusBarButton
-            // 
-            this.LinkConnectStatusBarButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.LinkConnectStatusBarButton.Text = "Link connection is currently enabled";
-            this.LinkConnectStatusBarButton.ToolTipText = "Link connection is currently enabled";
-            this.LinkConnectStatusBarButton.Click += new System.EventHandler(this.LinkConnectStatusBarButton_Click);
-            // 
-            // UpdateNotification
-            // 
-            this.UpdateNotification.IsLink = true;
-            this.UpdateNotification.LinkColor = System.Drawing.Color.Red;
-            this.UpdateNotification.Spring = true;
-            this.UpdateNotification.Text = "New version available!";
-            this.UpdateNotification.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.UpdateNotification.Click += new System.EventHandler(this.UpdateNotification_Click);
-            // 
-            // MainFormContextMenu
-            // 
-            this.MainFormContextMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.MainFormContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.OpenRomContextMenuItem,
-            this.LoadLastRomContextMenuItem,
-            this.StopAVContextMenuItem,
-            this.ContextSeparator_AfterROM,
-            this.RecordMovieContextMenuItem,
-            this.PlayMovieContextMenuItem,
-            this.RestartMovieContextMenuItem,
-            this.StopMovieContextMenuItem,
-            this.LoadLastMovieContextMenuItem,
-            this.BackupMovieContextMenuItem,
-            this.StopNoSaveContextMenuItem,
-            this.ViewSubtitlesContextMenuItem,
-            this.AddSubtitleContextMenuItem,
-            this.ViewCommentsContextMenuItem,
-            this.SaveMovieContextMenuItem,
-            this.SaveMovieAsContextMenuItem,
-            this.ContextSeparator_AfterMovie,
-            this.UndoSavestateContextMenuItem,
-            this.ContextSeparator_AfterUndo,
-            this.ConfigContextMenuItem,
-            this.ScreenshotContextMenuItem,
-            this.CloseRomContextMenuItem,
-            this.ClearSRAMContextMenuItem,
-            this.ShowMenuContextMenuSeparator,
-            this.ShowMenuContextMenuItem});
-            this.MainFormContextMenu.Name = "contextMenuStrip1";
-            this.MainFormContextMenu.Size = new System.Drawing.Size(257, 532);
-            this.MainFormContextMenu.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.MainFormContextMenu_Closing);
-            this.MainFormContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.MainFormContextMenu_Opening);
-            // 
-            // OpenRomContextMenuItem
-            // 
-            this.OpenRomContextMenuItem.Text = "Open Rom";
-            this.OpenRomContextMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
-            // 
-            // LoadLastRomContextMenuItem
-            // 
-            this.LoadLastRomContextMenuItem.Text = "Load Last ROM";
-            this.LoadLastRomContextMenuItem.Click += new System.EventHandler(this.LoadLastRomContextMenuItem_Click);
-            // 
-            // StopAVContextMenuItem
-            // 
-            this.StopAVContextMenuItem.Text = "Stop AVI/WAV";
-            this.StopAVContextMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
-            // 
-            // RecordMovieContextMenuItem
-            // 
-            this.RecordMovieContextMenuItem.Text = "Record Movie";
-            this.RecordMovieContextMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
-            // 
-            // PlayMovieContextMenuItem
-            // 
-            this.PlayMovieContextMenuItem.Text = "Play Movie";
-            this.PlayMovieContextMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
-            // 
-            // RestartMovieContextMenuItem
-            // 
-            this.RestartMovieContextMenuItem.Text = "Restart Movie";
-            this.RestartMovieContextMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
-            // 
-            // StopMovieContextMenuItem
-            // 
-            this.StopMovieContextMenuItem.Text = "Stop Movie";
-            this.StopMovieContextMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
-            // 
-            // LoadLastMovieContextMenuItem
-            // 
-            this.LoadLastMovieContextMenuItem.Text = "Load Last Movie";
-            this.LoadLastMovieContextMenuItem.Click += new System.EventHandler(this.LoadLastMovieContextMenuItem_Click);
-            // 
-            // BackupMovieContextMenuItem
-            // 
-            this.BackupMovieContextMenuItem.Text = "Backup Movie";
-            this.BackupMovieContextMenuItem.Click += new System.EventHandler(this.BackupMovieContextMenuItem_Click);
-            // 
-            // StopNoSaveContextMenuItem
-            // 
-            this.StopNoSaveContextMenuItem.Text = "Stop Movie without Saving";
-            this.StopNoSaveContextMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
-            // 
-            // ViewSubtitlesContextMenuItem
-            // 
-            this.ViewSubtitlesContextMenuItem.Text = "View Subtitles";
-            this.ViewSubtitlesContextMenuItem.Click += new System.EventHandler(this.ViewSubtitlesContextMenuItem_Click);
-            // 
-            // AddSubtitleContextMenuItem
-            // 
-            this.AddSubtitleContextMenuItem.Text = "Add Subtitle";
-            this.AddSubtitleContextMenuItem.Click += new System.EventHandler(this.AddSubtitleContextMenuItem_Click);
-            // 
-            // ViewCommentsContextMenuItem
-            // 
-            this.ViewCommentsContextMenuItem.Text = "View Comments";
-            this.ViewCommentsContextMenuItem.Click += new System.EventHandler(this.ViewCommentsContextMenuItem_Click);
-            // 
-            // SaveMovieContextMenuItem
-            // 
-            this.SaveMovieContextMenuItem.Text = "Save Movie";
-            this.SaveMovieContextMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
-            // 
-            // SaveMovieAsContextMenuItem
-            // 
-            this.SaveMovieAsContextMenuItem.Text = "Save Movie As...";
-            this.SaveMovieAsContextMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
-            // 
-            // UndoSavestateContextMenuItem
-            // 
-            this.UndoSavestateContextMenuItem.Text = "Undo Savestate";
-            this.UndoSavestateContextMenuItem.Click += new System.EventHandler(this.UndoSavestateContextMenuItem_Click);
-            // 
-            // ConfigContextMenuItem
-            // 
-            this.ConfigContextMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItem6,
-            this.toolStripMenuItem7,
-            this.toolStripMenuItem8,
-            this.toolStripMenuItem9,
-            this.toolStripMenuItem10,
-            this.toolStripMenuItem11,
-            this.toolStripMenuItem12,
-            this.toolStripMenuItem13,
-            this.toolStripMenuItem14,
-            this.toolStripMenuItem15,
-            this.customizeToolStripMenuItem,
-            this.toolStripSeparator30,
-            this.toolStripMenuItem66,
-            this.toolStripMenuItem67});
-            this.ConfigContextMenuItem.Text = "Config";
-            // 
-            // toolStripMenuItem6
-            // 
-            this.toolStripMenuItem6.Text = "&Controllers...";
-            this.toolStripMenuItem6.Click += new System.EventHandler(this.ControllersMenuItem_Click);
-            // 
-            // toolStripMenuItem7
-            // 
-            this.toolStripMenuItem7.Text = "&Hotkeys...";
-            this.toolStripMenuItem7.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
-            // 
-            // toolStripMenuItem8
-            // 
-            this.toolStripMenuItem8.Text = "Display...";
-            this.toolStripMenuItem8.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
-            // 
-            // toolStripMenuItem9
-            // 
-            this.toolStripMenuItem9.Text = "&Sound...";
-            this.toolStripMenuItem9.Click += new System.EventHandler(this.SoundMenuItem_Click);
-            // 
-            // toolStripMenuItem10
-            // 
-            this.toolStripMenuItem10.Text = "Paths...";
-            this.toolStripMenuItem10.Click += new System.EventHandler(this.PathsMenuItem_Click);
-            // 
-            // toolStripMenuItem11
-            // 
-            this.toolStripMenuItem11.Text = "&Firmwares...";
-            this.toolStripMenuItem11.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
-            // 
-            // toolStripMenuItem12
-            // 
-            this.toolStripMenuItem12.Text = "&Messages...";
-            this.toolStripMenuItem12.Click += new System.EventHandler(this.MessagesMenuItem_Click);
-            // 
-            // toolStripMenuItem13
-            // 
-            this.toolStripMenuItem13.Text = "&Autofire...";
-            this.toolStripMenuItem13.Click += new System.EventHandler(this.AutofireMenuItem_Click);
-            // 
-            // toolStripMenuItem14
-            // 
-            this.toolStripMenuItem14.Text = "&Rewind...";
-            this.toolStripMenuItem14.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
-            // 
-            // toolStripMenuItem15
-            // 
-            this.toolStripMenuItem15.Text = "File Extensions...";
-            this.toolStripMenuItem15.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
-            // 
-            // customizeToolStripMenuItem
-            // 
-            this.customizeToolStripMenuItem.Text = "Customize...";
-            this.customizeToolStripMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
-            // 
-            // toolStripMenuItem66
-            // 
-            this.toolStripMenuItem66.Text = "Save Config";
-            this.toolStripMenuItem66.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
-            // 
-            // toolStripMenuItem67
-            // 
-            this.toolStripMenuItem67.Text = "Load Config";
-            this.toolStripMenuItem67.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
-            // 
-            // ScreenshotContextMenuItem
-            // 
-            this.ScreenshotContextMenuItem.Text = "Screenshot";
-            this.ScreenshotContextMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
-            // 
-            // CloseRomContextMenuItem
-            // 
-            this.CloseRomContextMenuItem.Text = "Close ROM";
-            this.CloseRomContextMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
-            // 
-            // ClearSRAMContextMenuItem
-            // 
-            this.ClearSRAMContextMenuItem.Text = "Close and Clear SRAM";
-            this.ClearSRAMContextMenuItem.Click += new System.EventHandler(this.ClearSramContextMenuItem_Click);
-            // 
-            // ShowMenuContextMenuItem
-            // 
-            this.ShowMenuContextMenuItem.Text = "Show Menu";
-            this.ShowMenuContextMenuItem.Click += new System.EventHandler(this.ShowMenuContextMenuItem_Click);
-            // 
-            // timerMouseIdle
-            // 
-            this.timerMouseIdle.Enabled = true;
-            this.timerMouseIdle.Interval = 2000;
-            this.timerMouseIdle.Tick += new System.EventHandler(this.TimerMouseIdle_Tick);
-            // 
-            // MainForm
-            // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.ClientSize = new System.Drawing.Size(470, 408);
-            this.Controls.Add(this.MainStatusBar);
-            this.Controls.Add(this.MainformMenu);
-            this.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MainMenuStrip = this.MainformMenu;
-            this.Name = "MainForm";
-            this.Activated += new System.EventHandler(this.MainForm_Activated);
-            this.Deactivate += new System.EventHandler(this.MainForm_Deactivate);
-            this.Load += new System.EventHandler(this.MainForm_Load);
-            this.Shown += new System.EventHandler(this.MainForm_Shown);
-            this.Enter += new System.EventHandler(this.MainForm_Enter);
-            this.Resize += new System.EventHandler(this.MainForm_Resize);
-            this.MainformMenu.ResumeLayout(false);
-            this.MainformMenu.PerformLayout();
-            this.MainStatusBar.ResumeLayout(false);
-            this.MainStatusBar.PerformLayout();
-            this.MainFormContextMenu.ResumeLayout(false);
-            this.ResumeLayout(false);
-            this.PerformLayout();
+		            this.components = new System.ComponentModel.Container();
+		            this.MainformMenu = new BizHawk.WinForms.Controls.MenuStripEx();
+		            this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.OpenRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.RecentRomSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.OpenAdvancedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.CloseRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.SaveStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.SaveNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator24 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.AutosaveLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.LoadNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator21 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.AutoloadLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveSlotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SelectSlot1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SelectSlot2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SelectSlot3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SelectSlot4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SelectSlot5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SelectSlot6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SelectSlot7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SelectSlot8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SelectSlot9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SelectSlot0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PreviousSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.NextSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.SaveToCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveRAMSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.FlushSaveRAMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.MovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ReadonlyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator15 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.RecentMovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator16 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.RecordMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PlayMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.StopMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PlayFromBeginningMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ImportMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveMovieAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.StopMovieWithoutSavingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator14 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.AutomaticallyBackupMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.FullMovieLoadstatesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MovieEndSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MovieEndFinishMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MovieEndRecordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MovieEndStopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MovieEndPauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AVSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.RecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ConfigAndRecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.StopAVIMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator19 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.CaptureOSDMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.CaptureLuaMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+		            this.SynclessRecordingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ScreenshotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ScreenshotAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ScreenshotClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ScreenshotClientClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator20 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.ScreenshotCaptureOSDMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.EmulationSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.RebootCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.SoftResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.HardResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.EmulatorMenuSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.LoadedCoreNameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ViewSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.WindowSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.x1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.x2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.x3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.x4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.x5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.x6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.x7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.x8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.x9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.mzMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SwitchToFullscreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.DisplayFPSMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.DisplayFrameCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.DisplayLagCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.DisplayInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.DisplayRerecordCountMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.DisplaySubtitlesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.DisplayStatusBarMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.DisplayMessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.DisplayLogWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ControllersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.HotkeysMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.DisplayConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SoundMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PathsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.FirmwaresMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AutofireMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.RewindOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.extensionsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ClientOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ProfilesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator9 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.SpeedSkipSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ClockThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AudioThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.VsyncThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator27 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.VsyncEnabledMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.miUnthrottled = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MinimizeSkippingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.NeverSkipMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem17 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Frameskip1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Frameskip2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Frameskip3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Frameskip4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Frameskip5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Frameskip6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Frameskip7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Frameskip8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Frameskip9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.Speed50MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Speed75MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Speed100MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Speed150MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Speed200MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Speed400MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.KeyPrioritySubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.BothHkAndControllerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.InputOverHkMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.HkOverInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.CoresSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator10 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.SaveConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveConfigAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadConfigFromMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ToolsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ToolBoxMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator12 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.RamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.RamSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LuaConsoleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.TAStudioMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.HexEditorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.TraceLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.DebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.CodeDataLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MacroToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.VirtualPadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.BasicBotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator11 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.CheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.GameSharkConverterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator29 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.MultiDiskBundlerFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.BatchRunnerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ExternalToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.dummyExternalTool = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.RetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.StartRetroAchievementsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.NESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.NESPPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.NESNametableViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MusicRipperMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator17 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.NesControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.NESGraphicSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.NESSoundChannelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.VSSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MovieSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator22 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.FDSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.FdsEjectDiskMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.VSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.VSInsertCoinP1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.VSInsertCoinP2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.VSServiceSwitchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.BarcodeReaderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.TI83SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.KeypadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadTIFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator13 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.paletteToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.A7800SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.A7800ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.A7800FilterSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.GBSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.GBcoreSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SameBoyColorChooserMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator28 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.GBGPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.GBPrinterViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PSXSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PSXControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PSXOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PSXDiscControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PSXHashDiscsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SNESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SNESControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator18 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.SnesGfxDebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SnesOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ColecoSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ColecoControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator35 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.ColecoSkipBiosMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ColecoUseSGMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.N64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.N64PluginSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.N64ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator23 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.N64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MupenStyleLagMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.N64ExpansionSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Ares64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Ares64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.Ares64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.GBLSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.GBLsettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AppleSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AppleDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator31 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.settingsToolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.C64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.C64DisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator36 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.C64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.IntvSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.IntVControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.zXSpectrumToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ZXSpectrumCoreEmulationSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ZXSpectrumControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ZXSpectrumAudioSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ZXSpectrumNonSyncSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ZXSpectrumMediaMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ZXSpectrumTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.zxt1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ZXSpectrumDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.zxt2ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ZXSpectrumExportSnapshotMenuItemMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.GenericCoreSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.amstradCPCToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.amstradCPCCoreEmulationSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AmstradCPCAudioSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AmstradCPCNonSyncSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AmstradCPCMediaToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AmstradCPCTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.cpct1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AmstradCPCDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.cpcd1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.HelpSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.OnlineHelpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ForumsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.FeaturesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AboutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.A7800HawkCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.MainStatusBar = new BizHawk.WinForms.Controls.StatusStripEx();
+		            this.DumpStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
+		            this.EmuStatus = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.PlayRecordStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
+		            this.PauseStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
+		            this.RebootStatusBarIcon = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.AVIStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.LedLightStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.SaveSlotsStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.Slot1StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.Slot2StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.Slot3StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.Slot4StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.Slot5StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.Slot6StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.Slot7StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.Slot8StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.Slot9StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.Slot0StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.CheatStatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.KeyPriorityStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.CoreNameStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.ProfileFirstBootLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.LinkConnectStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.UpdateNotification = new BizHawk.WinForms.Controls.StatusLabelEx();
+		            this.MainFormContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+		            this.OpenRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadLastRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.StopAVContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ContextSeparator_AfterROM = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.RecordMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.PlayMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.RestartMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.StopMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.LoadLastMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.BackupMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.StopNoSaveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ViewSubtitlesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.AddSubtitleContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ViewCommentsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.SaveMovieAsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ContextSeparator_AfterMovie = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.UndoSavestateContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ContextSeparator_AfterUndo = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.ConfigContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem6 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem7 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem8 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem9 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem10 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem11 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem12 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem13 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem14 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem15 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.customizeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripSeparator30 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.toolStripMenuItem66 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.toolStripMenuItem67 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ScreenshotContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.CloseRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ClearSRAMContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.ShowMenuContextMenuSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+		            this.ShowMenuContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+		            this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
+		            this.MainformMenu.SuspendLayout();
+		            this.MainStatusBar.SuspendLayout();
+		            this.MainFormContextMenu.SuspendLayout();
+		            this.SuspendLayout();
+		            // 
+		            // MainformMenu
+		            // 
+		            this.MainformMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
+		            this.MainformMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.FileSubMenu,
+		            this.EmulationSubMenu,
+		            this.ViewSubMenu,
+		            this.ConfigSubMenu,
+		            this.ToolsSubMenu,
+		            this.NESSubMenu,
+		            this.TI83SubMenu,
+		            this.A7800SubMenu,
+		            this.GBSubMenu,
+		            this.PSXSubMenu,
+		            this.SNESSubMenu,
+		            this.ColecoSubMenu,
+		            this.N64SubMenu,
+		            this.Ares64SubMenu,
+		            this.GBLSubMenu,
+		            this.AppleSubMenu,
+		            this.C64SubMenu,
+		            this.IntvSubMenu,
+		            this.zXSpectrumToolStripMenuItem,
+		            this.GenericCoreSubMenu,
+		            this.amstradCPCToolStripMenuItem,
+		            this.HelpSubMenu});
+		            this.MainformMenu.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
+		            this.MainformMenu.TabIndex = 0;
+		            this.MainformMenu.MenuActivate += new System.EventHandler(this.MainformMenu_MenuActivate);
+		            this.MainformMenu.MenuDeactivate += new System.EventHandler(this.MainformMenu_MenuDeactivate);
+		            // 
+		            // FileSubMenu
+		            // 
+		            this.FileSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.OpenRomMenuItem,
+		            this.RecentRomSubMenu,
+		            this.OpenAdvancedMenuItem,
+		            this.CloseRomMenuItem,
+		            this.toolStripMenuItem1,
+		            this.SaveStateSubMenu,
+		            this.LoadStateSubMenu,
+		            this.SaveSlotSubMenu,
+		            this.SaveRAMSubMenu,
+		            this.toolStripMenuItem2,
+		            this.MovieSubMenu,
+		            this.AVSubMenu,
+		            this.ScreenshotSubMenu,
+		            this.toolStripSeparator4,
+		            this.ExitMenuItem});
+		            this.FileSubMenu.Text = "&File";
+		            this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
+		            // 
+		            // OpenRomMenuItem
+		            // 
+		            this.OpenRomMenuItem.Text = "&Open ROM...";
+		            this.OpenRomMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
+		            // 
+		            // RecentRomSubMenu
+		            // 
+		            this.RecentRomSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.toolStripSeparator3});
+		            this.RecentRomSubMenu.Text = "&Recent ROM";
+		            this.RecentRomSubMenu.DropDownOpened += new System.EventHandler(this.RecentRomMenuItem_DropDownOpened);
+		            // 
+		            // OpenAdvancedMenuItem
+		            // 
+		            this.OpenAdvancedMenuItem.Text = "Open Ad&vanced...";
+		            this.OpenAdvancedMenuItem.Click += new System.EventHandler(this.OpenAdvancedMenuItem_Click);
+		            // 
+		            // CloseRomMenuItem
+		            // 
+		            this.CloseRomMenuItem.Text = "&Close ROM";
+		            this.CloseRomMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
+		            // 
+		            // SaveStateSubMenu
+		            // 
+		            this.SaveStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.SaveState1MenuItem,
+		            this.SaveState2MenuItem,
+		            this.SaveState3MenuItem,
+		            this.SaveState4MenuItem,
+		            this.SaveState5MenuItem,
+		            this.SaveState6MenuItem,
+		            this.SaveState7MenuItem,
+		            this.SaveState8MenuItem,
+		            this.SaveState9MenuItem,
+		            this.SaveState0MenuItem,
+		            this.toolStripSeparator6,
+		            this.SaveNamedStateMenuItem,
+		            this.toolStripSeparator24,
+		            this.AutosaveLastSlotMenuItem});
+		            this.SaveStateSubMenu.Text = "&Save State";
+		            this.SaveStateSubMenu.DropDownOpened += new System.EventHandler(this.SaveStateSubMenu_DropDownOpened);
+		            // 
+		            // SaveState1MenuItem
+		            // 
+		            this.SaveState1MenuItem.Text = "1";
+		            this.SaveState1MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+		            // 
+		            // SaveState2MenuItem
+		            // 
+		            this.SaveState2MenuItem.Text = "2";
+		            this.SaveState2MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+		            // 
+		            // SaveState3MenuItem
+		            // 
+		            this.SaveState3MenuItem.Text = "3";
+		            this.SaveState3MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+		            // 
+		            // SaveState4MenuItem
+		            // 
+		            this.SaveState4MenuItem.Text = "4";
+		            this.SaveState4MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+		            // 
+		            // SaveState5MenuItem
+		            // 
+		            this.SaveState5MenuItem.Text = "5";
+		            this.SaveState5MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+		            // 
+		            // SaveState6MenuItem
+		            // 
+		            this.SaveState6MenuItem.Text = "6";
+		            this.SaveState6MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+		            // 
+		            // SaveState7MenuItem
+		            // 
+		            this.SaveState7MenuItem.Text = "7";
+		            this.SaveState7MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+		            // 
+		            // SaveState8MenuItem
+		            // 
+		            this.SaveState8MenuItem.Text = "8";
+		            this.SaveState8MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+		            // 
+		            // SaveState9MenuItem
+		            // 
+		            this.SaveState9MenuItem.Text = "9";
+		            this.SaveState9MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+		            // 
+		            // SaveState0MenuItem
+		            // 
+		            this.SaveState0MenuItem.Text = "10";
+		            this.SaveState0MenuItem.Click += new System.EventHandler(this.QuickSavestateMenuItem_Click);
+		            // 
+		            // SaveNamedStateMenuItem
+		            // 
+		            this.SaveNamedStateMenuItem.Text = "Save Named State...";
+		            this.SaveNamedStateMenuItem.Click += new System.EventHandler(this.SaveNamedStateMenuItem_Click);
+		            // 
+		            // AutosaveLastSlotMenuItem
+		            // 
+		            this.AutosaveLastSlotMenuItem.Text = "Autosave Last Slot";
+		            this.AutosaveLastSlotMenuItem.Click += new System.EventHandler(this.AutosaveLastSlotMenuItem_Click);
+		            // 
+		            // LoadStateSubMenu
+		            // 
+		            this.LoadStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.LoadState1MenuItem,
+		            this.LoadState2MenuItem,
+		            this.LoadState3MenuItem,
+		            this.LoadState4MenuItem,
+		            this.LoadState5MenuItem,
+		            this.LoadState6MenuItem,
+		            this.LoadState7MenuItem,
+		            this.LoadState8MenuItem,
+		            this.LoadState9MenuItem,
+		            this.LoadState0MenuItem,
+		            this.toolStripSeparator7,
+		            this.LoadNamedStateMenuItem,
+		            this.toolStripSeparator21,
+		            this.AutoloadLastSlotMenuItem});
+		            this.LoadStateSubMenu.Text = "&Load State";
+		            this.LoadStateSubMenu.DropDownOpened += new System.EventHandler(this.LoadStateSubMenu_DropDownOpened);
+		            // 
+		            // LoadState1MenuItem
+		            // 
+		            this.LoadState1MenuItem.Text = "1";
+		            this.LoadState1MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+		            // 
+		            // LoadState2MenuItem
+		            // 
+		            this.LoadState2MenuItem.Text = "2";
+		            this.LoadState2MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+		            // 
+		            // LoadState3MenuItem
+		            // 
+		            this.LoadState3MenuItem.Text = "3";
+		            this.LoadState3MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+		            // 
+		            // LoadState4MenuItem
+		            // 
+		            this.LoadState4MenuItem.Text = "4";
+		            this.LoadState4MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+		            // 
+		            // LoadState5MenuItem
+		            // 
+		            this.LoadState5MenuItem.Text = "5";
+		            this.LoadState5MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+		            // 
+		            // LoadState6MenuItem
+		            // 
+		            this.LoadState6MenuItem.Text = "6";
+		            this.LoadState6MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+		            // 
+		            // LoadState7MenuItem
+		            // 
+		            this.LoadState7MenuItem.Text = "7";
+		            this.LoadState7MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+		            // 
+		            // LoadState8MenuItem
+		            // 
+		            this.LoadState8MenuItem.Text = "8";
+		            this.LoadState8MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+		            // 
+		            // LoadState9MenuItem
+		            // 
+		            this.LoadState9MenuItem.Text = "9";
+		            this.LoadState9MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+		            // 
+		            // LoadState0MenuItem
+		            // 
+		            this.LoadState0MenuItem.Text = "10";
+		            this.LoadState0MenuItem.Click += new System.EventHandler(this.QuickLoadstateMenuItem_Click);
+		            // 
+		            // LoadNamedStateMenuItem
+		            // 
+		            this.LoadNamedStateMenuItem.Text = "Load Named State...";
+		            this.LoadNamedStateMenuItem.Click += new System.EventHandler(this.LoadNamedStateMenuItem_Click);
+		            // 
+		            // AutoloadLastSlotMenuItem
+		            // 
+		            this.AutoloadLastSlotMenuItem.Text = "Autoload Last Slot";
+		            this.AutoloadLastSlotMenuItem.Click += new System.EventHandler(this.AutoloadLastSlotMenuItem_Click);
+		            // 
+		            // SaveSlotSubMenu
+		            // 
+		            this.SaveSlotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.SelectSlot1MenuItem,
+		            this.SelectSlot2MenuItem,
+		            this.SelectSlot3MenuItem,
+		            this.SelectSlot4MenuItem,
+		            this.SelectSlot5MenuItem,
+		            this.SelectSlot6MenuItem,
+		            this.SelectSlot7MenuItem,
+		            this.SelectSlot8MenuItem,
+		            this.SelectSlot9MenuItem,
+		            this.SelectSlot0MenuItem,
+		            this.PreviousSlotMenuItem,
+		            this.NextSlotMenuItem,
+		            this.toolStripSeparator5,
+		            this.SaveToCurrentSlotMenuItem,
+		            this.LoadCurrentSlotMenuItem});
+		            this.SaveSlotSubMenu.Text = "Save S&lot";
+		            this.SaveSlotSubMenu.DropDownOpened += new System.EventHandler(this.SaveSlotSubMenu_DropDownOpened);
+		            // 
+		            // SelectSlot1MenuItem
+		            // 
+		            this.SelectSlot1MenuItem.Text = "Select Slot 1";
+		            this.SelectSlot1MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+		            // 
+		            // SelectSlot2MenuItem
+		            // 
+		            this.SelectSlot2MenuItem.Text = "Select Slot 2";
+		            this.SelectSlot2MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+		            // 
+		            // SelectSlot3MenuItem
+		            // 
+		            this.SelectSlot3MenuItem.Text = "Select Slot 3";
+		            this.SelectSlot3MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+		            // 
+		            // SelectSlot4MenuItem
+		            // 
+		            this.SelectSlot4MenuItem.Text = "Select Slot 4";
+		            this.SelectSlot4MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+		            // 
+		            // SelectSlot5MenuItem
+		            // 
+		            this.SelectSlot5MenuItem.Text = "Select Slot 5";
+		            this.SelectSlot5MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+		            // 
+		            // SelectSlot6MenuItem
+		            // 
+		            this.SelectSlot6MenuItem.Text = "Select Slot 6";
+		            this.SelectSlot6MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+		            // 
+		            // SelectSlot7MenuItem
+		            // 
+		            this.SelectSlot7MenuItem.Text = "Select Slot 7";
+		            this.SelectSlot7MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+		            // 
+		            // SelectSlot8MenuItem
+		            // 
+		            this.SelectSlot8MenuItem.Text = "Select Slot 8";
+		            this.SelectSlot8MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+		            // 
+		            // SelectSlot9MenuItem
+		            // 
+		            this.SelectSlot9MenuItem.Text = "Select Slot 9";
+		            this.SelectSlot9MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+		            // 
+		            // SelectSlot0MenuItem
+		            // 
+		            this.SelectSlot0MenuItem.Text = "Select Slot 10";
+		            this.SelectSlot0MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
+		            // 
+		            // PreviousSlotMenuItem
+		            // 
+		            this.PreviousSlotMenuItem.Text = "Previous Slot";
+		            this.PreviousSlotMenuItem.Click += new System.EventHandler(this.PreviousSlotMenuItem_Click);
+		            // 
+		            // NextSlotMenuItem
+		            // 
+		            this.NextSlotMenuItem.Text = "Next Slot";
+		            this.NextSlotMenuItem.Click += new System.EventHandler(this.NextSlotMenuItem_Click);
+		            // 
+		            // SaveToCurrentSlotMenuItem
+		            // 
+		            this.SaveToCurrentSlotMenuItem.Text = "Save to Current Slot";
+		            this.SaveToCurrentSlotMenuItem.Click += new System.EventHandler(this.SaveToCurrentSlotMenuItem_Click);
+		            // 
+		            // LoadCurrentSlotMenuItem
+		            // 
+		            this.LoadCurrentSlotMenuItem.Text = "Load Current Slot";
+		            this.LoadCurrentSlotMenuItem.Click += new System.EventHandler(this.LoadCurrentSlotMenuItem_Click);
+		            // 
+		            // SaveRAMSubMenu
+		            // 
+		            this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.FlushSaveRAMMenuItem});
+		            this.SaveRAMSubMenu.Text = "Save &RAM";
+		            this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
+		            // 
+		            // FlushSaveRAMMenuItem
+		            // 
+		            this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
+		            this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
+		            // 
+		            // MovieSubMenu
+		            // 
+		            this.MovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.ReadonlyMenuItem,
+		            this.toolStripSeparator15,
+		            this.RecentMovieSubMenu,
+		            this.RecordMovieMenuItem,
+		            this.PlayMovieMenuItem,
+		            this.StopMovieMenuItem,
+		            this.PlayFromBeginningMenuItem,
+		            this.ImportMoviesMenuItem,
+		            this.SaveMovieMenuItem,
+		            this.SaveMovieAsMenuItem,
+		            this.StopMovieWithoutSavingMenuItem,
+		            this.toolStripSeparator14,
+		            this.AutomaticallyBackupMoviesMenuItem,
+		            this.FullMovieLoadstatesMenuItem,
+		            this.MovieEndSubMenu});
+		            this.MovieSubMenu.Text = "&Movie";
+		            this.MovieSubMenu.DropDownOpened += new System.EventHandler(this.MovieSubMenu_DropDownOpened);
+		            // 
+		            // ReadonlyMenuItem
+		            // 
+		            this.ReadonlyMenuItem.Text = "Read-only";
+		            this.ReadonlyMenuItem.Click += new System.EventHandler(this.ReadonlyMenuItem_Click);
+		            // 
+		            // RecentMovieSubMenu
+		            // 
+		            this.RecentMovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.toolStripSeparator16});
+		            this.RecentMovieSubMenu.Text = "Recent";
+		            this.RecentMovieSubMenu.DropDownOpened += new System.EventHandler(this.RecentMovieSubMenu_DropDownOpened);
+		            // 
+		            // RecordMovieMenuItem
+		            // 
+		            this.RecordMovieMenuItem.Text = "&Record Movie...";
+		            this.RecordMovieMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
+		            // 
+		            // PlayMovieMenuItem
+		            // 
+		            this.PlayMovieMenuItem.Text = "&Play Movie...";
+		            this.PlayMovieMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
+		            // 
+		            // StopMovieMenuItem
+		            // 
+		            this.StopMovieMenuItem.Text = "Stop Movie";
+		            this.StopMovieMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
+		            // 
+		            // PlayFromBeginningMenuItem
+		            // 
+		            this.PlayFromBeginningMenuItem.Text = "Play from Beginning";
+		            this.PlayFromBeginningMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
+		            // 
+		            // ImportMoviesMenuItem
+		            // 
+		            this.ImportMoviesMenuItem.Text = "Import Movies...";
+		            this.ImportMoviesMenuItem.Click += new System.EventHandler(this.ImportMovieMenuItem_Click);
+		            // 
+		            // SaveMovieMenuItem
+		            // 
+		            this.SaveMovieMenuItem.Text = "&Save Movie";
+		            this.SaveMovieMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
+		            // 
+		            // SaveMovieAsMenuItem
+		            // 
+		            this.SaveMovieAsMenuItem.Text = "Save Movie As...";
+		            this.SaveMovieAsMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
+		            // 
+		            // StopMovieWithoutSavingMenuItem
+		            // 
+		            this.StopMovieWithoutSavingMenuItem.Text = "Stop Movie without Saving";
+		            this.StopMovieWithoutSavingMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
+		            // 
+		            // AutomaticallyBackupMoviesMenuItem
+		            // 
+		            this.AutomaticallyBackupMoviesMenuItem.Text = "Automatically Backup Movies";
+		            this.AutomaticallyBackupMoviesMenuItem.Click += new System.EventHandler(this.AutomaticMovieBackupMenuItem_Click);
+		            // 
+		            // FullMovieLoadstatesMenuItem
+		            // 
+		            this.FullMovieLoadstatesMenuItem.Text = "Full Movie Loadstates";
+		            this.FullMovieLoadstatesMenuItem.Click += new System.EventHandler(this.FullMovieLoadstatesMenuItem_Click);
+		            // 
+		            // MovieEndSubMenu
+		            // 
+		            this.MovieEndSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.MovieEndFinishMenuItem,
+		            this.MovieEndRecordMenuItem,
+		            this.MovieEndStopMenuItem,
+		            this.MovieEndPauseMenuItem});
+		            this.MovieEndSubMenu.Text = "On Movie End";
+		            this.MovieEndSubMenu.DropDownOpened += new System.EventHandler(this.MovieEndSubMenu_DropDownOpened);
+		            // 
+		            // MovieEndFinishMenuItem
+		            // 
+		            this.MovieEndFinishMenuItem.Text = "Switch to Finished";
+		            this.MovieEndFinishMenuItem.Click += new System.EventHandler(this.MovieEndFinishMenuItem_Click);
+		            // 
+		            // MovieEndRecordMenuItem
+		            // 
+		            this.MovieEndRecordMenuItem.Text = "Switch To Record";
+		            this.MovieEndRecordMenuItem.Click += new System.EventHandler(this.MovieEndRecordMenuItem_Click);
+		            // 
+		            // MovieEndStopMenuItem
+		            // 
+		            this.MovieEndStopMenuItem.Text = "Stop";
+		            this.MovieEndStopMenuItem.Click += new System.EventHandler(this.MovieEndStopMenuItem_Click);
+		            // 
+		            // MovieEndPauseMenuItem
+		            // 
+		            this.MovieEndPauseMenuItem.Text = "Pause";
+		            this.MovieEndPauseMenuItem.Click += new System.EventHandler(this.MovieEndPauseMenuItem_Click);
+		            // 
+		            // AVSubMenu
+		            // 
+		            this.AVSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.RecordAVMenuItem,
+		            this.ConfigAndRecordAVMenuItem,
+		            this.StopAVIMenuItem,
+		            this.toolStripSeparator19,
+		            this.CaptureOSDMenuItem,
+		            this.CaptureLuaMenuItem,
+		            this.SynclessRecordingMenuItem});
+		            this.AVSubMenu.Text = "&AVI/WAV";
+		            this.AVSubMenu.DropDownOpened += new System.EventHandler(this.AVSubMenu_DropDownOpened);
+		            // 
+		            // RecordAVMenuItem
+		            // 
+		            this.RecordAVMenuItem.Text = "&Record AVI/WAV";
+		            this.RecordAVMenuItem.Click += new System.EventHandler(this.RecordAVMenuItem_Click);
+		            // 
+		            // ConfigAndRecordAVMenuItem
+		            // 
+		            this.ConfigAndRecordAVMenuItem.Text = "Config and Record AVI/WAV...";
+		            this.ConfigAndRecordAVMenuItem.Click += new System.EventHandler(this.ConfigAndRecordAVMenuItem_Click);
+		            // 
+		            // StopAVIMenuItem
+		            // 
+		            this.StopAVIMenuItem.Text = "&Stop AVI/WAV";
+		            this.StopAVIMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
+		            // 
+		            // CaptureOSDMenuItem
+		            // 
+		            this.CaptureOSDMenuItem.CheckOnClick = true;
+		            this.CaptureOSDMenuItem.Text = "Capture OSD";
+		            this.CaptureOSDMenuItem.Click += new System.EventHandler(this.CaptureOSDMenuItem_Click);
+		            // 
+		            // CaptureLuaMenuItem
+		            // 
+		            this.CaptureLuaMenuItem.CheckOnClick = true;
+		            this.CaptureLuaMenuItem.Name = "CaptureLuaMenuItem";
+		            this.CaptureLuaMenuItem.Size = new System.Drawing.Size(288, 26);
+		            this.CaptureLuaMenuItem.Text = "Capture Lua";
+		            this.CaptureLuaMenuItem.Click += new System.EventHandler(this.CaptureLuaMenuItem_Click);
+		            // 
+		            // SynclessRecordingMenuItem
+		            // 
+		            this.SynclessRecordingMenuItem.Text = "S&yncless Recording Tools";
+		            // 
+		            // ScreenshotSubMenu
+		            // 
+		            this.ScreenshotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.ScreenshotMenuItem,
+		            this.ScreenshotAsMenuItem,
+		            this.ScreenshotClipboardMenuItem,
+		            this.ScreenshotClientClipboardMenuItem,
+		            this.toolStripSeparator20,
+		            this.ScreenshotCaptureOSDMenuItem1});
+		            this.ScreenshotSubMenu.Text = "Scree&nshot";
+		            this.ScreenshotSubMenu.DropDownOpening += new System.EventHandler(this.ScreenshotSubMenu_DropDownOpening);
+		            // 
+		            // ScreenshotMenuItem
+		            // 
+		            this.ScreenshotMenuItem.Text = "Screenshot";
+		            this.ScreenshotMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
+		            // 
+		            // ScreenshotAsMenuItem
+		            // 
+		            this.ScreenshotAsMenuItem.Text = "Screenshot As...";
+		            this.ScreenshotAsMenuItem.Click += new System.EventHandler(this.ScreenshotAsMenuItem_Click);
+		            // 
+		            // ScreenshotClipboardMenuItem
+		            // 
+		            this.ScreenshotClipboardMenuItem.Text = "Screenshot (raw) -> Clipboard";
+		            this.ScreenshotClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClipboardMenuItem_Click);
+		            // 
+		            // ScreenshotClientClipboardMenuItem
+		            // 
+		            this.ScreenshotClientClipboardMenuItem.Text = "Screenshot (client) -> Clipboard";
+		            this.ScreenshotClientClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClientClipboardMenuItem_Click);
+		            // 
+		            // ScreenshotCaptureOSDMenuItem1
+		            // 
+		            this.ScreenshotCaptureOSDMenuItem1.Text = "Capture OSD";
+		            this.ScreenshotCaptureOSDMenuItem1.Click += new System.EventHandler(this.ScreenshotCaptureOSDMenuItem_Click);
+		            // 
+		            // ExitMenuItem
+		            // 
+		            this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
+		            this.ExitMenuItem.Text = "E&xit";
+		            this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
+		            // 
+		            // EmulationSubMenu
+		            // 
+		            this.EmulationSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.PauseMenuItem,
+		            this.RebootCoreMenuItem,
+		            this.toolStripSeparator1,
+		            this.SoftResetMenuItem,
+		            this.HardResetMenuItem,
+		            this.EmulatorMenuSeparator2,
+		            this.LoadedCoreNameMenuItem});
+		            this.EmulationSubMenu.Text = "&Emulation";
+		            this.EmulationSubMenu.DropDownOpened += new System.EventHandler(this.EmulationMenuItem_DropDownOpened);
+		            // 
+		            // PauseMenuItem
+		            // 
+		            this.PauseMenuItem.Text = "&Pause";
+		            this.PauseMenuItem.Click += new System.EventHandler(this.PauseMenuItem_Click);
+		            // 
+		            // RebootCoreMenuItem
+		            // 
+		            this.RebootCoreMenuItem.Text = "&Reboot Core";
+		            this.RebootCoreMenuItem.Click += new System.EventHandler(this.PowerMenuItem_Click);
+		            // 
+		            // SoftResetMenuItem
+		            // 
+		            this.SoftResetMenuItem.Text = "&Soft Reset";
+		            this.SoftResetMenuItem.Click += new System.EventHandler(this.SoftResetMenuItem_Click);
+		            // 
+		            // HardResetMenuItem
+		            // 
+		            this.HardResetMenuItem.Text = "&Hard Reset";
+		            this.HardResetMenuItem.Click += new System.EventHandler(this.HardResetMenuItem_Click);
+		            // 
+		            // LoadedCoreNameMenuItem
+		            // 
+		            this.LoadedCoreNameMenuItem.Enabled = false;
+		            this.LoadedCoreNameMenuItem.Text = "Loaded core: <core name> (sysID)";
+		            // 
+		            // ViewSubMenu
+		            // 
+		            this.ViewSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.WindowSizeSubMenu,
+		            this.SwitchToFullscreenMenuItem,
+		            this.toolStripSeparator2,
+		            this.DisplayFPSMenuItem,
+		            this.DisplayFrameCounterMenuItem,
+		            this.DisplayLagCounterMenuItem,
+		            this.DisplayInputMenuItem,
+		            this.DisplayRerecordCountMenuItem,
+		            this.DisplaySubtitlesMenuItem,
+		            this.toolStripMenuItem4,
+		            this.DisplayStatusBarMenuItem,
+		            this.DisplayMessagesMenuItem,
+		            this.toolStripSeparator8,
+		            this.DisplayLogWindowMenuItem});
+		            this.ViewSubMenu.Text = "&View";
+		            this.ViewSubMenu.DropDownOpened += new System.EventHandler(this.ViewSubMenu_DropDownOpened);
+		            // 
+		            // WindowSizeSubMenu
+		            // 
+		            this.WindowSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.x1MenuItem,
+		            this.x2MenuItem,
+		            this.x3MenuItem,
+		            this.x4MenuItem,
+		            this.x5MenuItem,
+		            this.x6MenuItem,
+		            this.x7MenuItem,
+		            this.x8MenuItem,
+		            this.x9MenuItem,
+		            this.mzMenuItem});
+		            this.WindowSizeSubMenu.Text = "&Window Size";
+		            this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
+		            // 
+		            // x1MenuItem
+		            // 
+		            this.x1MenuItem.Text = "&1x";
+		            this.x1MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+		            // 
+		            // x2MenuItem
+		            // 
+		            this.x2MenuItem.Text = "&2x";
+		            this.x2MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+		            // 
+		            // x3MenuItem
+		            // 
+		            this.x3MenuItem.Text = "&3x";
+		            this.x3MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+		            // 
+		            // x4MenuItem
+		            // 
+		            this.x4MenuItem.Text = "&4x";
+		            this.x4MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+		            // 
+		            // x5MenuItem
+		            // 
+		            this.x5MenuItem.Text = "&5x";
+		            this.x5MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+		            // 
+		            // x6MenuItem
+		            // 
+		            this.x6MenuItem.Text = "&6x";
+		            this.x6MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+		            // 
+		            // x7MenuItem
+		            // 
+		            this.x7MenuItem.Text = "&7x";
+		            this.x7MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+		            // 
+		            // x8MenuItem
+		            // 
+		            this.x8MenuItem.Text = "&8x";
+		            this.x8MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+		            // 
+		            // x9MenuItem
+		            // 
+		            this.x9MenuItem.Text = "&9x";
+		            this.x9MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+		            // 
+		            // mzMenuItem
+		            // 
+		            this.mzMenuItem.Text = "1&0x";
+		            this.mzMenuItem.Click += new System.EventHandler(this.WindowSize_Click);
+		            // 
+		            // SwitchToFullscreenMenuItem
+		            // 
+		            this.SwitchToFullscreenMenuItem.Text = "Switch to Fullscreen";
+		            this.SwitchToFullscreenMenuItem.Click += new System.EventHandler(this.SwitchToFullscreenMenuItem_Click);
+		            // 
+		            // DisplayFPSMenuItem
+		            // 
+		            this.DisplayFPSMenuItem.Text = "Display FPS";
+		            this.DisplayFPSMenuItem.Click += new System.EventHandler(this.DisplayFpsMenuItem_Click);
+		            // 
+		            // DisplayFrameCounterMenuItem
+		            // 
+		            this.DisplayFrameCounterMenuItem.Text = "Display Frame Count";
+		            this.DisplayFrameCounterMenuItem.Click += new System.EventHandler(this.DisplayFrameCounterMenuItem_Click);
+		            // 
+		            // DisplayLagCounterMenuItem
+		            // 
+		            this.DisplayLagCounterMenuItem.Text = "Display Lag Frame Count";
+		            this.DisplayLagCounterMenuItem.Click += new System.EventHandler(this.DisplayLagCounterMenuItem_Click);
+		            // 
+		            // DisplayInputMenuItem
+		            // 
+		            this.DisplayInputMenuItem.Text = "Display Input";
+		            this.DisplayInputMenuItem.Click += new System.EventHandler(this.DisplayInputMenuItem_Click);
+		            // 
+		            // DisplayRerecordCountMenuItem
+		            // 
+		            this.DisplayRerecordCountMenuItem.Text = "Display Rerecord Count";
+		            this.DisplayRerecordCountMenuItem.Click += new System.EventHandler(this.DisplayRerecordsMenuItem_Click);
+		            // 
+		            // DisplaySubtitlesMenuItem
+		            // 
+		            this.DisplaySubtitlesMenuItem.Text = "Display Subtitles";
+		            this.DisplaySubtitlesMenuItem.Click += new System.EventHandler(this.DisplaySubtitlesMenuItem_Click);
+		            // 
+		            // DisplayStatusBarMenuItem
+		            // 
+		            this.DisplayStatusBarMenuItem.Text = "Display Status Bar";
+		            this.DisplayStatusBarMenuItem.Click += new System.EventHandler(this.DisplayStatusBarMenuItem_Click);
+		            // 
+		            // DisplayMessagesMenuItem
+		            // 
+		            this.DisplayMessagesMenuItem.Text = "Display Messages";
+		            this.DisplayMessagesMenuItem.Click += new System.EventHandler(this.DisplayMessagesMenuItem_Click);
+		            // 
+		            // DisplayLogWindowMenuItem
+		            // 
+		            this.DisplayLogWindowMenuItem.Text = "Open &Log Window...";
+		            this.DisplayLogWindowMenuItem.Click += new System.EventHandler(this.DisplayLogWindowMenuItem_Click);
+		            // 
+		            // ConfigSubMenu
+		            // 
+		            this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.ControllersMenuItem,
+		            this.HotkeysMenuItem,
+		            this.DisplayConfigMenuItem,
+		            this.SoundMenuItem,
+		            this.PathsMenuItem,
+		            this.FirmwaresMenuItem,
+		            this.MessagesMenuItem,
+		            this.AutofireMenuItem,
+		            this.RewindOptionsMenuItem,
+		            this.extensionsToolStripMenuItem,
+		            this.ClientOptionsMenuItem,
+		            this.ProfilesMenuItem,
+		            this.toolStripSeparator9,
+		            this.SpeedSkipSubMenu,
+		            this.KeyPrioritySubMenu,
+		            this.CoresSubMenu,
+		            this.toolStripSeparator10,
+		            this.SaveConfigMenuItem,
+		            this.SaveConfigAsMenuItem,
+		            this.LoadConfigMenuItem,
+		            this.LoadConfigFromMenuItem});
+		            this.ConfigSubMenu.Text = "&Config";
+		            this.ConfigSubMenu.DropDownOpened += new System.EventHandler(this.ConfigSubMenu_DropDownOpened);
+		            // 
+		            // ControllersMenuItem
+		            // 
+		            this.ControllersMenuItem.Text = "&Controllers...";
+		            this.ControllersMenuItem.Click += new System.EventHandler(this.ControllersMenuItem_Click);
+		            // 
+		            // HotkeysMenuItem
+		            // 
+		            this.HotkeysMenuItem.Text = "&Hotkeys...";
+		            this.HotkeysMenuItem.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
+		            // 
+		            // DisplayConfigMenuItem
+		            // 
+		            this.DisplayConfigMenuItem.Text = "Display...";
+		            this.DisplayConfigMenuItem.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
+		            // 
+		            // SoundMenuItem
+		            // 
+		            this.SoundMenuItem.Text = "&Sound...";
+		            this.SoundMenuItem.Click += new System.EventHandler(this.SoundMenuItem_Click);
+		            // 
+		            // PathsMenuItem
+		            // 
+		            this.PathsMenuItem.Text = "Paths...";
+		            this.PathsMenuItem.Click += new System.EventHandler(this.PathsMenuItem_Click);
+		            // 
+		            // FirmwaresMenuItem
+		            // 
+		            this.FirmwaresMenuItem.Text = "&Firmwares...";
+		            this.FirmwaresMenuItem.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
+		            // 
+		            // MessagesMenuItem
+		            // 
+		            this.MessagesMenuItem.Text = "&Messages...";
+		            this.MessagesMenuItem.Click += new System.EventHandler(this.MessagesMenuItem_Click);
+		            // 
+		            // AutofireMenuItem
+		            // 
+		            this.AutofireMenuItem.Text = "&Autofire...";
+		            this.AutofireMenuItem.Click += new System.EventHandler(this.AutofireMenuItem_Click);
+		            // 
+		            // RewindOptionsMenuItem
+		            // 
+		            this.RewindOptionsMenuItem.Text = "&Rewind && States...";
+		            this.RewindOptionsMenuItem.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
+		            // 
+		            // extensionsToolStripMenuItem
+		            // 
+		            this.extensionsToolStripMenuItem.Text = "File Extensions...";
+		            this.extensionsToolStripMenuItem.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
+		            // 
+		            // ClientOptionsMenuItem
+		            // 
+		            this.ClientOptionsMenuItem.Text = "&Customize...";
+		            this.ClientOptionsMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
+		            // 
+		            // ProfilesMenuItem
+		            // 
+		            this.ProfilesMenuItem.Text = "&Profiles...";
+		            this.ProfilesMenuItem.Click += new System.EventHandler(this.ProfilesMenuItem_Click);
+		            // 
+		            // SpeedSkipSubMenu
+		            // 
+		            this.SpeedSkipSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.ClockThrottleMenuItem,
+		            this.AudioThrottleMenuItem,
+		            this.VsyncThrottleMenuItem,
+		            this.toolStripSeparator27,
+		            this.VsyncEnabledMenuItem,
+		            this.toolStripMenuItem3,
+		            this.miUnthrottled,
+		            this.MinimizeSkippingMenuItem,
+		            this.NeverSkipMenuItem,
+		            this.toolStripMenuItem17,
+		            this.toolStripMenuItem5,
+		            this.Speed50MenuItem,
+		            this.Speed75MenuItem,
+		            this.Speed100MenuItem,
+		            this.Speed150MenuItem,
+		            this.Speed200MenuItem,
+		            this.Speed400MenuItem});
+		            this.SpeedSkipSubMenu.Text = "Speed/Skip";
+		            this.SpeedSkipSubMenu.DropDownOpened += new System.EventHandler(this.FrameSkipMenuItem_DropDownOpened);
+		            // 
+		            // ClockThrottleMenuItem
+		            // 
+		            this.ClockThrottleMenuItem.Text = "Clock Throttle";
+		            this.ClockThrottleMenuItem.Click += new System.EventHandler(this.ClockThrottleMenuItem_Click);
+		            // 
+		            // AudioThrottleMenuItem
+		            // 
+		            this.AudioThrottleMenuItem.Text = "Audio Throttle";
+		            this.AudioThrottleMenuItem.Click += new System.EventHandler(this.AudioThrottleMenuItem_Click);
+		            // 
+		            // VsyncThrottleMenuItem
+		            // 
+		            this.VsyncThrottleMenuItem.Text = "VSync Throttle";
+		            this.VsyncThrottleMenuItem.Click += new System.EventHandler(this.VsyncThrottleMenuItem_Click);
+		            // 
+		            // VsyncEnabledMenuItem
+		            // 
+		            this.VsyncEnabledMenuItem.Text = "VSync Enabled";
+		            this.VsyncEnabledMenuItem.Click += new System.EventHandler(this.VsyncEnabledMenuItem_Click);
+		            // 
+		            // miUnthrottled
+		            // 
+		            this.miUnthrottled.Text = "Unthrottled";
+		            this.miUnthrottled.Click += new System.EventHandler(this.UnthrottledMenuItem_Click);
+		            // 
+		            // MinimizeSkippingMenuItem
+		            // 
+		            this.MinimizeSkippingMenuItem.Text = "Auto-minimize skipping";
+		            this.MinimizeSkippingMenuItem.Click += new System.EventHandler(this.MinimizeSkippingMenuItem_Click);
+		            // 
+		            // NeverSkipMenuItem
+		            // 
+		            this.NeverSkipMenuItem.Text = "Skip 0 (never)";
+		            this.NeverSkipMenuItem.Click += new System.EventHandler(this.NeverSkipMenuItem_Click);
+		            // 
+		            // toolStripMenuItem17
+		            // 
+		            this.toolStripMenuItem17.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.Frameskip1MenuItem,
+		            this.Frameskip2MenuItem,
+		            this.Frameskip3MenuItem,
+		            this.Frameskip4MenuItem,
+		            this.Frameskip5MenuItem,
+		            this.Frameskip6MenuItem,
+		            this.Frameskip7MenuItem,
+		            this.Frameskip8MenuItem,
+		            this.Frameskip9MenuItem});
+		            this.toolStripMenuItem17.Text = "Skip 1..9";
+		            // 
+		            // Frameskip1MenuItem
+		            // 
+		            this.Frameskip1MenuItem.Text = "1";
+		            this.Frameskip1MenuItem.Click += new System.EventHandler(this.Frameskip1MenuItem_Click);
+		            // 
+		            // Frameskip2MenuItem
+		            // 
+		            this.Frameskip2MenuItem.Text = "2";
+		            this.Frameskip2MenuItem.Click += new System.EventHandler(this.Frameskip2MenuItem_Click);
+		            // 
+		            // Frameskip3MenuItem
+		            // 
+		            this.Frameskip3MenuItem.Text = "3";
+		            this.Frameskip3MenuItem.Click += new System.EventHandler(this.Frameskip3MenuItem_Click);
+		            // 
+		            // Frameskip4MenuItem
+		            // 
+		            this.Frameskip4MenuItem.Text = "4";
+		            this.Frameskip4MenuItem.Click += new System.EventHandler(this.Frameskip4MenuItem_Click);
+		            // 
+		            // Frameskip5MenuItem
+		            // 
+		            this.Frameskip5MenuItem.Text = "5";
+		            this.Frameskip5MenuItem.Click += new System.EventHandler(this.Frameskip5MenuItem_Click);
+		            // 
+		            // Frameskip6MenuItem
+		            // 
+		            this.Frameskip6MenuItem.Text = "6";
+		            this.Frameskip6MenuItem.Click += new System.EventHandler(this.Frameskip6MenuItem_Click);
+		            // 
+		            // Frameskip7MenuItem
+		            // 
+		            this.Frameskip7MenuItem.Text = "7";
+		            this.Frameskip7MenuItem.Click += new System.EventHandler(this.Frameskip7MenuItem_Click);
+		            // 
+		            // Frameskip8MenuItem
+		            // 
+		            this.Frameskip8MenuItem.Text = "8";
+		            this.Frameskip8MenuItem.Click += new System.EventHandler(this.Frameskip8MenuItem_Click);
+		            // 
+		            // Frameskip9MenuItem
+		            // 
+		            this.Frameskip9MenuItem.Text = "9";
+		            this.Frameskip9MenuItem.Click += new System.EventHandler(this.Frameskip9MenuItem_Click);
+		            // 
+		            // Speed50MenuItem
+		            // 
+		            this.Speed50MenuItem.Text = "Speed 50%";
+		            this.Speed50MenuItem.Click += new System.EventHandler(this.Speed50MenuItem_Click);
+		            // 
+		            // Speed75MenuItem
+		            // 
+		            this.Speed75MenuItem.Text = "Speed 75%";
+		            this.Speed75MenuItem.Click += new System.EventHandler(this.Speed75MenuItem_Click);
+		            // 
+		            // Speed100MenuItem
+		            // 
+		            this.Speed100MenuItem.Text = "Speed 100%";
+		            this.Speed100MenuItem.Click += new System.EventHandler(this.Speed100MenuItem_Click);
+		            // 
+		            // Speed150MenuItem
+		            // 
+		            this.Speed150MenuItem.Text = "Speed 150%";
+		            this.Speed150MenuItem.Click += new System.EventHandler(this.Speed150MenuItem_Click);
+		            // 
+		            // Speed200MenuItem
+		            // 
+		            this.Speed200MenuItem.Text = "Speed 200%";
+		            this.Speed200MenuItem.Click += new System.EventHandler(this.Speed200MenuItem_Click);
+		            // 
+		            // Speed400MenuItem
+		            // 
+		            this.Speed400MenuItem.Text = "Speed 400%";
+		            this.Speed400MenuItem.Click += new System.EventHandler(this.Speed400MenuItem_Click);
+		            // 
+		            // KeyPrioritySubMenu
+		            // 
+		            this.KeyPrioritySubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.BothHkAndControllerMenuItem,
+		            this.InputOverHkMenuItem,
+		            this.HkOverInputMenuItem});
+		            this.KeyPrioritySubMenu.Text = "Key Priority";
+		            this.KeyPrioritySubMenu.DropDownOpened += new System.EventHandler(this.KeyPriorityMenuItem_DropDownOpened);
+		            // 
+		            // BothHkAndControllerMenuItem
+		            // 
+		            this.BothHkAndControllerMenuItem.Text = "Both Hotkeys and Controllers";
+		            this.BothHkAndControllerMenuItem.Click += new System.EventHandler(this.BothHkAndControllerMenuItem_Click);
+		            // 
+		            // InputOverHkMenuItem
+		            // 
+		            this.InputOverHkMenuItem.Text = "Input overrides Hotkeys";
+		            this.InputOverHkMenuItem.Click += new System.EventHandler(this.InputOverHkMenuItem_Click);
+		            // 
+		            // HkOverInputMenuItem
+		            // 
+		            this.HkOverInputMenuItem.Text = "Hotkeys override Input";
+		            this.HkOverInputMenuItem.Click += new System.EventHandler(this.HkOverInputMenuItem_Click);
+		            // 
+		            // CoresSubMenu
+		            // 
+		            this.CoresSubMenu.Text = "Preferred Cores";
+		            // 
+		            // SaveConfigMenuItem
+		            // 
+		            this.SaveConfigMenuItem.Text = "Save Config";
+		            this.SaveConfigMenuItem.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
+		            // 
+		            // SaveConfigAsMenuItem
+		            // 
+		            this.SaveConfigAsMenuItem.Text = "Save Config As...";
+		            this.SaveConfigAsMenuItem.Click += new System.EventHandler(this.SaveConfigAsMenuItem_Click);
+		            // 
+		            // LoadConfigMenuItem
+		            // 
+		            this.LoadConfigMenuItem.Text = "Load Config";
+		            this.LoadConfigMenuItem.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
+		            // 
+		            // LoadConfigFromMenuItem
+		            // 
+		            this.LoadConfigFromMenuItem.Text = "Load Config From...";
+		            this.LoadConfigFromMenuItem.Click += new System.EventHandler(this.LoadConfigFromMenuItem_Click);
+		            // 
+		            // ToolsSubMenu
+		            // 
+		            this.ToolsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.ToolBoxMenuItem,
+		            this.toolStripSeparator12,
+		            this.RamWatchMenuItem,
+		            this.RamSearchMenuItem,
+		            this.LuaConsoleMenuItem,
+		            this.TAStudioMenuItem,
+		            this.HexEditorMenuItem,
+		            this.TraceLoggerMenuItem,
+		            this.DebuggerMenuItem,
+		            this.CodeDataLoggerMenuItem,
+		            this.MacroToolMenuItem,
+		            this.VirtualPadMenuItem,
+		            this.BasicBotMenuItem,
+		            this.toolStripSeparator11,
+		            this.CheatsMenuItem,
+		            this.GameSharkConverterMenuItem,
+		            this.toolStripSeparator29,
+		            this.MultiDiskBundlerFileMenuItem,
+		            this.BatchRunnerMenuItem,
+		            this.ExternalToolMenuItem,
+		            this.RetroAchievementsMenuItem});
+		            this.ToolsSubMenu.Text = "&Tools";
+		            this.ToolsSubMenu.DropDownOpened += new System.EventHandler(this.ToolsSubMenu_DropDownOpened);
+		            // 
+		            // ToolBoxMenuItem
+		            // 
+		            this.ToolBoxMenuItem.Text = "&Tool Box";
+		            this.ToolBoxMenuItem.Click += new System.EventHandler(this.ToolBoxMenuItem_Click);
+		            // 
+		            // RamWatchMenuItem
+		            // 
+		            this.RamWatchMenuItem.Text = "RAM &Watch";
+		            this.RamWatchMenuItem.Click += new System.EventHandler(this.RamWatchMenuItem_Click);
+		            // 
+		            // RamSearchMenuItem
+		            // 
+		            this.RamSearchMenuItem.Text = "RAM &Search";
+		            this.RamSearchMenuItem.Click += new System.EventHandler(this.RamSearchMenuItem_Click);
+		            // 
+		            // LuaConsoleMenuItem
+		            // 
+		            this.LuaConsoleMenuItem.Text = "Lua Console";
+		            this.LuaConsoleMenuItem.Click += new System.EventHandler(this.LuaConsoleMenuItem_Click);
+		            // 
+		            // TAStudioMenuItem
+		            // 
+		            this.TAStudioMenuItem.Text = "&TAStudio";
+		            this.TAStudioMenuItem.Click += new System.EventHandler(this.TAStudioMenuItem_Click);
+		            // 
+		            // HexEditorMenuItem
+		            // 
+		            this.HexEditorMenuItem.Text = "&Hex Editor";
+		            this.HexEditorMenuItem.Click += new System.EventHandler(this.HexEditorMenuItem_Click);
+		            // 
+		            // TraceLoggerMenuItem
+		            // 
+		            this.TraceLoggerMenuItem.Text = "Trace &Logger";
+		            this.TraceLoggerMenuItem.Click += new System.EventHandler(this.TraceLoggerMenuItem_Click);
+		            // 
+		            // DebuggerMenuItem
+		            // 
+		            this.DebuggerMenuItem.Text = "&Debugger";
+		            this.DebuggerMenuItem.Click += new System.EventHandler(this.DebuggerMenuItem_Click);
+		            // 
+		            // CodeDataLoggerMenuItem
+		            // 
+		            this.CodeDataLoggerMenuItem.Text = "Code-Data Logger";
+		            this.CodeDataLoggerMenuItem.Click += new System.EventHandler(this.CodeDataLoggerMenuItem_Click);
+		            // 
+		            // MacroToolMenuItem
+		            // 
+		            this.MacroToolMenuItem.Text = "&Macro Tool";
+		            this.MacroToolMenuItem.Click += new System.EventHandler(this.MacroToolMenuItem_Click);
+		            // 
+		            // VirtualPadMenuItem
+		            // 
+		            this.VirtualPadMenuItem.Text = "Virtual Pad";
+		            this.VirtualPadMenuItem.Click += new System.EventHandler(this.VirtualPadMenuItem_Click);
+		            // 
+		            // BasicBotMenuItem
+		            // 
+		            this.BasicBotMenuItem.Text = "Basic Bot";
+		            this.BasicBotMenuItem.Click += new System.EventHandler(this.BasicBotMenuItem_Click);
+		            // 
+		            // CheatsMenuItem
+		            // 
+		            this.CheatsMenuItem.Text = "Cheats";
+		            this.CheatsMenuItem.Click += new System.EventHandler(this.CheatsMenuItem_Click);
+		            // 
+		            // GameSharkConverterMenuItem
+		            // 
+		            this.GameSharkConverterMenuItem.Text = "Cheat Code Converter";
+		            this.GameSharkConverterMenuItem.Click += new System.EventHandler(this.CheatCodeConverterMenuItem_Click);
+		            // 
+		            // MultiDiskBundlerFileMenuItem
+		            // 
+		            this.MultiDiskBundlerFileMenuItem.Text = "Multi-disk Bundler";
+		            this.MultiDiskBundlerFileMenuItem.Click += new System.EventHandler(this.MultidiskBundlerMenuItem_Click);
+		            // 
+		            // BatchRunnerMenuItem
+		            // 
+		            this.BatchRunnerMenuItem.Text = "Batch Runner...";
+		            this.BatchRunnerMenuItem.Visible = false;
+		            this.BatchRunnerMenuItem.Click += new System.EventHandler(this.BatchRunnerMenuItem_Click);
+		            // 
+		            // ExternalToolMenuItem
+		            // 
+		            this.ExternalToolMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.dummyExternalTool});
+		            this.ExternalToolMenuItem.Text = "External Tool";
+		            this.ExternalToolMenuItem.DropDownOpening += new System.EventHandler(this.ExternalToolMenuItem_DropDownOpening);
+		            // 
+		            // dummyExternalTool
+		            // 
+		            this.dummyExternalTool.Text = "None";
+		            // 
+		            // RetroAchievementsMenuItem
+		            // 
+		            this.RetroAchievementsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.StartRetroAchievementsMenuItem});
+		            this.RetroAchievementsMenuItem.Text = "&RetroAchievements";
+		            // 
+		            // StartRetroAchievementsMenuItem
+		            // 
+		            this.StartRetroAchievementsMenuItem.Text = "&Start RetroAchievements";
+		            this.StartRetroAchievementsMenuItem.Click += new System.EventHandler(this.StartRetroAchievementsMenuItem_Click);
+		            // 
+		            // NESSubMenu
+		            // 
+		            this.NESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.NESPPUViewerMenuItem,
+		            this.NESNametableViewerMenuItem,
+		            this.MusicRipperMenuItem,
+		            this.toolStripSeparator17,
+		            this.NesControllerSettingsMenuItem,
+		            this.NESGraphicSettingsMenuItem,
+		            this.NESSoundChannelsMenuItem,
+		            this.VSSettingsMenuItem,
+		            this.MovieSettingsMenuItem,
+		            this.toolStripSeparator22,
+		            this.FDSControlsMenuItem,
+		            this.VSControlsMenuItem,
+		            this.BarcodeReaderMenuItem});
+		            this.NESSubMenu.Text = "&NES";
+		            this.NESSubMenu.DropDownOpened += new System.EventHandler(this.NesSubMenu_DropDownOpened);
+		            // 
+		            // NESPPUViewerMenuItem
+		            // 
+		            this.NESPPUViewerMenuItem.Text = "&PPU Viewer";
+		            this.NESPPUViewerMenuItem.Click += new System.EventHandler(this.NesPpuViewerMenuItem_Click);
+		            // 
+		            // NESNametableViewerMenuItem
+		            // 
+		            this.NESNametableViewerMenuItem.Text = "&Nametable Viewer";
+		            this.NESNametableViewerMenuItem.Click += new System.EventHandler(this.NesNametableViewerMenuItem_Click);
+		            // 
+		            // MusicRipperMenuItem
+		            // 
+		            this.MusicRipperMenuItem.Text = "Music Ripper";
+		            this.MusicRipperMenuItem.Click += new System.EventHandler(this.MusicRipperMenuItem_Click);
+		            // 
+		            // NesControllerSettingsMenuItem
+		            // 
+		            this.NesControllerSettingsMenuItem.Text = "Controller Settings...";
+		            this.NesControllerSettingsMenuItem.Click += new System.EventHandler(this.NesControllerSettingsMenuItem_Click);
+		            // 
+		            // NESGraphicSettingsMenuItem
+		            // 
+		            this.NESGraphicSettingsMenuItem.Text = "Graphics Settings...";
+		            this.NESGraphicSettingsMenuItem.Click += new System.EventHandler(this.NesGraphicSettingsMenuItem_Click);
+		            // 
+		            // NESSoundChannelsMenuItem
+		            // 
+		            this.NESSoundChannelsMenuItem.Text = "Sound Channels...";
+		            this.NESSoundChannelsMenuItem.Click += new System.EventHandler(this.NesSoundChannelsMenuItem_Click);
+		            // 
+		            // VSSettingsMenuItem
+		            // 
+		            this.VSSettingsMenuItem.Text = "VS Settings...";
+		            this.VSSettingsMenuItem.Click += new System.EventHandler(this.VsSettingsMenuItem_Click);
+		            // 
+		            // MovieSettingsMenuItem
+		            // 
+		            this.MovieSettingsMenuItem.Text = "Advanced Settings...";
+		            this.MovieSettingsMenuItem.Click += new System.EventHandler(this.MovieSettingsMenuItem_Click);
+		            // 
+		            // FDSControlsMenuItem
+		            // 
+		            this.FDSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.FdsEjectDiskMenuItem});
+		            this.FDSControlsMenuItem.Text = "FDS Controls";
+		            this.FDSControlsMenuItem.DropDownOpened += new System.EventHandler(this.FdsControlsMenuItem_DropDownOpened);
+		            // 
+		            // FdsEjectDiskMenuItem
+		            // 
+		            this.FdsEjectDiskMenuItem.Text = "&Eject Disk";
+		            this.FdsEjectDiskMenuItem.Click += new System.EventHandler(this.FdsEjectDiskMenuItem_Click);
+		            // 
+		            // VSControlsMenuItem
+		            // 
+		            this.VSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.VSInsertCoinP1MenuItem,
+		            this.VSInsertCoinP2MenuItem,
+		            this.VSServiceSwitchMenuItem});
+		            this.VSControlsMenuItem.Text = "VS Controls";
+		            // 
+		            // VSInsertCoinP1MenuItem
+		            // 
+		            this.VSInsertCoinP1MenuItem.Text = "Insert Coin P1";
+		            this.VSInsertCoinP1MenuItem.Click += new System.EventHandler(this.VsInsertCoinP1MenuItem_Click);
+		            // 
+		            // VSInsertCoinP2MenuItem
+		            // 
+		            this.VSInsertCoinP2MenuItem.Text = "Insert Coin P2";
+		            this.VSInsertCoinP2MenuItem.Click += new System.EventHandler(this.VsInsertCoinP2MenuItem_Click);
+		            // 
+		            // VSServiceSwitchMenuItem
+		            // 
+		            this.VSServiceSwitchMenuItem.Text = "Service Switch";
+		            this.VSServiceSwitchMenuItem.Click += new System.EventHandler(this.VsServiceSwitchMenuItem_Click);
+		            // 
+		            // BarcodeReaderMenuItem
+		            // 
+		            this.BarcodeReaderMenuItem.Text = "Barcode Reader";
+		            this.BarcodeReaderMenuItem.Click += new System.EventHandler(this.BarcodeReaderMenuItem_Click);
+		            // 
+		            // TI83SubMenu
+		            // 
+		            this.TI83SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.KeypadMenuItem,
+		            this.LoadTIFileMenuItem,
+		            this.toolStripSeparator13,
+		            this.paletteToolStripMenuItem});
+		            this.TI83SubMenu.Text = "TI83";
+		            // 
+		            // KeypadMenuItem
+		            // 
+		            this.KeypadMenuItem.Text = "Keypad";
+		            this.KeypadMenuItem.Click += new System.EventHandler(this.Ti83KeypadMenuItem_Click);
+		            // 
+		            // LoadTIFileMenuItem
+		            // 
+		            this.LoadTIFileMenuItem.Text = "Load TI-83 File...";
+		            this.LoadTIFileMenuItem.Click += new System.EventHandler(this.Ti83LoadTIFileMenuItem_Click);
+		            // 
+		            // paletteToolStripMenuItem
+		            // 
+		            this.paletteToolStripMenuItem.Text = "Palette...";
+		            this.paletteToolStripMenuItem.Click += new System.EventHandler(this.Ti83PaletteMenuItem_Click);
+		            // 
+		            // A7800SubMenu
+		            // 
+		            this.A7800SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.A7800ControllerSettingsMenuItem,
+		            this.A7800FilterSettingsMenuItem});
+		            this.A7800SubMenu.Text = "&A7800";
+		            this.A7800SubMenu.DropDownOpened += new System.EventHandler(this.A7800SubMenu_DropDownOpened);
+		            // 
+		            // A7800ControllerSettingsMenuItem
+		            // 
+		            this.A7800ControllerSettingsMenuItem.Text = "Controller Settings";
+		            this.A7800ControllerSettingsMenuItem.Click += new System.EventHandler(this.A7800ControllerSettingsMenuItem_Click);
+		            // 
+		            // A7800FilterSettingsMenuItem
+		            // 
+		            this.A7800FilterSettingsMenuItem.Text = "Filter Settings";
+		            this.A7800FilterSettingsMenuItem.Click += new System.EventHandler(this.A7800FilterSettingsMenuItem_Click);
+		            // 
+		            // GBSubMenu
+		            // 
+		            this.GBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.GBcoreSettingsToolStripMenuItem,
+		            this.SameBoyColorChooserMenuItem,
+		            this.toolStripSeparator28,
+		            this.GBGPUViewerMenuItem,
+		            this.GBPrinterViewerMenuItem});
+		            this.GBSubMenu.Text = "&GB";
+		            // 
+		            // GBcoreSettingsToolStripMenuItem
+		            // 
+		            this.GBcoreSettingsToolStripMenuItem.Text = "Settings...";
+		            this.GBcoreSettingsToolStripMenuItem.Click += new System.EventHandler(this.GbCoreSettingsMenuItem_Click);
+		            // 
+		            // SameBoyColorChooserMenuItem
+		            // 
+		            this.SameBoyColorChooserMenuItem.Text = "&Choose Custom Palette...";
+		            this.SameBoyColorChooserMenuItem.Click += new System.EventHandler(this.SameboyColorChooserMenuItem_Click);
+		            // 
+		            // GBGPUViewerMenuItem
+		            // 
+		            this.GBGPUViewerMenuItem.Text = "GPU Viewer";
+		            this.GBGPUViewerMenuItem.Click += new System.EventHandler(this.GbGpuViewerMenuItem_Click);
+		            // 
+		            // GBPrinterViewerMenuItem
+		            // 
+		            this.GBPrinterViewerMenuItem.Text = "&Printer Viewer";
+		            this.GBPrinterViewerMenuItem.Click += new System.EventHandler(this.GbPrinterViewerMenuItem_Click);
+		            // 
+		            // PSXSubMenu
+		            // 
+		            this.PSXSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.PSXControllerSettingsMenuItem,
+		            this.PSXOptionsMenuItem,
+		            this.PSXDiscControlsMenuItem,
+		            this.PSXHashDiscsToolStripMenuItem});
+		            this.PSXSubMenu.Text = "PSX";
+		            this.PSXSubMenu.DropDownOpened += new System.EventHandler(this.PsxSubMenu_DropDownOpened);
+		            // 
+		            // PSXControllerSettingsMenuItem
+		            // 
+		            this.PSXControllerSettingsMenuItem.Text = "Controller / Memcard Settings";
+		            this.PSXControllerSettingsMenuItem.Click += new System.EventHandler(this.PsxControllerSettingsMenuItem_Click);
+		            // 
+		            // PSXOptionsMenuItem
+		            // 
+		            this.PSXOptionsMenuItem.Text = "&Options";
+		            this.PSXOptionsMenuItem.Click += new System.EventHandler(this.PsxOptionsMenuItem_Click);
+		            // 
+		            // PSXDiscControlsMenuItem
+		            // 
+		            this.PSXDiscControlsMenuItem.Text = "&Disc Controls";
+		            this.PSXDiscControlsMenuItem.Click += new System.EventHandler(this.PsxDiscControlsMenuItem_Click);
+		            // 
+		            // PSXHashDiscsToolStripMenuItem
+		            // 
+		            this.PSXHashDiscsToolStripMenuItem.Text = "&Hash Discs";
+		            this.PSXHashDiscsToolStripMenuItem.Click += new System.EventHandler(this.PsxHashDiscsMenuItem_Click);
+		            // 
+		            // SNESSubMenu
+		            // 
+		            this.SNESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.SNESControllerConfigurationMenuItem,
+		            this.toolStripSeparator18,
+		            this.SnesGfxDebuggerMenuItem,
+		            this.SnesOptionsMenuItem});
+		            this.SNESSubMenu.Text = "&SNES";
+		            this.SNESSubMenu.DropDownOpened += new System.EventHandler(this.SnesSubMenu_DropDownOpened);
+		            // 
+		            // SNESControllerConfigurationMenuItem
+		            // 
+		            this.SNESControllerConfigurationMenuItem.Text = "Controller Configuration";
+		            this.SNESControllerConfigurationMenuItem.Click += new System.EventHandler(this.SNESControllerConfigurationMenuItem_Click);
+		            // 
+		            // SnesGfxDebuggerMenuItem
+		            // 
+		            this.SnesGfxDebuggerMenuItem.Text = "Graphics Debugger";
+		            this.SnesGfxDebuggerMenuItem.Click += new System.EventHandler(this.SnesGfxDebuggerMenuItem_Click);
+		            // 
+		            // SnesOptionsMenuItem
+		            // 
+		            this.SnesOptionsMenuItem.Text = "&Options";
+		            this.SnesOptionsMenuItem.Click += new System.EventHandler(this.SnesOptionsMenuItem_Click);
+		            // 
+		            // ColecoSubMenu
+		            // 
+		            this.ColecoSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.ColecoControllerSettingsMenuItem,
+		            this.toolStripSeparator35,
+		            this.ColecoSkipBiosMenuItem,
+		            this.ColecoUseSGMMenuItem});
+		            this.ColecoSubMenu.Text = "&Coleco";
+		            this.ColecoSubMenu.DropDownOpened += new System.EventHandler(this.ColecoSubMenu_DropDownOpened);
+		            // 
+		            // ColecoControllerSettingsMenuItem
+		            // 
+		            this.ColecoControllerSettingsMenuItem.Text = "&Controller Settings...";
+		            this.ColecoControllerSettingsMenuItem.Click += new System.EventHandler(this.ColecoControllerSettingsMenuItem_Click);
+		            // 
+		            // ColecoSkipBiosMenuItem
+		            // 
+		            this.ColecoSkipBiosMenuItem.Text = "&Skip BIOS intro (When Applicable)";
+		            this.ColecoSkipBiosMenuItem.Click += new System.EventHandler(this.ColecoSkipBiosMenuItem_Click);
+		            // 
+		            // ColecoUseSGMMenuItem
+		            // 
+		            this.ColecoUseSGMMenuItem.Text = "&Use the Super Game Module";
+		            this.ColecoUseSGMMenuItem.Click += new System.EventHandler(this.ColecoUseSGMMenuItem_Click);
+		            // 
+		            // N64SubMenu
+		            // 
+		            this.N64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.N64PluginSettingsMenuItem,
+		            this.N64ControllerSettingsMenuItem,
+		            this.toolStripSeparator23,
+		            this.N64CircularAnalogRangeMenuItem,
+		            this.MupenStyleLagMenuItem,
+		            this.N64ExpansionSlotMenuItem});
+		            this.N64SubMenu.Text = "N64";
+		            this.N64SubMenu.DropDownOpened += new System.EventHandler(this.N64SubMenu_DropDownOpened);
+		            // 
+		            // N64PluginSettingsMenuItem
+		            // 
+		            this.N64PluginSettingsMenuItem.Text = "Plugins";
+		            this.N64PluginSettingsMenuItem.Click += new System.EventHandler(this.N64PluginSettingsMenuItem_Click);
+		            // 
+		            // N64ControllerSettingsMenuItem
+		            // 
+		            this.N64ControllerSettingsMenuItem.Text = "Controller Settings...";
+		            this.N64ControllerSettingsMenuItem.Click += new System.EventHandler(this.N64ControllerSettingsMenuItem_Click);
+		            // 
+		            // N64CircularAnalogRangeMenuItem
+		            // 
+		            this.N64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
+		            this.N64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
+		            // 
+		            // MupenStyleLagMenuItem
+		            // 
+		            this.MupenStyleLagMenuItem.Text = "&Mupen Style Lag Frames";
+		            this.MupenStyleLagMenuItem.Click += new System.EventHandler(this.MupenStyleLagMenuItem_Click);
+		            // 
+		            // N64ExpansionSlotMenuItem
+		            // 
+		            this.N64ExpansionSlotMenuItem.Text = "&Use Expansion Slot";
+		            this.N64ExpansionSlotMenuItem.Click += new System.EventHandler(this.N64ExpansionSlotMenuItem_Click);
+		            // 
+		            // Ares64SubMenu
+		            // 
+		            this.Ares64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.Ares64SettingsMenuItem,
+		            this.Ares64CircularAnalogRangeMenuItem});
+		            this.Ares64SubMenu.Text = "N64";
+		            this.Ares64SubMenu.DropDownOpened += new System.EventHandler(this.Ares64SubMenu_DropDownOpened);
+		            // 
+		            // Ares64SettingsMenuItem
+		            // 
+		            this.Ares64SettingsMenuItem.Text = "Settings...";
+		            this.Ares64SettingsMenuItem.Click += new System.EventHandler(this.Ares64SettingsMenuItem_Click);
+		            // 
+		            // Ares64CircularAnalogRangeMenuItem
+		            // 
+		            this.Ares64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
+		            this.Ares64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
+		            // 
+		            // GBLSubMenu
+		            // 
+		            this.GBLSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.GBLsettingsToolStripMenuItem});
+		            this.GBLSubMenu.Text = "&GB Link";
+		            // 
+		            // GBLsettingsToolStripMenuItem
+		            // 
+		            this.GBLsettingsToolStripMenuItem.Text = "Settings...";
+		            this.GBLsettingsToolStripMenuItem.Click += new System.EventHandler(this.GblSettingsMenuItem_Click);
+		            // 
+		            // AppleSubMenu
+		            // 
+		            this.AppleSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.AppleDisksSubMenu,
+		            this.settingsToolStripMenuItem1});
+		            this.AppleSubMenu.Text = "Apple";
+		            this.AppleSubMenu.DropDownOpened += new System.EventHandler(this.AppleSubMenu_DropDownOpened);
+		            // 
+		            // AppleDisksSubMenu
+		            // 
+		            this.AppleDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.toolStripSeparator31});
+		            this.AppleDisksSubMenu.Text = "Disks";
+		            this.AppleDisksSubMenu.DropDownOpened += new System.EventHandler(this.AppleDisksSubMenu_DropDownOpened);
+		            // 
+		            // settingsToolStripMenuItem1
+		            // 
+		            this.settingsToolStripMenuItem1.Text = "&Settings...";
+		            this.settingsToolStripMenuItem1.Click += new System.EventHandler(this.AppleIISettingsMenuItem_Click);
+		            // 
+		            // C64SubMenu
+		            // 
+		            this.C64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.C64DisksSubMenu,
+		            this.C64SettingsMenuItem});
+		            this.C64SubMenu.Text = "&C64";
+		            this.C64SubMenu.DropDownOpened += new System.EventHandler(this.C64SubMenu_DropDownOpened);
+		            // 
+		            // C64DisksSubMenu
+		            // 
+		            this.C64DisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.toolStripSeparator36});
+		            this.C64DisksSubMenu.Text = "Disks";
+		            this.C64DisksSubMenu.DropDownOpened += new System.EventHandler(this.C64DisksSubMenu_DropDownOpened);
+		            // 
+		            // C64SettingsMenuItem
+		            // 
+		            this.C64SettingsMenuItem.Text = "&Settings...";
+		            this.C64SettingsMenuItem.Click += new System.EventHandler(this.C64SettingsMenuItem_Click);
+		            // 
+		            // IntvSubMenu
+		            // 
+		            this.IntvSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.IntVControllerSettingsMenuItem});
+		            this.IntvSubMenu.Text = "&Intv";
+		            this.IntvSubMenu.DropDownOpened += new System.EventHandler(this.IntVSubMenu_DropDownOpened);
+		            // 
+		            // IntVControllerSettingsMenuItem
+		            // 
+		            this.IntVControllerSettingsMenuItem.Text = "Controller Settings...";
+		            this.IntVControllerSettingsMenuItem.Click += new System.EventHandler(this.IntVControllerSettingsMenuItem_Click);
+		            // 
+		            // zXSpectrumToolStripMenuItem
+		            // 
+		            this.zXSpectrumToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.ZXSpectrumCoreEmulationSettingsMenuItem,
+		            this.ZXSpectrumControllerConfigurationMenuItem,
+		            this.ZXSpectrumAudioSettingsMenuItem,
+		            this.ZXSpectrumNonSyncSettingsMenuItem,
+		            this.ZXSpectrumMediaMenuItem});
+		            this.zXSpectrumToolStripMenuItem.Text = "ZX Spectrum";
+		            // 
+		            // ZXSpectrumCoreEmulationSettingsMenuItem
+		            // 
+		            this.ZXSpectrumCoreEmulationSettingsMenuItem.Text = "Core Emulation Settings";
+		            this.ZXSpectrumCoreEmulationSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumCoreEmulationSettingsMenuItem_Click);
+		            // 
+		            // ZXSpectrumControllerConfigurationMenuItem
+		            // 
+		            this.ZXSpectrumControllerConfigurationMenuItem.Text = "Joystick Configuration";
+		            this.ZXSpectrumControllerConfigurationMenuItem.Click += new System.EventHandler(this.ZXSpectrumControllerConfigurationMenuItem_Click);
+		            // 
+		            // ZXSpectrumAudioSettingsMenuItem
+		            // 
+		            this.ZXSpectrumAudioSettingsMenuItem.Text = "Audio Settings";
+		            this.ZXSpectrumAudioSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumAudioSettingsMenuItem_Click);
+		            // 
+		            // ZXSpectrumNonSyncSettingsMenuItem
+		            // 
+		            this.ZXSpectrumNonSyncSettingsMenuItem.Text = "Non-Sync Settings";
+		            this.ZXSpectrumNonSyncSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumNonSyncSettingsMenuItem_Click);
+		            // 
+		            // ZXSpectrumMediaMenuItem
+		            // 
+		            this.ZXSpectrumMediaMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.ZXSpectrumTapesSubMenu,
+		            this.ZXSpectrumDisksSubMenu,
+		            this.ZXSpectrumExportSnapshotMenuItemMenuItem});
+		            this.ZXSpectrumMediaMenuItem.Text = "Media";
+		            this.ZXSpectrumMediaMenuItem.DropDownOpened += new System.EventHandler(this.ZXSpectrumMediaMenuItem_DropDownOpened);
+		            // 
+		            // ZXSpectrumTapesSubMenu
+		            // 
+		            this.ZXSpectrumTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.zxt1ToolStripMenuItem});
+		            this.ZXSpectrumTapesSubMenu.Text = "Tapes";
+		            this.ZXSpectrumTapesSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumTapesSubMenu_DropDownOpened);
+		            // 
+		            // zxt1ToolStripMenuItem
+		            // 
+		            this.zxt1ToolStripMenuItem.Text = "zxt1";
+		            // 
+		            // ZXSpectrumDisksSubMenu
+		            // 
+		            this.ZXSpectrumDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.zxt2ToolStripMenuItem});
+		            this.ZXSpectrumDisksSubMenu.Text = "Disks";
+		            this.ZXSpectrumDisksSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumDisksSubMenu_DropDownOpened);
+		            // 
+		            // zxt2ToolStripMenuItem
+		            // 
+		            this.zxt2ToolStripMenuItem.Text = "zxt2";
+		            // 
+		            // ZXSpectrumExportSnapshotMenuItemMenuItem
+		            // 
+		            this.ZXSpectrumExportSnapshotMenuItemMenuItem.Text = "Export Snapshot";
+		            this.ZXSpectrumExportSnapshotMenuItemMenuItem.Click += new System.EventHandler(this.ZXSpectrumExportSnapshotMenuItemMenuItem_Click);
+		            // 
+		            // GenericCoreSubMenu
+		            // 
+		            this.GenericCoreSubMenu.Text = "&Core";
+		            // 
+		            // amstradCPCToolStripMenuItem
+		            // 
+		            this.amstradCPCToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.amstradCPCCoreEmulationSettingsToolStripMenuItem,
+		            this.AmstradCPCAudioSettingsToolStripMenuItem,
+		            this.AmstradCPCNonSyncSettingsToolStripMenuItem,
+		            this.AmstradCPCMediaToolStripMenuItem});
+		            this.amstradCPCToolStripMenuItem.Text = "Amstrad CPC";
+		            // 
+		            // amstradCPCCoreEmulationSettingsToolStripMenuItem
+		            // 
+		            this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Text = "Core Emulation Settings";
+		            this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcCoreEmulationSettingsMenuItem_Click);
+		            // 
+		            // AmstradCPCAudioSettingsToolStripMenuItem
+		            // 
+		            this.AmstradCPCAudioSettingsToolStripMenuItem.Text = "Audio Settings";
+		            this.AmstradCPCAudioSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcAudioSettingsMenuItem_Click);
+		            // 
+		            // AmstradCPCNonSyncSettingsToolStripMenuItem
+		            // 
+		            this.AmstradCPCNonSyncSettingsToolStripMenuItem.Text = "Non-Sync Settings";
+		            this.AmstradCPCNonSyncSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcNonSyncSettingsMenuItem_Click);
+		            // 
+		            // AmstradCPCMediaToolStripMenuItem
+		            // 
+		            this.AmstradCPCMediaToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.AmstradCPCTapesSubMenu,
+		            this.AmstradCPCDisksSubMenu});
+		            this.AmstradCPCMediaToolStripMenuItem.Text = "Media";
+		            this.AmstradCPCMediaToolStripMenuItem.DropDownOpened += new System.EventHandler(this.AmstradCpcMediaMenuItem_DropDownOpened);
+		            // 
+		            // AmstradCPCTapesSubMenu
+		            // 
+		            this.AmstradCPCTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.cpct1ToolStripMenuItem});
+		            this.AmstradCPCTapesSubMenu.Text = "Tapes";
+		            this.AmstradCPCTapesSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcTapesSubMenu_DropDownOpened);
+		            // 
+		            // cpct1ToolStripMenuItem
+		            // 
+		            this.cpct1ToolStripMenuItem.Text = "cpct1";
+		            // 
+		            // AmstradCPCDisksSubMenu
+		            // 
+		            this.AmstradCPCDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.cpcd1ToolStripMenuItem});
+		            this.AmstradCPCDisksSubMenu.Text = "Disks";
+		            this.AmstradCPCDisksSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcDisksSubMenu_DropDownOpened);
+		            // 
+		            // cpcd1ToolStripMenuItem
+		            // 
+		            this.cpcd1ToolStripMenuItem.Text = "cpcd1";
+		            // 
+		            // HelpSubMenu
+		            // 
+		            this.HelpSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.OnlineHelpMenuItem,
+		            this.ForumsMenuItem,
+		            this.FeaturesMenuItem,
+		            this.AboutMenuItem});
+		            this.HelpSubMenu.Text = "&Help";
+		            this.HelpSubMenu.DropDownOpened += new System.EventHandler(this.HelpSubMenu_DropDownOpened);
+		            // 
+		            // OnlineHelpMenuItem
+		            // 
+		            this.OnlineHelpMenuItem.Text = "Open TASVideos Wiki in Browser";
+		            this.OnlineHelpMenuItem.Click += new System.EventHandler(this.OnlineHelpMenuItem_Click);
+		            // 
+		            // ForumsMenuItem
+		            // 
+		            this.ForumsMenuItem.Text = "Open Forums in Browser";
+		            this.ForumsMenuItem.Click += new System.EventHandler(this.ForumsMenuItem_Click);
+		            // 
+		            // FeaturesMenuItem
+		            // 
+		            this.FeaturesMenuItem.Text = "&Features";
+		            this.FeaturesMenuItem.Click += new System.EventHandler(this.FeaturesMenuItem_Click);
+		            // 
+		            // AboutMenuItem
+		            // 
+		            this.AboutMenuItem.Text = "&About...";
+		            this.AboutMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
+		            // 
+		            // A7800HawkCoreMenuItem
+		            // 
+		            this.A7800HawkCoreMenuItem.Text = "A7800Hawk";
+		            // 
+		            // MainStatusBar
+		            // 
+		            this.MainStatusBar.ImageScalingSize = new System.Drawing.Size(20, 20);
+		            this.MainStatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.DumpStatusButton,
+		            this.EmuStatus,
+		            this.PlayRecordStatusButton,
+		            this.PauseStatusButton,
+		            this.RebootStatusBarIcon,
+		            this.AVIStatusLabel,
+		            this.LedLightStatusLabel,
+		            this.SaveSlotsStatusLabel,
+		            this.Slot1StatusButton,
+		            this.Slot2StatusButton,
+		            this.Slot3StatusButton,
+		            this.Slot4StatusButton,
+		            this.Slot5StatusButton,
+		            this.Slot6StatusButton,
+		            this.Slot7StatusButton,
+		            this.Slot8StatusButton,
+		            this.Slot9StatusButton,
+		            this.Slot0StatusButton,
+		            this.CheatStatusButton,
+		            this.KeyPriorityStatusLabel,
+		            this.CoreNameStatusBarButton,
+		            this.ProfileFirstBootLabel,
+		            this.LinkConnectStatusBarButton,
+		            this.UpdateNotification});
+		            this.MainStatusBar.Location = new System.Drawing.Point(0, 382);
+		            this.MainStatusBar.Name = "MainStatusBar";
+		            this.MainStatusBar.ShowItemToolTips = true;
+		            this.MainStatusBar.SizingGrip = false;
+		            this.MainStatusBar.TabIndex = 1;
+		            // 
+		            // DumpStatusButton
+		            // 
+		            this.DumpStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+		            this.DumpStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+		            this.DumpStatusButton.Name = "DumpStatusButton";
+		            this.DumpStatusButton.ShowDropDownArrow = false;
+		            this.DumpStatusButton.Size = new System.Drawing.Size(4, 24);
+		            this.DumpStatusButton.Text = "No ROM loaded";
+		            this.DumpStatusButton.Click += new System.EventHandler(this.DumpStatusButton_Click);
+		            // 
+		            // PlayRecordStatusButton
+		            // 
+		            this.PlayRecordStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+		            this.PlayRecordStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+		            this.PlayRecordStatusButton.Name = "PlayRecordStatusButton";
+		            this.PlayRecordStatusButton.ShowDropDownArrow = false;
+		            this.PlayRecordStatusButton.Size = new System.Drawing.Size(4, 24);
+		            this.PlayRecordStatusButton.Text = "No movie is active";
+		            // 
+		            // PauseStatusButton
+		            // 
+		            this.PauseStatusButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+		            this.PauseStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+		            this.PauseStatusButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+		            this.PauseStatusButton.Name = "PauseStatusButton";
+		            this.PauseStatusButton.ShowDropDownArrow = false;
+		            this.PauseStatusButton.Size = new System.Drawing.Size(4, 24);
+		            this.PauseStatusButton.Text = "toolStripDropDownButton1";
+		            this.PauseStatusButton.ToolTipText = "Emulator is paused";
+		            this.PauseStatusButton.Click += new System.EventHandler(this.PauseMenuItem_Click);
+		            // 
+		            // RebootStatusBarIcon
+		            // 
+		            this.RebootStatusBarIcon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+		            this.RebootStatusBarIcon.RightToLeft = System.Windows.Forms.RightToLeft.No;
+		            this.RebootStatusBarIcon.Text = "Reboot";
+		            this.RebootStatusBarIcon.ToolTipText = "A reboot of the core is needed for a setting change to take effect";
+		            this.RebootStatusBarIcon.Click += new System.EventHandler(this.PowerMenuItem_Click);
+		            // 
+		            // AVIStatusLabel
+		            // 
+		            this.AVIStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+		            this.AVIStatusLabel.Text = "AVI Capture";
+		            // 
+		            // LedLightStatusLabel
+		            // 
+		            this.LedLightStatusLabel.ToolTipText = "Disk Drive LED Light";
+		            // 
+		            // SaveSlotsStatusLabel
+		            // 
+		            this.SaveSlotsStatusLabel.BackColor = System.Drawing.SystemColors.Control;
+		            this.SaveSlotsStatusLabel.Text = "Save slots";
+		            // 
+		            // Slot1StatusButton
+		            // 
+		            this.Slot1StatusButton.Text = "1";
+		            this.Slot1StatusButton.ToolTipText = "Save slot 1";
+		            this.Slot1StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+		            // 
+		            // Slot2StatusButton
+		            // 
+		            this.Slot2StatusButton.Text = "2";
+		            this.Slot2StatusButton.ToolTipText = "Save slot 2";
+		            this.Slot2StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+		            // 
+		            // Slot3StatusButton
+		            // 
+		            this.Slot3StatusButton.Text = "3";
+		            this.Slot3StatusButton.ToolTipText = "Save slot 3";
+		            this.Slot3StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+		            // 
+		            // Slot4StatusButton
+		            // 
+		            this.Slot4StatusButton.Text = "4";
+		            this.Slot4StatusButton.ToolTipText = "Save slot 4";
+		            this.Slot4StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+		            // 
+		            // Slot5StatusButton
+		            // 
+		            this.Slot5StatusButton.Text = "5";
+		            this.Slot5StatusButton.ToolTipText = "Save slot 5";
+		            this.Slot5StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+		            // 
+		            // Slot6StatusButton
+		            // 
+		            this.Slot6StatusButton.Text = "6";
+		            this.Slot6StatusButton.ToolTipText = "Save slot 6";
+		            this.Slot6StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+		            // 
+		            // Slot7StatusButton
+		            // 
+		            this.Slot7StatusButton.Text = "7";
+		            this.Slot7StatusButton.ToolTipText = "Save slot 7";
+		            this.Slot7StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+		            // 
+		            // Slot8StatusButton
+		            // 
+		            this.Slot8StatusButton.Text = "8";
+		            this.Slot8StatusButton.ToolTipText = "Save slot 8";
+		            this.Slot8StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+		            // 
+		            // Slot9StatusButton
+		            // 
+		            this.Slot9StatusButton.Text = "9";
+		            this.Slot9StatusButton.ToolTipText = "Save slot 9";
+		            this.Slot9StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+		            // 
+		            // Slot0StatusButton
+		            // 
+		            this.Slot0StatusButton.Text = "0";
+		            this.Slot0StatusButton.ToolTipText = "Save slot 10";
+		            this.Slot0StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
+		            // 
+		            // CheatStatusButton
+		            // 
+		            this.CheatStatusButton.Click += new System.EventHandler(this.FreezeStatus_Click);
+		            // 
+		            // KeyPriorityStatusLabel
+		            // 
+		            this.KeyPriorityStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+		            this.KeyPriorityStatusLabel.Margin = new System.Windows.Forms.Padding(5, 3, 5, 0);
+		            this.KeyPriorityStatusLabel.Text = "KeyPriority";
+		            this.KeyPriorityStatusLabel.Click += new System.EventHandler(this.KeyPriorityStatusLabel_Click);
+		            // 
+		            // CoreNameStatusBarButton
+		            // 
+		            this.CoreNameStatusBarButton.Text = "<core name>";
+		            // 
+		            // ProfileFirstBootLabel
+		            // 
+		            this.ProfileFirstBootLabel.AutoToolTip = true;
+		            this.ProfileFirstBootLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+		            this.ProfileFirstBootLabel.Text = "ProfileFirstBootLabel";
+		            this.ProfileFirstBootLabel.ToolTipText = "Set up your profile before use";
+		            this.ProfileFirstBootLabel.Visible = false;
+		            this.ProfileFirstBootLabel.Click += new System.EventHandler(this.ProfileFirstBootLabel_Click);
+		            // 
+		            // LinkConnectStatusBarButton
+		            // 
+		            this.LinkConnectStatusBarButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+		            this.LinkConnectStatusBarButton.Text = "Link connection is currently enabled";
+		            this.LinkConnectStatusBarButton.ToolTipText = "Link connection is currently enabled";
+		            this.LinkConnectStatusBarButton.Click += new System.EventHandler(this.LinkConnectStatusBarButton_Click);
+		            // 
+		            // UpdateNotification
+		            // 
+		            this.UpdateNotification.IsLink = true;
+		            this.UpdateNotification.LinkColor = System.Drawing.Color.Red;
+		            this.UpdateNotification.Spring = true;
+		            this.UpdateNotification.Text = "New version available!";
+		            this.UpdateNotification.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+		            this.UpdateNotification.Click += new System.EventHandler(this.UpdateNotification_Click);
+		            // 
+		            // MainFormContextMenu
+		            // 
+		            this.MainFormContextMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
+		            this.MainFormContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.OpenRomContextMenuItem,
+		            this.LoadLastRomContextMenuItem,
+		            this.StopAVContextMenuItem,
+		            this.ContextSeparator_AfterROM,
+		            this.RecordMovieContextMenuItem,
+		            this.PlayMovieContextMenuItem,
+		            this.RestartMovieContextMenuItem,
+		            this.StopMovieContextMenuItem,
+		            this.LoadLastMovieContextMenuItem,
+		            this.BackupMovieContextMenuItem,
+		            this.StopNoSaveContextMenuItem,
+		            this.ViewSubtitlesContextMenuItem,
+		            this.AddSubtitleContextMenuItem,
+		            this.ViewCommentsContextMenuItem,
+		            this.SaveMovieContextMenuItem,
+		            this.SaveMovieAsContextMenuItem,
+		            this.ContextSeparator_AfterMovie,
+		            this.UndoSavestateContextMenuItem,
+		            this.ContextSeparator_AfterUndo,
+		            this.ConfigContextMenuItem,
+		            this.ScreenshotContextMenuItem,
+		            this.CloseRomContextMenuItem,
+		            this.ClearSRAMContextMenuItem,
+		            this.ShowMenuContextMenuSeparator,
+		            this.ShowMenuContextMenuItem});
+		            this.MainFormContextMenu.Name = "contextMenuStrip1";
+		            this.MainFormContextMenu.Size = new System.Drawing.Size(257, 532);
+		            this.MainFormContextMenu.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.MainFormContextMenu_Closing);
+		            this.MainFormContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.MainFormContextMenu_Opening);
+		            // 
+		            // OpenRomContextMenuItem
+		            // 
+		            this.OpenRomContextMenuItem.Text = "Open Rom";
+		            this.OpenRomContextMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
+		            // 
+		            // LoadLastRomContextMenuItem
+		            // 
+		            this.LoadLastRomContextMenuItem.Text = "Load Last ROM";
+		            this.LoadLastRomContextMenuItem.Click += new System.EventHandler(this.LoadLastRomContextMenuItem_Click);
+		            // 
+		            // StopAVContextMenuItem
+		            // 
+		            this.StopAVContextMenuItem.Text = "Stop AVI/WAV";
+		            this.StopAVContextMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
+		            // 
+		            // RecordMovieContextMenuItem
+		            // 
+		            this.RecordMovieContextMenuItem.Text = "Record Movie";
+		            this.RecordMovieContextMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
+		            // 
+		            // PlayMovieContextMenuItem
+		            // 
+		            this.PlayMovieContextMenuItem.Text = "Play Movie";
+		            this.PlayMovieContextMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
+		            // 
+		            // RestartMovieContextMenuItem
+		            // 
+		            this.RestartMovieContextMenuItem.Text = "Restart Movie";
+		            this.RestartMovieContextMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
+		            // 
+		            // StopMovieContextMenuItem
+		            // 
+		            this.StopMovieContextMenuItem.Text = "Stop Movie";
+		            this.StopMovieContextMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
+		            // 
+		            // LoadLastMovieContextMenuItem
+		            // 
+		            this.LoadLastMovieContextMenuItem.Text = "Load Last Movie";
+		            this.LoadLastMovieContextMenuItem.Click += new System.EventHandler(this.LoadLastMovieContextMenuItem_Click);
+		            // 
+		            // BackupMovieContextMenuItem
+		            // 
+		            this.BackupMovieContextMenuItem.Text = "Backup Movie";
+		            this.BackupMovieContextMenuItem.Click += new System.EventHandler(this.BackupMovieContextMenuItem_Click);
+		            // 
+		            // StopNoSaveContextMenuItem
+		            // 
+		            this.StopNoSaveContextMenuItem.Text = "Stop Movie without Saving";
+		            this.StopNoSaveContextMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
+		            // 
+		            // ViewSubtitlesContextMenuItem
+		            // 
+		            this.ViewSubtitlesContextMenuItem.Text = "View Subtitles";
+		            this.ViewSubtitlesContextMenuItem.Click += new System.EventHandler(this.ViewSubtitlesContextMenuItem_Click);
+		            // 
+		            // AddSubtitleContextMenuItem
+		            // 
+		            this.AddSubtitleContextMenuItem.Text = "Add Subtitle";
+		            this.AddSubtitleContextMenuItem.Click += new System.EventHandler(this.AddSubtitleContextMenuItem_Click);
+		            // 
+		            // ViewCommentsContextMenuItem
+		            // 
+		            this.ViewCommentsContextMenuItem.Text = "View Comments";
+		            this.ViewCommentsContextMenuItem.Click += new System.EventHandler(this.ViewCommentsContextMenuItem_Click);
+		            // 
+		            // SaveMovieContextMenuItem
+		            // 
+		            this.SaveMovieContextMenuItem.Text = "Save Movie";
+		            this.SaveMovieContextMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
+		            // 
+		            // SaveMovieAsContextMenuItem
+		            // 
+		            this.SaveMovieAsContextMenuItem.Text = "Save Movie As...";
+		            this.SaveMovieAsContextMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
+		            // 
+		            // UndoSavestateContextMenuItem
+		            // 
+		            this.UndoSavestateContextMenuItem.Text = "Undo Savestate";
+		            this.UndoSavestateContextMenuItem.Click += new System.EventHandler(this.UndoSavestateContextMenuItem_Click);
+		            // 
+		            // ConfigContextMenuItem
+		            // 
+		            this.ConfigContextMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+		            this.toolStripMenuItem6,
+		            this.toolStripMenuItem7,
+		            this.toolStripMenuItem8,
+		            this.toolStripMenuItem9,
+		            this.toolStripMenuItem10,
+		            this.toolStripMenuItem11,
+		            this.toolStripMenuItem12,
+		            this.toolStripMenuItem13,
+		            this.toolStripMenuItem14,
+		            this.toolStripMenuItem15,
+		            this.customizeToolStripMenuItem,
+		            this.toolStripSeparator30,
+		            this.toolStripMenuItem66,
+		            this.toolStripMenuItem67});
+		            this.ConfigContextMenuItem.Text = "Config";
+		            // 
+		            // toolStripMenuItem6
+		            // 
+		            this.toolStripMenuItem6.Text = "&Controllers...";
+		            this.toolStripMenuItem6.Click += new System.EventHandler(this.ControllersMenuItem_Click);
+		            // 
+		            // toolStripMenuItem7
+		            // 
+		            this.toolStripMenuItem7.Text = "&Hotkeys...";
+		            this.toolStripMenuItem7.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
+		            // 
+		            // toolStripMenuItem8
+		            // 
+		            this.toolStripMenuItem8.Text = "Display...";
+		            this.toolStripMenuItem8.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
+		            // 
+		            // toolStripMenuItem9
+		            // 
+		            this.toolStripMenuItem9.Text = "&Sound...";
+		            this.toolStripMenuItem9.Click += new System.EventHandler(this.SoundMenuItem_Click);
+		            // 
+		            // toolStripMenuItem10
+		            // 
+		            this.toolStripMenuItem10.Text = "Paths...";
+		            this.toolStripMenuItem10.Click += new System.EventHandler(this.PathsMenuItem_Click);
+		            // 
+		            // toolStripMenuItem11
+		            // 
+		            this.toolStripMenuItem11.Text = "&Firmwares...";
+		            this.toolStripMenuItem11.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
+		            // 
+		            // toolStripMenuItem12
+		            // 
+		            this.toolStripMenuItem12.Text = "&Messages...";
+		            this.toolStripMenuItem12.Click += new System.EventHandler(this.MessagesMenuItem_Click);
+		            // 
+		            // toolStripMenuItem13
+		            // 
+		            this.toolStripMenuItem13.Text = "&Autofire...";
+		            this.toolStripMenuItem13.Click += new System.EventHandler(this.AutofireMenuItem_Click);
+		            // 
+		            // toolStripMenuItem14
+		            // 
+		            this.toolStripMenuItem14.Text = "&Rewind...";
+		            this.toolStripMenuItem14.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
+		            // 
+		            // toolStripMenuItem15
+		            // 
+		            this.toolStripMenuItem15.Text = "File Extensions...";
+		            this.toolStripMenuItem15.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
+		            // 
+		            // customizeToolStripMenuItem
+		            // 
+		            this.customizeToolStripMenuItem.Text = "Customize...";
+		            this.customizeToolStripMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
+		            // 
+		            // toolStripMenuItem66
+		            // 
+		            this.toolStripMenuItem66.Text = "Save Config";
+		            this.toolStripMenuItem66.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
+		            // 
+		            // toolStripMenuItem67
+		            // 
+		            this.toolStripMenuItem67.Text = "Load Config";
+		            this.toolStripMenuItem67.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
+		            // 
+		            // ScreenshotContextMenuItem
+		            // 
+		            this.ScreenshotContextMenuItem.Text = "Screenshot";
+		            this.ScreenshotContextMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
+		            // 
+		            // CloseRomContextMenuItem
+		            // 
+		            this.CloseRomContextMenuItem.Text = "Close ROM";
+		            this.CloseRomContextMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
+		            // 
+		            // ClearSRAMContextMenuItem
+		            // 
+		            this.ClearSRAMContextMenuItem.Text = "Close and Clear SRAM";
+		            this.ClearSRAMContextMenuItem.Click += new System.EventHandler(this.ClearSramContextMenuItem_Click);
+		            // 
+		            // ShowMenuContextMenuItem
+		            // 
+		            this.ShowMenuContextMenuItem.Text = "Show Menu";
+		            this.ShowMenuContextMenuItem.Click += new System.EventHandler(this.ShowMenuContextMenuItem_Click);
+		            // 
+		            // timerMouseIdle
+		            // 
+		            this.timerMouseIdle.Enabled = true;
+		            this.timerMouseIdle.Interval = 2000;
+		            this.timerMouseIdle.Tick += new System.EventHandler(this.TimerMouseIdle_Tick);
+		            // 
+		            // MainForm
+		            // 
+		            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+		            this.ClientSize = new System.Drawing.Size(470, 408);
+		            this.Controls.Add(this.MainStatusBar);
+		            this.Controls.Add(this.MainformMenu);
+		            this.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+		            this.MainMenuStrip = this.MainformMenu;
+		            this.Name = "MainForm";
+		            this.Activated += new System.EventHandler(this.MainForm_Activated);
+		            this.Deactivate += new System.EventHandler(this.MainForm_Deactivate);
+		            this.Load += new System.EventHandler(this.MainForm_Load);
+		            this.Shown += new System.EventHandler(this.MainForm_Shown);
+		            this.Enter += new System.EventHandler(this.MainForm_Enter);
+		            this.Resize += new System.EventHandler(this.MainForm_Resize);
+		            this.MainformMenu.ResumeLayout(false);
+		            this.MainformMenu.PerformLayout();
+		            this.MainStatusBar.ResumeLayout(false);
+		            this.MainStatusBar.PerformLayout();
+		            this.MainFormContextMenu.ResumeLayout(false);
+		            this.ResumeLayout(false);
+		            this.PerformLayout();
 
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -123,16 +123,6 @@ namespace BizHawk.Client.EmuHawk
 			this.LoadedCoreNameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ViewSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.WindowSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.x9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.mzMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SwitchToFullscreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DisplayFPSMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -987,69 +977,8 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// WindowSizeSubMenu
 			// 
-			this.WindowSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.x1MenuItem,
-			this.x2MenuItem,
-			this.x3MenuItem,
-			this.x4MenuItem,
-			this.x5MenuItem,
-			this.x6MenuItem,
-			this.x7MenuItem,
-			this.x8MenuItem,
-			this.x9MenuItem,
-			this.mzMenuItem});
 			this.WindowSizeSubMenu.Text = "&Window Size";
 			this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
-			// 
-			// x1MenuItem
-			// 
-			this.x1MenuItem.Text = "&1x";
-			this.x1MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x2MenuItem
-			// 
-			this.x2MenuItem.Text = "&2x";
-			this.x2MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x3MenuItem
-			// 
-			this.x3MenuItem.Text = "&3x";
-			this.x3MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x4MenuItem
-			// 
-			this.x4MenuItem.Text = "&4x";
-			this.x4MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x5MenuItem
-			// 
-			this.x5MenuItem.Text = "&5x";
-			this.x5MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x6MenuItem
-			// 
-			this.x6MenuItem.Text = "&6x";
-			this.x6MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x7MenuItem
-			// 
-			this.x7MenuItem.Text = "&7x";
-			this.x7MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x8MenuItem
-			// 
-			this.x8MenuItem.Text = "&8x";
-			this.x8MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// x9MenuItem
-			// 
-			this.x9MenuItem.Text = "&9x";
-			this.x9MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
-			// 
-			// mzMenuItem
-			// 
-			this.mzMenuItem.Text = "1&0x";
-			this.mzMenuItem.Click += new System.EventHandler(this.WindowSize_Click);
 			// 
 			// SwitchToFullscreenMenuItem
 			// 
@@ -2554,16 +2483,6 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveNamedStateMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator7;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadNamedStateMenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x1MenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x2MenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x3MenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x4MenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x5MenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x6MenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x7MenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x8MenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x9MenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx mzMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MovieSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentMovieSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecordMovieMenuItem;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -690,67 +690,36 @@ namespace BizHawk.Client.EmuHawk
 			DisplayMessagesMenuItem.Checked = Config.DisplayMessages;
 		}
 
+		private IReadOnlyCollection<ToolStripItem> CreateWindowSizeFactorSubmenus(int max_factor)
+		{
+			List<ToolStripItem> items = new();
+			for (int i = 1; i <= max_factor; i++)
+			{
+				var temp = new ToolStripMenuItemEx()
+				{
+					Tag = i,
+					Text = $"{i / 10}&{i % 10}x"
+				};
+				temp.Click += new System.EventHandler(this.WindowSize_Click);
+				items.Add(temp);
+			}
+			return items;
+		}
+
 		private void WindowSizeSubMenu_DropDownOpened(object sender, EventArgs e)
 		{
-			x1MenuItem.Checked =
-				x2MenuItem.Checked =
-				x3MenuItem.Checked =
-				x4MenuItem.Checked =
-				x5MenuItem.Checked =
-				x6MenuItem.Checked =
-				x7MenuItem.Checked =
-				x8MenuItem.Checked =
-				x9MenuItem.Checked =
-				mzMenuItem.Checked = false;
-
-			switch (Config.TargetZoomFactors[Emulator.SystemId])
+			foreach (ToolStripMenuItemEx item in WindowSizeSubMenu.DropDownItems)
 			{
-				case 1:
-					x1MenuItem.Checked = true;
-					break;
-				case 2:
-					x2MenuItem.Checked = true;
-					break;
-				case 3:
-					x3MenuItem.Checked = true;
-					break;
-				case 4:
-					x4MenuItem.Checked = true;
-					break;
-				case 5:
-					x5MenuItem.Checked = true;
-					break;
-				case 6:
-					x6MenuItem.Checked = true;
-					break;
-				case 7:
-					x7MenuItem.Checked = true;
-					break;
-				case 8:
-					x8MenuItem.Checked = true;
-					break;
-				case 9:
-					x9MenuItem.Checked = true;
-					break;
-				case 10:
-					mzMenuItem.Checked = true;
-					break;
+				item.Checked = Config.TargetZoomFactors[Emulator.SystemId] == (int) item.Tag;
 			}
 		}
 
 		private void WindowSize_Click(object sender, EventArgs e)
 		{
-			if (sender == x1MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 1;
-			if (sender == x2MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 2;
-			if (sender == x3MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 3;
-			if (sender == x4MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 4;
-			if (sender == x5MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 5;
-			if (sender == x6MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 6;
-			if (sender == x7MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 7;
-			if (sender == x8MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 8;
-			if (sender == x9MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 9;
-			if (sender == mzMenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 10;
-
+			foreach (ToolStripMenuItemEx item in WindowSizeSubMenu.DropDownItems)
+			{
+				if (sender == item) Config.TargetZoomFactors[Emulator.SystemId] = (int) item.Tag;
+			}
 			FrameBufferResized();
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -690,22 +690,6 @@ namespace BizHawk.Client.EmuHawk
 			DisplayMessagesMenuItem.Checked = Config.DisplayMessages;
 		}
 
-		private IReadOnlyCollection<ToolStripItem> CreateWindowSizeFactorSubmenus(int max_factor)
-		{
-			List<ToolStripItem> items = new();
-			for (int i = 1; i <= max_factor; i++)
-			{
-				var temp = new ToolStripMenuItemEx()
-				{
-					Tag = i,
-					Text = $"{i / 10}&{i % 10}x"
-				};
-				temp.Click += new System.EventHandler(this.WindowSize_Click);
-				items.Add(temp);
-			}
-			return items;
-		}
-
 		private void WindowSizeSubMenu_DropDownOpened(object sender, EventArgs e)
 		{
 			foreach (ToolStripMenuItemEx item in WindowSizeSubMenu.DropDownItems)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -696,7 +696,11 @@ namespace BizHawk.Client.EmuHawk
 				x2MenuItem.Checked =
 				x3MenuItem.Checked =
 				x4MenuItem.Checked =
-				x5MenuItem.Checked = 
+				x5MenuItem.Checked =
+				x6MenuItem.Checked =
+				x7MenuItem.Checked =
+				x8MenuItem.Checked =
+				x9MenuItem.Checked =
 				mzMenuItem.Checked = false;
 
 			switch (Config.TargetZoomFactors[Emulator.SystemId])
@@ -716,6 +720,18 @@ namespace BizHawk.Client.EmuHawk
 				case 5:
 					x5MenuItem.Checked = true;
 					break;
+				case 6:
+					x6MenuItem.Checked = true;
+					break;
+				case 7:
+					x7MenuItem.Checked = true;
+					break;
+				case 8:
+					x8MenuItem.Checked = true;
+					break;
+				case 9:
+					x9MenuItem.Checked = true;
+					break;
 				case 10:
 					mzMenuItem.Checked = true;
 					break;
@@ -729,6 +745,10 @@ namespace BizHawk.Client.EmuHawk
 			if (sender == x3MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 3;
 			if (sender == x4MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 4;
 			if (sender == x5MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 5;
+			if (sender == x6MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 6;
+			if (sender == x7MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 7;
+			if (sender == x8MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 8;
+			if (sender == x9MenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 9;
 			if (sender == mzMenuItem) Config.TargetZoomFactors[Emulator.SystemId] = 10;
 
 			FrameBufferResized();

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -692,7 +692,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void WindowSizeSubMenu_DropDownOpened(object sender, EventArgs e)
 		{
-			foreach (ToolStripMenuItemEx item in WindowSizeSubMenu.DropDownItems)
+			foreach (ToolStripMenuItem item in WindowSizeSubMenu.DropDownItems)
 			{
 				item.Checked = Config.TargetZoomFactors[Emulator.SystemId] == (int) item.Tag;
 			}
@@ -700,10 +700,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void WindowSize_Click(object sender, EventArgs e)
 		{
-			foreach (ToolStripMenuItemEx item in WindowSizeSubMenu.DropDownItems)
-			{
-				if (sender == item) Config.TargetZoomFactors[Emulator.SystemId] = (int) item.Tag;
-			}
+			Config.TargetZoomFactors[Emulator.SystemId] = (int) ((Control)sender).Tag;
 			FrameBufferResized();
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -700,7 +700,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void WindowSize_Click(object sender, EventArgs e)
 		{
-			Config.TargetZoomFactors[Emulator.SystemId] = (int) ((Control)sender).Tag;
+			Config.TargetZoomFactors[Emulator.SystemId] = (int) ((ToolStripMenuItem) sender).Tag;
 			FrameBufferResized();
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2751,8 +2751,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void IncreaseWindowSize()
 		{
-			object max_factor = WindowSizeSubMenu.DropDownItems[WindowSizeSubMenu.DropDownItems.Count - 1].Tag;
-			if (Config.TargetZoomFactors[Emulator.SystemId] < (int) max_factor)
+			if (Config.TargetZoomFactors[Emulator.SystemId] < 10)
 			{
 				Config.TargetZoomFactors[Emulator.SystemId]++;
 			}
@@ -2762,8 +2761,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void DecreaseWindowSize()
 		{
-			object min_factor = WindowSizeSubMenu.DropDownItems[1].Tag;
-			if (Config.TargetZoomFactors[Emulator.SystemId] > (int) min_factor)
+			if (Config.TargetZoomFactors[Emulator.SystemId] > 1)
 			{
 				Config.TargetZoomFactors[Emulator.SystemId]--;
 			}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -62,14 +62,16 @@ namespace BizHawk.Client.EmuHawk
 			AppendAllFilesEntry = false,
 		};
 
-		private void MainForm_Load(object sender, EventArgs e)
-		{
-			UpdateWindowTitle();
+		private const int WINDOW_SCALE_MAX = 10;
 
-			ToolStripItem[] CreateWindowSizeFactorSubmenus(int max_factor)
+		private void MainForm_Load(object sender, EventArgs e)
+		{	
+			UpdateWindowTitle();
+			
+			ToolStripItem[] CreateWindowSizeFactorSubmenus()
 			{
-				var items = new ToolStripItem[max_factor];
-				for (int i = 1; i <= max_factor; i++)
+				var items = new ToolStripItem[WINDOW_SCALE_MAX];
+				for (int i = 1; i <= WINDOW_SCALE_MAX; i++)
 				{
 					long quotient = Math.DivRem(i, 10, out long remainder);
 					var temp = new ToolStripMenuItemEx
@@ -82,7 +84,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 				return items;
 			}
-			WindowSizeSubMenu.DropDownItems.AddRange(CreateWindowSizeFactorSubmenus(max_factor: 10));
+			WindowSizeSubMenu.DropDownItems.AddRange(CreateWindowSizeFactorSubmenus());
 
 			foreach (var (groupLabel, appliesTo, coreNames) in Config.CorePickerUIData.Select(static tuple => (GroupLabel: tuple.AppliesTo[0], tuple.AppliesTo, tuple.CoreNames))
 				.OrderBy(static tuple => tuple.GroupLabel))
@@ -2751,7 +2753,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void IncreaseWindowSize()
 		{
-			if (Config.TargetZoomFactors[Emulator.SystemId] < 10)
+			if (Config.TargetZoomFactors[Emulator.SystemId] < WINDOW_SCALE_MAX)
 			{
 				Config.TargetZoomFactors[Emulator.SystemId]++;
 			}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -66,7 +66,23 @@ namespace BizHawk.Client.EmuHawk
 		{
 			UpdateWindowTitle();
 
-			WindowSizeSubMenu.DropDownItems.AddRange(CreateWindowSizeFactorSubmenus(max_factor: 10).ToArray());
+			ToolStripItem[] CreateWindowSizeFactorSubmenus(int max_factor)
+			{
+				var items = new ToolStripItem[max_factor];
+				for (int i = 1; i <= max_factor; i++)
+				{
+					long quotient = Math.DivRem(i, 10, out long remainder);
+					var temp = new ToolStripMenuItemEx
+					{
+						Tag = i,
+						Text = $"{(quotient > 0 ? quotient : "")}&{remainder}x"
+					};
+					temp.Click += this.WindowSize_Click;
+					items[i - 1] = temp;
+				}
+				return items;
+			}
+			WindowSizeSubMenu.DropDownItems.AddRange(CreateWindowSizeFactorSubmenus(max_factor: 10));
 
 			foreach (var (groupLabel, appliesTo, coreNames) in Config.CorePickerUIData.Select(static tuple => (GroupLabel: tuple.AppliesTo[0], tuple.AppliesTo, tuple.CoreNames))
 				.OrderBy(static tuple => tuple.GroupLabel))

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -66,6 +66,8 @@ namespace BizHawk.Client.EmuHawk
 		{
 			UpdateWindowTitle();
 
+			WindowSizeSubMenu.DropDownItems.AddRange(CreateWindowSizeFactorSubmenus(max_factor: 10).ToArray());
+
 			foreach (var (groupLabel, appliesTo, coreNames) in Config.CorePickerUIData.Select(static tuple => (GroupLabel: tuple.AppliesTo[0], tuple.AppliesTo, tuple.CoreNames))
 				.OrderBy(static tuple => tuple.GroupLabel))
 			{
@@ -2733,78 +2735,22 @@ namespace BizHawk.Client.EmuHawk
 
 		private void IncreaseWindowSize()
 		{
-			switch (Config.TargetZoomFactors[Emulator.SystemId])
+			object max_factor = WindowSizeSubMenu.DropDownItems[WindowSizeSubMenu.DropDownItems.Count - 1].Tag;
+			if (Config.TargetZoomFactors[Emulator.SystemId] < (int) max_factor)
 			{
-				case 1:
-					Config.TargetZoomFactors[Emulator.SystemId] = 2;
-					break;
-				case 2:
-					Config.TargetZoomFactors[Emulator.SystemId] = 3;
-					break;
-				case 3:
-					Config.TargetZoomFactors[Emulator.SystemId] = 4;
-					break;
-				case 4:
-					Config.TargetZoomFactors[Emulator.SystemId] = 5;
-					break;
-				case 5:
-					Config.TargetZoomFactors[Emulator.SystemId] = 6;
-					break;
-				case 6:
-					Config.TargetZoomFactors[Emulator.SystemId] = 7;
-					break;
-				case 7:
-					Config.TargetZoomFactors[Emulator.SystemId] = 8;
-					break;
-				case 8:
-					Config.TargetZoomFactors[Emulator.SystemId] = 9;
-					break;
-				case 9:
-					Config.TargetZoomFactors[Emulator.SystemId] = 10;
-					break;
-				case 10:
-					return;
+				Config.TargetZoomFactors[Emulator.SystemId]++;
 			}
-
 			AddOnScreenMessage($"Screensize set to {Config.TargetZoomFactors[Emulator.SystemId]}x");
 			FrameBufferResized();
 		}
 
 		private void DecreaseWindowSize()
 		{
-			switch (Config.TargetZoomFactors[Emulator.SystemId])
+			object min_factor = WindowSizeSubMenu.DropDownItems[1].Tag;
+			if (Config.TargetZoomFactors[Emulator.SystemId] > (int) min_factor)
 			{
-				case 1:
-					return;
-				case 2:
-					Config.TargetZoomFactors[Emulator.SystemId] = 1;
-					break;
-				case 3:
-					Config.TargetZoomFactors[Emulator.SystemId] = 2;
-					break;
-				case 4:
-					Config.TargetZoomFactors[Emulator.SystemId] = 3;
-					break;
-				case 5:
-					Config.TargetZoomFactors[Emulator.SystemId] = 4;
-					break;
-				case 6:
-					Config.TargetZoomFactors[Emulator.SystemId] = 5;
-					break;
-				case 7:
-					Config.TargetZoomFactors[Emulator.SystemId] = 6;
-					break;
-				case 8:
-					Config.TargetZoomFactors[Emulator.SystemId] = 7;
-					break;
-				case 9:
-					Config.TargetZoomFactors[Emulator.SystemId] = 8;
-					break;
-				case 10:
-					Config.TargetZoomFactors[Emulator.SystemId] = 9;
-					return;
+				Config.TargetZoomFactors[Emulator.SystemId]--;
 			}
-
 			AddOnScreenMessage($"Screensize set to {Config.TargetZoomFactors[Emulator.SystemId]}x");
 			FrameBufferResized();
 		}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2748,6 +2748,18 @@ namespace BizHawk.Client.EmuHawk
 					Config.TargetZoomFactors[Emulator.SystemId] = 5;
 					break;
 				case 5:
+					Config.TargetZoomFactors[Emulator.SystemId] = 6;
+					break;
+				case 6:
+					Config.TargetZoomFactors[Emulator.SystemId] = 7;
+					break;
+				case 7:
+					Config.TargetZoomFactors[Emulator.SystemId] = 8;
+					break;
+				case 8:
+					Config.TargetZoomFactors[Emulator.SystemId] = 9;
+					break;
+				case 9:
 					Config.TargetZoomFactors[Emulator.SystemId] = 10;
 					break;
 				case 10:
@@ -2776,8 +2788,20 @@ namespace BizHawk.Client.EmuHawk
 				case 5:
 					Config.TargetZoomFactors[Emulator.SystemId] = 4;
 					break;
-				case 10:
+				case 6:
 					Config.TargetZoomFactors[Emulator.SystemId] = 5;
+					break;
+				case 7:
+					Config.TargetZoomFactors[Emulator.SystemId] = 6;
+					break;
+				case 8:
+					Config.TargetZoomFactors[Emulator.SystemId] = 7;
+					break;
+				case 9:
+					Config.TargetZoomFactors[Emulator.SystemId] = 8;
+					break;
+				case 10:
+					Config.TargetZoomFactors[Emulator.SystemId] = 9;
 					return;
 			}
 


### PR DESCRIPTION
Fixes #3826 

`View` -> `Window Size` can now be set to factors of x1-x10, instead of x1-x5 & x10.

Check if completed:
- [X] I have run any relevant test suites
- [X] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant
