### PR TITLE
Fix possible TAStudio NRE

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.cs
@@ -97,7 +97,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public override bool AskSaveChanges()
 		{
-			if (_unsavedZones.Count == 0 || IsDisposed)
+			if (_unsavedZones.Count == 0)
 			{
 				return true;
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
@@ -127,7 +127,7 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		public override bool AskSaveChanges()
 		{
-			if (_suppressAskSave)
+			if (_suppressAskSave || IsDisposed)
 			{
 				return true;
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
@@ -127,7 +127,7 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		public override bool AskSaveChanges()
 		{
-			if (_suppressAskSave || IsDisposed)
+			if (_suppressAskSave)
 			{
 				return true;
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -616,9 +616,7 @@ namespace BizHawk.Client.EmuHawk
 				return true;
 			}
 
-			return _tools
-				.Select(tool => tool.AskSaveChanges())
-				.All(result => result);
+			return _tools.TrueForAll(tool => !tool.IsActive || tool.AskSaveChanges());
 		}
 
 		/// <summary>


### PR DESCRIPTION
- ~~Bail out of `TAStudio.AskSaveChanges()` if dialog is already disposed~~
- Stop calling `AskSaveChanges()` on inactive tools
- Fix #3499

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-03-20) and am compliant
