### PR TITLE
make default.nix and shell.nix pure by adding checksums and system

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
 { system ? builtins.currentSystem
 , pkgs ? import (fetchTarball {
-		url = "https://github.com/NixOS/nixpkgs/archive/23.11.tar.gz";
-		sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
-	}) { inherit system; }
+	url = "https://github.com/NixOS/nixpkgs/archive/23.11.tar.gz";
+	sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
+}) { inherit system; }
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenvNoCC
 # infrastructure
@@ -43,9 +43,9 @@ in {
 , lua ? pkgs.lua54Packages.lua
 , mono ? null
 , nixGLChannel ? (pkgs.nixgl or import (fetchTarball {
-		url = "https://github.com/guibou/nixGL/archive/489d6b095ab9d289fe11af0219a9ff00fe87c7c5.tar.gz";
-		sha256 = "03kwsz8mf0p1v1clz42zx8cmy6hxka0cqfbfasimbj858lyd930k";
-	}) { inherit system; })
+	url = "https://github.com/guibou/nixGL/archive/489d6b095ab9d289fe11af0219a9ff00fe87c7c5.tar.gz";
+	sha256 = "03kwsz8mf0p1v1clz42zx8cmy6hxka0cqfbfasimbj858lyd930k";
+}) { inherit system; })
 , nixGL ? nixGLChannel.auto.nixGLDefault
 #, nixVulkan ? nixGLChannel.auto.nixVulkanNvidia
 , openal ? pkgs.openal

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,8 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/23.11.tar.gz") {}
+{ system ? builtins.currentSystem
+, pkgs ? import (fetchTarball {
+		url = "https://github.com/NixOS/nixpkgs/archive/23.11.tar.gz";
+		sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
+	}) { inherit system; }
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenvNoCC
 # infrastructure
@@ -27,7 +31,10 @@ in {
 , dotnet-sdk_6 ? pkgs.dotnet-sdk_6
 , dotnet-sdk_5 ? let result = builtins.tryEval pkgs.dotnet-sdk_5; in if result.success
 	then result.value
-	else (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5234f4ce9340fffb705b908fff4896faeddb8a12^.tar.gz") {}).dotnet-sdk_5
+	else (import (fetchTarball {
+		url = "https://github.com/NixOS/nixpkgs/archive/5234f4ce9340fffb705b908fff4896faeddb8a12^.tar.gz";
+		sha256 = "0glawbqvvvbiz1gn7i1skhaqw96ilgdds6gzq7mj29kfk4vkzng1";
+	}) { inherit system; }).dotnet-sdk_5
 , git ? pkgs.gitMinimal # only when building from-CWD (`-local`)
 # rundeps
 , coreutils ? pkgs.coreutils
@@ -35,7 +42,10 @@ in {
 , libGL ? pkgs.libGL
 , lua ? pkgs.lua54Packages.lua
 , mono ? null
-, nixGLChannel ? (pkgs.nixgl or import (fetchTarball "https://github.com/guibou/nixGL/archive/489d6b095ab9d289fe11af0219a9ff00fe87c7c5.tar.gz") {})
+, nixGLChannel ? (pkgs.nixgl or import (fetchTarball {
+		url = "https://github.com/guibou/nixGL/archive/489d6b095ab9d289fe11af0219a9ff00fe87c7c5.tar.gz";
+		sha256 = "03kwsz8mf0p1v1clz42zx8cmy6hxka0cqfbfasimbj858lyd930k";
+	}) { inherit system; })
 , nixGL ? nixGLChannel.auto.nixGLDefault
 #, nixVulkan ? nixGLChannel.auto.nixVulkanNvidia
 , openal ? pkgs.openal
@@ -100,7 +110,10 @@ in {
 			else if isVersionAtLeast "6.12.0.151" pkgs.mono.version
 				then pkgs.mono
 				else lib.trace "provided Mono too old, using Mono from Nixpkgs 23.05"
-					(import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz") {}).mono;
+					(import (fetchTarball {
+						url = "https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz";
+						sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
+					}) { inherit system; }).mono;
 		monoBasic = fetchzip {
 			url = "https://download.mono-project.com/repo/debian/pool/main/m/mono-basic/libmono-microsoft-visualbasic10.0-cil_4.7-0xamarin3+debian9b1_all.deb";
 			nativeBuildInputs = [ dpkg ];

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,5 @@
-{ pkgs ? import <nixpkgs> {}
+{ system ? builtins.currentSystem
+, pkgs ? import <nixpkgs> { inherit system; }
 , lib ? pkgs.lib
 , mkShell ? pkgs.mkShell
 , git-cola ? pkgs.git-cola
@@ -12,7 +13,7 @@
 , useVSCode ? false
 }: let
 	# thinking of exposing pre-configured IDEs from `default.nix` so they're available here
-	avail = import ./. { inherit debugDotnetHostCrashes debugPInvokes forNixOS; };
+	avail = import ./. { inherit debugDotnetHostCrashes debugPInvokes forNixOS system; };
 	f = drv: mkShell {
 		packages = [ git ]
 			++ lib.optionals useNanoAndCola [ git-cola nano ]


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

The only things keeping both `default.nix` and `shell.nix` from evaluating in [pure evaluation mode](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-pure-eval) are the lack of checksums on calls to `builtins.fetchTarball`, and the lack of a `system` attribute to be passed down to their corresponding `import` statements. The associated URLs have not been changed in 5 months and thus don't seem likely to change in the near future either (except for the first, when 24.05 drops; I'd be happy to amend this PR if that happens before it is merged).

Purity becomes much more important if and when BizHawk gets published to [nixpkgs](/NixOS/nixpkgs) or as a standalone flake, but in the meantime would still make users like me who consume and evaluate these build scripts directly happier, and at a trivial maintenance cost.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-03-20) and am compliant
