### PR TITLE
Updated Amstrad CPC Non-Sync Settings name

### DIFF
--- a/src/BizHawk.Client.EmuHawk/config/AmstradCPC/AmstradCPCNonSyncSettings.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/AmstradCPC/AmstradCPCNonSyncSettings.Designer.cs
@@ -63,7 +63,7 @@
 			// 
 			this.label1.Location = new System.Drawing.Point(12, 14);
 			this.label1.Name = "label1";
-			this.label1.Text = "ZX Spectrum Misc Non-Sync Settings";
+			this.label1.Text = "Amstrad CPC Misc Non-Sync Settings";
 			// 
 			// lblOSDVerbinfo
 			// 


### PR DESCRIPTION
Updated Amstrad CPC Non-Sync Settings text to be more accurate.
This was done by changing the label in the AmstradCPCNonSyncSettings.Designer.cs file
This solves issue #3845 
