### PR TITLE
Expanded color palette object inside Nes PPU Viewer

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESPPU.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESPPU.Designer.cs
@@ -204,7 +204,7 @@ namespace BizHawk.Client.EmuHawk
 			this.PaletteView.ContextMenuStrip = this.PaletteContext;
 			this.PaletteView.Location = new System.Drawing.Point(6, 19);
 			this.PaletteView.Name = "PaletteView";
-			this.PaletteView.Size = new System.Drawing.Size(192, 32);
+			this.PaletteView.Size = new System.Drawing.Size(256, 32);
 			this.PaletteView.TabIndex = 0;
 			this.PaletteView.Text = "Palettes";
 			this.PaletteView.MouseClick += new System.Windows.Forms.MouseEventHandler(this.PaletteView_MouseClick);


### PR DESCRIPTION
Expanded the palette viewer to show all the palettes.

For some reason, this object was only 192 pixels wide, instead of 256. The fourth palette is getting cut off:

![___PalettePullRequest_BeforePNG](https://github.com/TASEmulators/BizHawk/assets/23084831/1aed2062-fa48-48fa-90c6-0ce45a46aaba)

By making this change, all the palettes are visible:

![___PalettePullRequest_After](https://github.com/TASEmulators/BizHawk/assets/23084831/98681eaa-8c03-4554-ad3f-c4284644aa78)



- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-03-20) and am compliant
