### PR TITLE
[Core: GPGX] Fixing a wrong variable name that caused a crash in GPGX's load state

### DIFF
--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IDebuggable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IDebuggable.cs
@@ -99,9 +99,9 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 		private void RefreshMemCallbacks()
 		{
 			Core.gpgx_set_mem_callback(
-				MemoryCallbacks.HasReads ? ReadCallback : null,
-				MemoryCallbacks.HasWrites ? WriteCallback : null,
-				MemoryCallbacks.HasExecutes ? ExecCallback : null);
+				_memoryCallbacks.HasReads ? ReadCallback : null,
+				_memoryCallbacks.HasWrites ? WriteCallback : null,
+				_memoryCallbacks.HasExecutes ? ExecCallback : null);
 		}
 
 		private void KillMemCallbacks()


### PR DESCRIPTION
Fixing a bug reported by Morilli where GPGX crashes upon trying to load a state on SMS's Galactic Protector:

```
System.NotImplementedException: The method or operation is not implemented.
  at BizHawk.Emulation.Cores.Consoles.Sega.gpgx.GPGX.get_MemoryCallbacks () [0x00019] in <655556b5f7fe4f2daa09dea9e80ee688>:0 
  at BizHawk.Emulation.Cores.Consoles.Sega.gpgx.GPGX.RefreshMemCallbacks () [0x00000] in <655556b5f7fe4f2daa09dea9e80ee688>:0 
```

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-03-20) and am compliant
