### PR TITLE
Refactor IControlMainform handling in Mainform

### DIFF
--- a/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
+++ b/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
@@ -79,17 +79,11 @@ namespace BizHawk.Client.EmuHawk
 		bool BlockFrameAdvance { get; set; }
 
 		/// <remarks>only referenced from <see cref="TAStudio"/></remarks>
-		void RelinquishControl(IControlMainform master);
-
-		/// <remarks>only referenced from <see cref="TAStudio"/></remarks>
 		void SeekFrameAdvance();
 
 		void SetMainformMovieInfo();
 
 		bool StartNewMovie(IMovie movie, bool record);
-
-		/// <remarks>only referenced from <see cref="TAStudio"/></remarks>
-		void TakeBackControl();
 
 		/// <remarks>only referenced from <see cref="BasicBot"/></remarks>
 		void Throttle();

--- a/src/BizHawk.Client.EmuHawk/MainForm.Movie.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Movie.cs
@@ -101,9 +101,9 @@ namespace BizHawk.Client.EmuHawk
 
 		public void StopMovie(bool saveChanges = true)
 		{
-			if (IsSlave && Master.WantsToControlStopMovie)
+			if (ToolControllingStopMovie is { } tool)
 			{
-				Master.StopMovie(!saveChanges);
+				tool.StopMovie(!saveChanges);
 			}
 			else
 			{
@@ -114,7 +114,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public bool RestartMovie()
 		{
-			if (IsSlave && Master.WantsToControlRestartMovie) return Master.RestartMovie();
+			if (ToolControllingRestartMovie is { } tool) return tool.RestartMovie();
 			if (!MovieSession.Movie.IsActive()) return false;
 			var success = StartNewMovie(MovieSession.Movie, false);
 			if (success) AddOnScreenMessage("Replaying movie file in read-only mode");
@@ -123,9 +123,9 @@ namespace BizHawk.Client.EmuHawk
 
 		private void ToggleReadOnly()
 		{
-			if (IsSlave && Master.WantsToControlReadOnly)
+			if (ToolControllingReadOnly is { } tool)
 			{
-				Master.ToggleReadOnly();
+				tool.ToggleReadOnly();
 			}
 			else
 			{

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
@@ -68,7 +68,7 @@
 			}
 		}
 
-		public bool WantsToControlRewind => true;
+		public bool WantsToControlRewind { get; private set; } = true;
 
 		public void CaptureRewind()
 		{

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -285,7 +285,6 @@ namespace BizHawk.Client.EmuHawk
 			MainForm.AddOnScreenMessage("TAStudio engaged");
 			SetTasMovieCallbacks(CurrentTasMovie);
 			UpdateWindowTitle();
-			MainForm.RelinquishControl(this);
 			_originalEndAction = Config.Movies.MovieEndAction;
 			MainForm.DisableRewind();
 			Config.Movies.MovieEndAction = MovieEndAction.Record;
@@ -736,7 +735,6 @@ namespace BizHawk.Client.EmuHawk
 			_engaged = false;
 			MainForm.PauseOnFrame = null;
 			MainForm.AddOnScreenMessage("TAStudio disengaged");
-			MainForm.TakeBackControl();
 			Config.Movies.MovieEndAction = _originalEndAction;
 			MainForm.EnableRewind(true);
 			MainForm.SetMainformMovieInfo();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -736,6 +736,7 @@ namespace BizHawk.Client.EmuHawk
 			MainForm.PauseOnFrame = null;
 			MainForm.AddOnScreenMessage("TAStudio disengaged");
 			Config.Movies.MovieEndAction = _originalEndAction;
+			WantsToControlRewind = false;
 			MainForm.EnableRewind(true);
 			MainForm.SetMainformMovieInfo();
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -473,6 +473,19 @@ namespace BizHawk.Client.EmuHawk
 			return Load<T>(false);
 		}
 
+		public T FirstOrNull<T>(Predicate<T> condition) where T : class
+		{
+			foreach (var tool in _tools)
+			{
+				if (tool is T specialTool && condition(specialTool))
+				{
+					return specialTool;
+				}
+			}
+
+			return null;
+		}
+
 		/// <summary>
 		/// returns the instance of <paramref name="toolType"/>, regardless of whether it's loaded,<br/>
 		/// but doesn't create and load a new instance if it's not found
@@ -482,7 +495,7 @@ namespace BizHawk.Client.EmuHawk
 		/// you may pass any class or interface
 		/// </remarks>
 		public IToolForm/*?*/ LazyGet(Type toolType)
-			=> _tools.Find(t => toolType.IsAssignableFrom(t.GetType()));
+			=> _tools.Find(toolType.IsInstanceOfType);
 
 		internal static readonly IDictionary<Type, (Image/*?*/ Icon, string Name)> IconAndNameCache = new Dictionary<Type, (Image/*?*/ Icon, string Name)>
 		{

--- a/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -477,7 +477,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			foreach (var tool in _tools)
 			{
-				if (tool is T specialTool && condition(specialTool))
+				if (tool.IsActive && tool is T specialTool && condition(specialTool))
 				{
 					return specialTool;
 				}

--- a/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -473,6 +473,12 @@ namespace BizHawk.Client.EmuHawk
 			return Load<T>(false);
 		}
 
+		/// <summary>
+		/// Returns the first tool of type <typeparamref name="T"/> that fulfills the given condition
+		/// </summary>
+		/// <param name="condition">The condition to check for</param>
+		/// <typeparam name="T">Type of tools to check</typeparam>
+		/// <returns></returns>
 		public T FirstOrNull<T>(Predicate<T> condition) where T : class
 		{
 			foreach (var tool in _tools)


### PR DESCRIPTION
- closes #3870
 
This changes the handling of `IControlMainform` tools loaded in the following way:
There is no longer a way for a tool to take or relinquish control over all mainform actions specified in that interface, instead, each of the `WantsToControlX` fields are queried for all loaded tools, and if one matches, that tool will be controlling this action.
That means that there could now be different loaded tools handling different actions, for example one tool controlling rewind, a different tool controlling savestates, etc.

Additionally, `CreateRewinder` now returns immediately if any tool has `WantsToControlRewind` set to true, for example TAStudio.
This still feels a bit arbitrary, every tool wanting to control rewind will have to manually disable rewind on load and re-enable it on close as TAStudio does, but this isn't a new issue introduced here, so...

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-03-20) and am compliant
