### PR TITLE
Update AUR package link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ A "backport" release, [1.13.2](https://github.com/TASEmulators/BizHawk/releases/
 
 Install the listed package with your package manager (some buttons are links to the relevant package). The changelog can be found [over on TASVideos](https://tasvideos.org/Bizhawk/ReleaseHistory).
 
-[![Arch Linux | bizhawk-monort (AUR)](https://img.shields.io/badge/Arch_Linux-bizhawk--bin_(AUR)-%231793D1.svg?logo=archlinux&style=popout)](https://aur.archlinux.org/packages/bizhawk-bin)
+[![Arch Linux | bizhawk-bin (AUR)](https://img.shields.io/badge/Arch_Linux-bizhawk--bin_(AUR)-%231793D1.svg?logo=archlinux&style=popout)](https://aur.archlinux.org/packages/bizhawk-bin)
 
 No package for your distro? Install via Nix (see below), or install manually by grabbing the latest release here on GitHub:
 

--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ A "backport" release, [1.13.2](https://github.com/TASEmulators/BizHawk/releases/
 
 Install the listed package with your package manager (some buttons are links to the relevant package). The changelog can be found [over on TASVideos](https://tasvideos.org/Bizhawk/ReleaseHistory).
 
-[![Manjaro | bizhawk-monort (AUR)](https://img.shields.io/badge/Manjaro-bizhawk--monort_(AUR)-%2335BF5C.svg?logo=manjaro&style=popout)](https://aur.archlinux.org/packages/bizhawk-monort)
+[![Arch Linux | bizhawk-monort (AUR)](https://img.shields.io/badge/Arch_Linux-bizhawk--bin_(AUR)-%231793D1.svg?logo=archlinux&style=popout)](https://aur.archlinux.org/packages/bizhawk-bin)
 
 No package for your distro? Install via Nix (see below), or install manually by grabbing the latest release here on GitHub:
 
-[![Misc. Linux | bizhawk-monort](https://img.shields.io/badge/Misc._Linux-bizhawk--monort-%23FCC624.svg?logo=linux&logoColor=black&style=popout)](https://github.com/TASEmulators/BizHawk/releases/latest)
+[![Misc. Linux | binaries](https://img.shields.io/badge/Misc._Linux-binaries-%23FCC624.svg?logo=linux&logoColor=black&style=popout)](https://github.com/TASEmulators/BizHawk/releases/latest)
 
 If you download BizHawk this way, **don't mix different versions**, keep each version in its own folder.
 The runtime dependencies are glibc, Mono "complete", OpenAL, Lua 5.4, and `lsb_release`.


### PR DESCRIPTION
Since the `bizhawk-monort` AUR package got merged with the [`bizhawk-bin`](https://aur.archlinux.org/packages/bizhawk-bin) one two days ago, here's a PR fixing the link in the README, as well as changing the badge to Arch Linux instead, since Manjaro is based on Arch Linux and any distro based on it can use the AUR.

Also changed the text in the "Misc. Linux" badge to "binaries" to match with Windows' badge.