### PR TITLE
Replace UniformInfos with init-only UniformInfo

### DIFF
--- a/src/BizHawk.Bizware.BizwareGL/Pipeline.cs
+++ b/src/BizHawk.Bizware.BizwareGL/Pipeline.cs
@@ -29,12 +29,10 @@ namespace BizHawk.Bizware.BizwareGL
 			UniformsDictionary = new(this);
 			foreach (var ui in uniforms)
 			{
-				UniformsDictionary[ui.Name] = new(this);
-			}
-
-			foreach (var ui in uniforms)
-			{
-				UniformsDictionary[ui.Name].AddUniformInfo(ui);
+				UniformsDictionary[ui.Name] = new(this)
+				{
+					UniformInfo = ui
+				};
 			}
 		}
 

--- a/src/BizHawk.Bizware.BizwareGL/PipelineUniform.cs
+++ b/src/BizHawk.Bizware.BizwareGL/PipelineUniform.cs
@@ -15,29 +15,7 @@ namespace BizHawk.Bizware.BizwareGL
 			Owner = owner;
 		}
 
-		internal void AddUniformInfo(UniformInfo ui)
-		{
-			_uniformInfos.Add(ui);
-		}
-
-		public IEnumerable<UniformInfo> UniformInfos => _uniformInfos;
-
-		private readonly List<UniformInfo> _uniformInfos = new();
-
-		/// <returns>the first and only <see cref="UniformInfo"/></returns>
-		/// <exception cref="InvalidOperationException">more than one <see cref="UniformInfo"/> exists</exception>
-		public UniformInfo Sole
-		{
-			get
-			{
-				if (_uniformInfos.Count != 1)
-				{
-					throw new InvalidOperationException();
-				}
-
-				return _uniformInfos[0];
-			}
-		}
+		public UniformInfo UniformInfo { get; init; }
 
 		public Pipeline Owner { get; }
 		

--- a/src/BizHawk.Bizware.BizwareGL/RetroShader.cs
+++ b/src/BizHawk.Bizware.BizwareGL/RetroShader.cs
@@ -42,7 +42,7 @@ namespace BizHawk.Bizware.BizwareGL
 				// sampler wasn't named correctly. this can happen on some retroarch shaders
 				foreach (var u in Pipeline.GetUniforms())
 				{
-					if (u.Sole.IsSampler && u.Sole.SamplerIndex == 0)
+					if (u.UniformInfo.IsSampler && u.UniformInfo.SamplerIndex == 0)
 					{
 						sampler0 = u;
 						break;

--- a/src/BizHawk.Bizware.Graphics/D3D9/IGL_D3D9.cs
+++ b/src/BizHawk.Bizware.Graphics/D3D9/IGL_D3D9.cs
@@ -508,11 +508,8 @@ namespace BizHawk.Bizware.Graphics
 
 		public void SetPipelineUniform(PipelineUniform uniform, bool value)
 		{
-			foreach (var ui in uniform.UniformInfos)
-			{
-				var uw = (UniformWrapper)ui.Opaque;
-				uw.CT.SetValue(_device, uw.EffectHandle, value);
-			}
+			var uw = (UniformWrapper)uniform.UniformInfo.Opaque;
+			uw.CT.SetValue(_device, uw.EffectHandle, value);
 		}
 
 		public void SetPipelineUniformMatrix(PipelineUniform uniform, Matrix4x4 mat, bool transpose)
@@ -520,48 +517,33 @@ namespace BizHawk.Bizware.Graphics
 
 		public void SetPipelineUniformMatrix(PipelineUniform uniform, ref Matrix4x4 mat, bool transpose)
 		{
-			foreach (var ui in uniform.UniformInfos)
-			{
-				var uw = (UniformWrapper)ui.Opaque;
-				uw.CT.SetValue(_device, uw.EffectHandle, mat.ToSharpDXMatrix(!transpose));
-			}
+			var uw = (UniformWrapper)uniform.UniformInfo.Opaque;
+			uw.CT.SetValue(_device, uw.EffectHandle, mat.ToSharpDXMatrix(!transpose));
 		}
 
 		public void SetPipelineUniform(PipelineUniform uniform, Vector4 value)
 		{
-			foreach (var ui in uniform.UniformInfos)
-			{
-				var uw = (UniformWrapper)ui.Opaque;
-				uw.CT.SetValue(_device, uw.EffectHandle, value.ToSharpDXVector4());
-			}
+			var uw = (UniformWrapper)uniform.UniformInfo.Opaque;
+			uw.CT.SetValue(_device, uw.EffectHandle, value.ToSharpDXVector4());
 		}
 
 		public void SetPipelineUniform(PipelineUniform uniform, Vector2 value)
 		{
-			foreach (var ui in uniform.UniformInfos)
-			{
-				var uw = (UniformWrapper)ui.Opaque;
-				uw.CT.SetValue(_device, uw.EffectHandle, value.ToSharpDXVector2());
-			}
+			var uw = (UniformWrapper)uniform.UniformInfo.Opaque;
+			uw.CT.SetValue(_device, uw.EffectHandle, value.ToSharpDXVector2());
 		}
 
 		public void SetPipelineUniform(PipelineUniform uniform, float value)
 		{
-			foreach (var ui in uniform.UniformInfos)
-			{
-				var uw = (UniformWrapper)ui.Opaque;
-				uw.CT.SetValue(_device, uw.EffectHandle, value);
-			}
+			var uw = (UniformWrapper)uniform.UniformInfo.Opaque;
+			uw.CT.SetValue(_device, uw.EffectHandle, value);
 		}
 
 		public void SetPipelineUniform(PipelineUniform uniform, Vector4[] values)
 		{
 			var v = Array.ConvertAll(values, v => v.ToSharpDXVector4());
-			foreach (var ui in uniform.UniformInfos)
-			{
-				var uw = (UniformWrapper)ui.Opaque;
-				uw.CT.SetValue(_device, uw.EffectHandle, v);
-			}
+			var uw = (UniformWrapper)uniform.UniformInfo.Opaque;
+			uw.CT.SetValue(_device, uw.EffectHandle, v);
 		}
 
 		public void SetPipelineUniformSampler(PipelineUniform uniform, Texture2d tex)
@@ -572,20 +554,17 @@ namespace BizHawk.Bizware.Graphics
 			}
 
 			var tw = (TextureWrapper)tex.Opaque;
-			foreach (var ui in uniform.UniformInfos)
+			if (!uniform.UniformInfo.IsSampler)
 			{
-				if (!ui.IsSampler)
-				{
-					throw new InvalidOperationException("Uniform was not a texture/sampler");
-				}
-
-				_device.SetTexture(ui.SamplerIndex, tw.Texture);
-
-				_device.SetSamplerState(ui.SamplerIndex, SamplerState.AddressU, (int)tw.WrapClamp);
-				_device.SetSamplerState(ui.SamplerIndex, SamplerState.AddressV, (int)tw.WrapClamp);
-				_device.SetSamplerState(ui.SamplerIndex, SamplerState.MinFilter, (int)tw.MinFilter);
-				_device.SetSamplerState(ui.SamplerIndex, SamplerState.MagFilter, (int)tw.MagFilter);
+				throw new InvalidOperationException("Uniform was not a texture/sampler");
 			}
+
+			_device.SetTexture(uniform.UniformInfo.SamplerIndex, tw.Texture);
+
+			_device.SetSamplerState(uniform.UniformInfo.SamplerIndex, SamplerState.AddressU, (int)tw.WrapClamp);
+			_device.SetSamplerState(uniform.UniformInfo.SamplerIndex, SamplerState.AddressV, (int)tw.WrapClamp);
+			_device.SetSamplerState(uniform.UniformInfo.SamplerIndex, SamplerState.MinFilter, (int)tw.MinFilter);
+			_device.SetSamplerState(uniform.UniformInfo.SamplerIndex, SamplerState.MagFilter, (int)tw.MagFilter);
 		}
 
 		public void SetTextureWrapMode(Texture2d tex, bool clamp)

--- a/src/BizHawk.Bizware.Graphics/OpenGL/IGL_OpenGL.cs
+++ b/src/BizHawk.Bizware.Graphics/OpenGL/IGL_OpenGL.cs
@@ -443,30 +443,30 @@ namespace BizHawk.Bizware.Graphics
 
 		public void SetPipelineUniform(PipelineUniform uniform, bool value)
 		{
-			GL.Uniform1((int)uniform.Sole.Opaque, value ? 1 : 0);
+			GL.Uniform1((int)uniform.UniformInfo.Opaque, value ? 1 : 0);
 		}
 
 		public unsafe void SetPipelineUniformMatrix(PipelineUniform uniform, Matrix4x4 mat, bool transpose)
 		{
-			GL.UniformMatrix4((int)uniform.Sole.Opaque, 1, transpose, (float*)&mat);
+			GL.UniformMatrix4((int)uniform.UniformInfo.Opaque, 1, transpose, (float*)&mat);
 		}
 
 		public unsafe void SetPipelineUniformMatrix(PipelineUniform uniform, ref Matrix4x4 mat, bool transpose)
 		{
 			fixed (Matrix4x4* pMat = &mat)
 			{
-				GL.UniformMatrix4((int)uniform.Sole.Opaque, 1, transpose, (float*)pMat);
+				GL.UniformMatrix4((int)uniform.UniformInfo.Opaque, 1, transpose, (float*)pMat);
 			}
 		}
 
 		public void SetPipelineUniform(PipelineUniform uniform, Vector4 value)
 		{
-			GL.Uniform4((int)uniform.Sole.Opaque, value.X, value.Y, value.Z, value.W);
+			GL.Uniform4((int)uniform.UniformInfo.Opaque, value.X, value.Y, value.Z, value.W);
 		}
 
 		public void SetPipelineUniform(PipelineUniform uniform, Vector2 value)
 		{
-			GL.Uniform2((int)uniform.Sole.Opaque, value.X, value.Y);
+			GL.Uniform2((int)uniform.UniformInfo.Opaque, value.X, value.Y);
 		}
 
 		public void SetPipelineUniform(PipelineUniform uniform, float value)
@@ -476,20 +476,20 @@ namespace BizHawk.Bizware.Graphics
 				return; // uniform was optimized out
             }
 
-			GL.Uniform1((int)uniform.Sole.Opaque, value);
+			GL.Uniform1((int)uniform.UniformInfo.Opaque, value);
 		}
 
 		public unsafe void SetPipelineUniform(PipelineUniform uniform, Vector4[] values)
 		{
 			fixed (Vector4* pValues = &values[0])
 			{
-				GL.Uniform4((int)uniform.Sole.Opaque, (uint)values.Length, (float*)pValues);
+				GL.Uniform4((int)uniform.UniformInfo.Opaque, (uint)values.Length, (float*)pValues);
 			}
 		}
 
 		public void SetPipelineUniformSampler(PipelineUniform uniform, Texture2d tex)
 		{
-			var n = (int)uniform.Sole.Opaque >> 24;
+			var n = (int)uniform.UniformInfo.Opaque >> 24;
 
 			// set the sampler index into the uniform first
 			GL.ActiveTexture(TextureUnit.Texture0 + n);


### PR DESCRIPTION
Seems like a simple simplification of the code, but I'm not sure if it could break anything.

Check if completed:
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-03-20) and am compliant
