### PR TITLE
Simplify `Range<T>` usage and implementation, switching to half-open (end is exclusive)

### DIFF
--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.InputLog.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.InputLog.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using BizHawk.Common;
+
 using BizHawk.Common.StringExtensions;
 
 namespace BizHawk.Client.Common
@@ -77,7 +77,7 @@ namespace BizHawk.Client.Common
 
 			var stateFramei = stateFrame ?? 0;
 
-			if (stateFramei.StrictlyBoundedBy(0.RangeTo(Log.Count)))
+			if (0 < stateFramei && stateFramei < Log.Count)
 			{
 				if (!Session.Settings.VBAStyleMovieLoadState)
 				{

--- a/src/BizHawk.Client.EmuHawk/Throttle.cs
+++ b/src/BizHawk.Client.EmuHawk/Throttle.cs
@@ -202,7 +202,7 @@ namespace BizHawk.Client.EmuHawk
 			// reset way-out-of-range values
 			if (diff > 1.0f)
 				diff = 1.0f;
-			if (!(-1.0f).RangeTo(1.0f).Contains(error))
+			if (Math.Abs(error) > 1.0f)
 				error = 0.0f;
 			if (diffUnthrottled > 1.0f)
 				diffUnthrottled = desiredspf;

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.cs
@@ -8,7 +8,6 @@ using System.Xml.XPath;
 using System.Xml.Linq;
 
 using BizHawk.Client.Common;
-using BizHawk.Common;
 using BizHawk.Emulation.Cores.Nintendo.NES;
 using BizHawk.Emulation.Common;
 
@@ -72,11 +71,7 @@ namespace BizHawk.Client.EmuHawk
 				float a = FreqTable[i - 1];
 				float b = FreqTable[i];
 				float c = FreqTable[i + 1];
-				var range = ((a + b) / 2).RangeTo((b + c) / 2);
-				if (range.Contains(freq))
-				{
-					return i - 1;
-				}
+				if ((a + b) / 2 <= freq && freq <= (b + c) / 2) return i - 1;
 			}
 
 			return 95; // I guess?

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/components/AnalogStickPanel.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/components/AnalogStickPanel.cs
@@ -76,8 +76,10 @@ namespace BizHawk.Client.EmuHawk
 			Rerange();
 		}
 
-		private Range<int> _rangeX = 0.RangeTo(0);
-		private Range<int> _rangeY = 0.RangeTo(0);
+		private Int32ClosedRange _rangeX = 0.RangeTo(0);
+
+		private Int32ClosedRange _rangeY = 0.RangeTo(0);
+
 		private AxisSpec _fullRangeX;
 		private AxisSpec _fullRangeY;
 
@@ -287,6 +289,6 @@ namespace BizHawk.Client.EmuHawk
 			Refresh();
 		}
 
-		private static readonly Range<int> PercentRange = 0.RangeTo(100);
+		private static readonly Int32ClosedRange PercentRange = 0.RangeTo(100);
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/components/AnalogStickPanel.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/components/AnalogStickPanel.cs
@@ -76,9 +76,9 @@ namespace BizHawk.Client.EmuHawk
 			Rerange();
 		}
 
-		private Int32ClosedRange _rangeX = 0.RangeTo(0);
+		private Int32HalfOpenRange _rangeX = 0.RangeTo(0);
 
-		private Int32ClosedRange _rangeY = 0.RangeTo(0);
+		private Int32HalfOpenRange _rangeY = 0.RangeTo(0);
 
 		private AxisSpec _fullRangeX;
 		private AxisSpec _fullRangeY;
@@ -289,6 +289,6 @@ namespace BizHawk.Client.EmuHawk
 			Refresh();
 		}
 
-		private static readonly Int32ClosedRange PercentRange = 0.RangeTo(100);
+		private static readonly Int32HalfOpenRange PercentRange = 0.RangeTo(100);
 	}
 }

--- a/src/BizHawk.Common/Ranges.cs
+++ b/src/BizHawk.Common/Ranges.cs
@@ -1,102 +1,212 @@
+using System.Runtime.CompilerServices;
+
 namespace BizHawk.Common
 {
-	/// <summary>represents a closed range of <typeparamref name="T"/> (class invariant: <see cref="Start"/> ≤ <see cref="EndInclusive"/>)</summary>
-#pragma warning disable CA1715 // breaks IInterface convention
-	public interface Range<out T> where T : unmanaged, IComparable<T>
-#pragma warning restore CA1715
+	/// <summary>
+	/// represents a closed interval (a.k.a. range) of <typeparamref name="T"/>
+	/// <br/>(class invariant: <see cref="INumericClosedIntervalContra{T}.Start"/> ≤ <see cref="INumericClosedIntervalContra{T}.EndInclusive"/>)
+	/// </summary>
+	public interface INumericClosedInterval<T> : INumericClosedIntervalContra<T>,
+		IEquatable<INumericClosedIntervalContra<T>>
+		where T : IComparable<T>
+	{
+		/// <summary>
+		/// leaves <paramref name="value"/> unchanged if it's contained in the interval,
+		/// or else sets it to whichever bound is closest
+		/// </summary>
+		void Clamp(ref T value);
+
+		/// <returns>
+		/// <see langword="true"/> iff <paramref name="value"/> is contained in this interval
+		/// (<paramref name="value"/> is considered to be in the interval if it's exactly equal to either bound)
+		/// </returns>
+		bool Contains(in T value);
+	}
+
+	/// <summary>see <see cref="INumericClosedInterval{T}"/>; this is a type parameter variance hack</summary>
+	public interface INumericClosedIntervalContra<out T>
 	{
 		T Start { get; }
 
 		T EndInclusive { get; }
 	}
 
-	internal class MutableRange<T> : Range<T> where T : unmanaged, IComparable<T>
+	/// <summary>
+	/// represents a closed range (a.k.a. interval) of <see cref="int"><c>s32</c>s</see>
+	/// <br/>(class invariant: <see cref="NumericClosedRangeBase{T}.Start"/> ≤ <see cref="NumericClosedRangeBase{T}.EndInclusive"/>)
+	/// </summary>
+#pragma warning disable MA0077 // already implements `IEquatable<TSelf>`
+	public sealed class Int32ClosedRange : NumericClosedRangeBase<int>
+#pragma warning restore MA0077
 	{
-		private (T Start, T EndInclusive) r;
+		private string? _ser = null;
 
-		public T Start
-		{
-			get => r.Start;
-		}
+		/// <inheritdoc cref="NumericClosedRangeBase{T}(T,T)"/>
+		public Int32ClosedRange(int start, int endInclusive)
+			: base(start, endInclusive) {}
 
-		public T EndInclusive
-		{
-			get => r.EndInclusive;
-		}
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public override bool Contains(in int value)
+			=> Start <= value && value <= EndInclusive;
 
-		/// <exception cref="ArgumentException"><typeparamref name="T"/> is <see langword="float"/>/<see langword="double"/> and either bound is <see cref="float.NaN"/></exception>
-		/// <exception cref="ArgumentOutOfRangeException"><paramref name="endInclusive"/> &lt; <paramref name="start"/></exception>
-		internal MutableRange(T start, T endInclusive)
-		{
-			if (endInclusive.CompareTo(start) < 0) throw new ArgumentOutOfRangeException(nameof(endInclusive), endInclusive, "range end < start");
-			if (start is float fs)
-			{
-				if (float.IsNaN(fs)) throw new ArgumentException("range start is NaN", nameof(start));
-				if (endInclusive is float fe && float.IsNaN(fe)) throw new ArgumentException("range end is NaN", nameof(endInclusive));
-			}
-			else if (start is double ds)
-			{
-				if (double.IsNaN(ds)) throw new ArgumentException("range start is NaN", nameof(start));
-				if (endInclusive is double de && double.IsNaN(de)) throw new ArgumentException("range end is NaN", nameof(endInclusive));
-			}
-			r = (start, endInclusive);
-		}
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool Contains(int value)
+			=> Start <= value && value <= EndInclusive;
 
+		/// <remarks>beware integer overflow when this range spans every value</remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public uint Count()
+			=> (uint) ((long) EndInclusive - Start) + 1U;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool Equals(Int32ClosedRange other)
+			=> Start == other.Start && EndInclusive == other.EndInclusive;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public override string ToString()
-			=> $"{Start}..={EndInclusive}";
+			=> _ser ??= $"{Start}..={EndInclusive}";
 	}
 
-	/// <summary>contains most of the logic for ranges</summary>
-	/// <remarks>
-	/// non-generic overloads are used where the method requires an increment or decrement
-	/// </remarks>
-	public static class RangeExtensions
+	/// <summary>
+	/// represents a closed range (a.k.a. interval) of <see cref="long"><c>s64</c>s</see>
+	/// <br/>(class invariant: <see cref="NumericClosedRangeBase{T}.Start"/> ≤ <see cref="NumericClosedRangeBase{T}.EndInclusive"/>)
+	/// </summary>
+#pragma warning disable MA0077 // already implements `IEquatable<TSelf>`
+	public sealed class Int64ClosedRange : NumericClosedRangeBase<long>
+#pragma warning restore MA0077
 	{
 		private const ulong MIN_LONG_NEGATION_AS_ULONG = 9223372036854775808UL;
 
+		private ulong? _count = null;
+
+		private string? _ser = null;
+
+		/// <inheritdoc cref="NumericClosedRangeBase{T}(T,T)"/>
+		public Int64ClosedRange(long start, long endInclusive)
+			: base(start, endInclusive) {}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public override bool Contains(in long value)
+			=> Start <= value && value <= EndInclusive;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool Contains(long value)
+			=> Start <= value && value <= EndInclusive;
+
+		/// <inheritdoc cref="Int32ClosedRange.Count"/>
+		public ulong Count()
+			=> _count ??= (Contains(0L)
+				? (Start is long.MinValue ? MIN_LONG_NEGATION_AS_ULONG : (ulong) -Start) + (ulong) EndInclusive
+				: (ulong) (EndInclusive - Start)
+			) + 1UL;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool Equals(Int64ClosedRange other)
+			=> Start == other.Start && EndInclusive == other.EndInclusive;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public override string ToString()
+			=> _ser ??= $"{Start}L..={EndInclusive}L";
+	}
+
+	/// <seealso cref="Int32ClosedRange"/>
+	/// <seealso cref="Int64ClosedRange"/>
+	public abstract class NumericClosedRangeBase<T> : INumericClosedInterval<T>
+		where T : IComparable<T>
+	{
+		public T Start { get; }
+
+		public T EndInclusive { get; }
+
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="endInclusive"/> &lt; <paramref name="start"/></exception>
+		protected NumericClosedRangeBase(T start, T endInclusive)
+		{
+			if (endInclusive.CompareTo(start) < 0) throw new ArgumentOutOfRangeException(paramName: nameof(endInclusive), actualValue: endInclusive, message: "range end < start");
+			Start = start;
+			EndInclusive = endInclusive;
+		}
+
+		public virtual void Clamp(ref T value)
+		{
+			if (Start.CompareTo(value) > 0) value = Start;
+			else if (EndInclusive.CompareTo(value) < 0) value = EndInclusive;
+		}
+
+		public virtual bool Contains(in T value)
+			=> Start.CompareTo(value) <= 0 && EndInclusive.CompareTo(value) >= 0;
+
+		public bool Equals(INumericClosedIntervalContra<T> other)
+			=> Start.CompareTo(other.Start) is 0 && EndInclusive.CompareTo(other.EndInclusive) is 0;
+
+		public override bool Equals(object? other)
+			=> other is INumericClosedIntervalContra<T> interval && Equals(interval);
+
+		public override int GetHashCode()
+			=> HashCode.Combine(Start, EndInclusive);
+
+		public abstract override string ToString();
+	}
+
+	public static class RangeExtensions
+	{
 		private static ArithmeticException ExclusiveRangeMinValExc
 			=> new("exclusive range end is min value of integral type");
 
-		/// <returns><paramref name="value"/> if it's contained in <paramref name="range"/>, or else whichever bound of <paramref name="range"/> is closest to <paramref name="value"/></returns>
-		public static T ConstrainWithin<T>(this T value, Range<T> range) where T : unmanaged, IComparable<T> => value.CompareTo(range.Start) < 0
-			? range.Start
-			: range.EndInclusive.CompareTo(value) < 0
-				? range.EndInclusive
-				: value;
+		/// <returns>
+		/// <paramref name="value"/> unchanged if it's contained in <paramref name="range"/>,
+		/// or else whichever bound of <paramref name="range"/> is closest to <paramref name="value"/>
+		/// </returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static T Clamp<T>(this INumericClosedInterval<T> range, T value)
+			where T : IComparable<T>
+		{
+			range.Clamp(ref value);
+			return value;
+		}
 
-		/// <returns>true iff <paramref name="value"/> is contained in <paramref name="range"/> (<paramref name="value"/> is considered to be in the range if it's exactly equal to either bound)</returns>
-		public static bool Contains<T>(this Range<T> range, T value) where T : unmanaged, IComparable<T> => !(value.CompareTo(range.Start) < 0 || range.EndInclusive.CompareTo(value) < 0);
+		/// <returns>
+		/// <paramref name="value"/> unchanged if it's contained in <paramref name="range"/>,
+		/// or else whichever bound of <paramref name="range"/> is closest to <paramref name="value"/>
+		/// </returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static T ConstrainWithin<T>(this T value, INumericClosedInterval<T> range)
+			where T : IComparable<T>
+		{
+			range.Clamp(ref value);
+			return value;
+		}
 
-		/// <remarks>beware integer overflow when <paramref name="range"/> contains every value</remarks>
-		public static uint Count(this Range<int> range) => (uint) ((long) range.EndInclusive - range.Start) + 1U;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static void Deconstruct<T>(this INumericClosedInterval<T> range, out T start, out T endInclusive)
+			where T : IComparable<T>
+		{
+			start = range.Start;
+			endInclusive = range.EndInclusive;
+		}
 
-		/// <inheritdoc cref="Count(Range{int})"/>
-		public static ulong Count(this Range<long> range) => (range.Contains(0L)
-			? (range.Start == long.MinValue ? MIN_LONG_NEGATION_AS_ULONG : (ulong) -range.Start) + (ulong) range.EndInclusive
-			: (ulong) (range.EndInclusive - range.Start)
-		) + 1UL;
+		/// <inheritdoc cref="Int32ClosedRange(int,int)"/>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Int32ClosedRange RangeTo(this int start, int endInclusive)
+			=> new(start: start, endInclusive: endInclusive);
 
-		/// <inheritdoc cref="MutableRange{T}(T,T)"/>
-		private static MutableRange<T> MutableRangeTo<T>(this T start, T endInclusive) where T : unmanaged, IComparable<T> => new MutableRange<T>(start, endInclusive);
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		private static MutableRange<int> MutableRangeToExclusive(this int start, int endExclusive) => endExclusive == int.MinValue
-			? throw ExclusiveRangeMinValExc
-			: new MutableRange<int>(start, endExclusive - 1);
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		private static MutableRange<long> MutableRangeToExclusive(this long start, long endExclusive) => endExclusive == long.MinValue
-			? throw ExclusiveRangeMinValExc
-			: new MutableRange<long>(start, endExclusive - 1L);
-
-		/// <inheritdoc cref="MutableRange{T}(T,T)"/>
-		public static Range<T> RangeTo<T>(this T start, T endInclusive) where T : unmanaged, IComparable<T> => start.MutableRangeTo(endInclusive);
+		/// <inheritdoc cref="Int64ClosedRange(long,long)"/>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Int64ClosedRange RangeTo(this long start, long endInclusive)
+			=> new(start: start, endInclusive: endInclusive);
 
 		/// <exception cref="ArgumentOutOfRangeException"><paramref name="endExclusive"/> ≤ <paramref name="start"/> (empty ranges where <paramref name="start"/> = <paramref name="endExclusive"/> are not permitted)</exception>
 		/// <exception cref="ArithmeticException"><paramref name="endExclusive"/> is min value of integral type (therefore <paramref name="endExclusive"/> ≤ <paramref name="start"/>)</exception>
-		public static Range<int> RangeToExclusive(this int start, int endExclusive) => MutableRangeToExclusive(start, endExclusive);
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Int32ClosedRange RangeToExclusive(this int start, int endExclusive)
+			=> endExclusive is int.MinValue
+				? throw ExclusiveRangeMinValExc
+				: new(start: start, endInclusive: endExclusive - 1);
 
 		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static Range<long> RangeToExclusive(this long start, long endExclusive) => MutableRangeToExclusive(start, endExclusive);
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Int64ClosedRange RangeToExclusive(this long start, long endExclusive)
+			=> endExclusive is long.MinValue
+				? throw ExclusiveRangeMinValExc
+				: new(start: start, endInclusive: endExclusive - 1L);
 	}
 }

--- a/src/BizHawk.Common/Ranges.cs
+++ b/src/BizHawk.Common/Ranges.cs
@@ -41,6 +41,9 @@ namespace BizHawk.Common
 			}
 			r = (start, endInclusive);
 		}
+
+		public override string ToString()
+			=> $"{Start}..={EndInclusive}";
 	}
 
 	/// <summary>contains most of the logic for ranges</summary>

--- a/src/BizHawk.Common/Ranges.cs
+++ b/src/BizHawk.Common/Ranges.cs
@@ -246,8 +246,5 @@ namespace BizHawk.Common
 
 		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
 		public static Range<ushort> RangeToExclusive(this ushort start, ushort endExclusive) => MutableRangeToExclusive(start, endExclusive);
-
-		/// <returns>true iff <paramref name="value"/> is strictly contained in <paramref name="range"/> (<paramref name="value"/> is considered to be OUTSIDE the range if it's exactly equal to either bound)</returns>
-		public static bool StrictlyBoundedBy<T>(this T value, Range<T> range) where T : unmanaged, IComparable<T> => range.Start.CompareTo(value) < 0 && value.CompareTo(range.EndInclusive) < 0;
 	}
 }

--- a/src/BizHawk.Common/Ranges.cs
+++ b/src/BizHawk.Common/Ranges.cs
@@ -3,11 +3,11 @@ using System.Runtime.CompilerServices;
 namespace BizHawk.Common
 {
 	/// <summary>
-	/// represents a closed interval (a.k.a. range) of <typeparamref name="T"/>
-	/// <br/>(class invariant: <see cref="INumericClosedIntervalContra{T}.Start"/> ≤ <see cref="INumericClosedIntervalContra{T}.EndInclusive"/>)
+	/// represents a half-open interval (a.k.a. range) of <typeparamref name="T"/>
+	/// <br/>(class invariant: <see cref="INumericHalfOpenIntervalContra{T}.Start"/> &lt; <see cref="INumericHalfOpenIntervalContra{T}.EndExclusive"/>)
 	/// </summary>
-	public interface INumericClosedInterval<T> : INumericClosedIntervalContra<T>,
-		IEquatable<INumericClosedIntervalContra<T>>
+	public interface INumericHalfOpenInterval<T> : INumericHalfOpenIntervalContra<T>,
+		IEquatable<INumericHalfOpenIntervalContra<T>>
 		where T : IComparable<T>
 	{
 		/// <summary>
@@ -23,56 +23,58 @@ namespace BizHawk.Common
 		bool Contains(in T value);
 	}
 
-	/// <summary>see <see cref="INumericClosedInterval{T}"/>; this is a type parameter variance hack</summary>
-	public interface INumericClosedIntervalContra<out T>
+	/// <summary>see <see cref="INumericHalfOpenInterval{T}"/>; this is a type parameter variance hack</summary>
+	public interface INumericHalfOpenIntervalContra<out T>
 	{
 		T Start { get; }
 
-		T EndInclusive { get; }
+		T EndExclusive { get; }
 	}
 
 	/// <summary>
-	/// represents a closed range (a.k.a. interval) of <see cref="int"><c>s32</c>s</see>
-	/// <br/>(class invariant: <see cref="NumericClosedRangeBase{T}.Start"/> ≤ <see cref="NumericClosedRangeBase{T}.EndInclusive"/>)
+	/// represents a half-open range (a.k.a. interval) of <see cref="int"><c>s32</c>s</see>
+	/// <br/>(class invariant: <see cref="NumericHalfOpenRangeBase{T}.Start"/> &lt; <see cref="NumericHalfOpenRangeBase{T}.EndExclusive"/>)
 	/// </summary>
 #pragma warning disable MA0077 // already implements `IEquatable<TSelf>`
-	public sealed class Int32ClosedRange : NumericClosedRangeBase<int>
+	public sealed class Int32HalfOpenRange : NumericHalfOpenRangeBase<int>
 #pragma warning restore MA0077
 	{
 		private string? _ser = null;
 
-		/// <inheritdoc cref="NumericClosedRangeBase{T}(T,T)"/>
-		public Int32ClosedRange(int start, int endInclusive)
-			: base(start, endInclusive) {}
+		public override int EndInclusive
+			=> EndExclusive - 1;
+
+		/// <inheritdoc cref="NumericHalfOpenRangeBase{T}(T,T)"/>
+		public Int32HalfOpenRange(int start, int endExclusive)
+			: base(start, endExclusive) {}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public override bool Contains(in int value)
-			=> Start <= value && value <= EndInclusive;
+			=> Start <= value && value < EndExclusive;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public bool Contains(int value)
-			=> Start <= value && value <= EndInclusive;
+			=> Start <= value && value < EndExclusive;
 
-		/// <remarks>beware integer overflow when this range spans every value</remarks>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public uint Count()
-			=> (uint) ((long) EndInclusive - Start) + 1U;
+			=> (uint) ((long) EndExclusive - Start);
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public bool Equals(Int32ClosedRange other)
-			=> Start == other.Start && EndInclusive == other.EndInclusive;
+		public bool Equals(Int32HalfOpenRange other)
+			=> Start == other.Start && EndExclusive == other.EndExclusive;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public override string ToString()
-			=> _ser ??= $"{Start}..={EndInclusive}";
+			=> _ser ??= $"{Start}..<{EndExclusive}";
 	}
 
 	/// <summary>
-	/// represents a closed range (a.k.a. interval) of <see cref="long"><c>s64</c>s</see>
-	/// <br/>(class invariant: <see cref="NumericClosedRangeBase{T}.Start"/> ≤ <see cref="NumericClosedRangeBase{T}.EndInclusive"/>)
+	/// represents a half-open range (a.k.a. interval) of <see cref="long"><c>s64</c>s</see>
+	/// <br/>(class invariant: <see cref="NumericHalfOpenRangeBase{T}.Start"/> &lt; <see cref="NumericHalfOpenRangeBase{T}.EndExclusive"/>)
 	/// </summary>
 #pragma warning disable MA0077 // already implements `IEquatable<TSelf>`
-	public sealed class Int64ClosedRange : NumericClosedRangeBase<long>
+	public sealed class Int64HalfOpenRange : NumericHalfOpenRangeBase<long>
 #pragma warning restore MA0077
 	{
 		private const ulong MIN_LONG_NEGATION_AS_ULONG = 9223372036854775808UL;
@@ -81,83 +83,88 @@ namespace BizHawk.Common
 
 		private string? _ser = null;
 
-		/// <inheritdoc cref="NumericClosedRangeBase{T}(T,T)"/>
-		public Int64ClosedRange(long start, long endInclusive)
-			: base(start, endInclusive) {}
+		public override long EndInclusive
+			=> EndExclusive - 1L;
+
+		/// <inheritdoc cref="NumericHalfOpenRangeBase{T}(T,T)"/>
+		public Int64HalfOpenRange(long start, long endExclusive)
+			: base(start, endExclusive) {}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public override bool Contains(in long value)
-			=> Start <= value && value <= EndInclusive;
+			=> Start <= value && value < EndExclusive;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public bool Contains(long value)
-			=> Start <= value && value <= EndInclusive;
+			=> Start <= value && value < EndExclusive;
 
-		/// <inheritdoc cref="Int32ClosedRange.Count"/>
 		public ulong Count()
 			=> _count ??= (Contains(0L)
-				? (Start is long.MinValue ? MIN_LONG_NEGATION_AS_ULONG : (ulong) -Start) + (ulong) EndInclusive
-				: (ulong) (EndInclusive - Start)
-			) + 1UL;
+				? (Start is long.MinValue ? MIN_LONG_NEGATION_AS_ULONG : (ulong) -Start) + (ulong) EndExclusive
+				: (ulong) (EndExclusive - Start));
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public bool Equals(Int64ClosedRange other)
-			=> Start == other.Start && EndInclusive == other.EndInclusive;
+		public bool Equals(Int64HalfOpenRange other)
+			=> Start == other.Start && EndExclusive == other.EndExclusive;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public override string ToString()
-			=> _ser ??= $"{Start}L..={EndInclusive}L";
+			=> _ser ??= $"{Start}L..<{EndExclusive}L";
 	}
 
-	/// <seealso cref="Int32ClosedRange"/>
-	/// <seealso cref="Int64ClosedRange"/>
-	public abstract class NumericClosedRangeBase<T> : INumericClosedInterval<T>
+	/// <seealso cref="Int32HalfOpenRange"/>
+	/// <seealso cref="Int64HalfOpenRange"/>
+	public abstract class NumericHalfOpenRangeBase<T> : INumericHalfOpenInterval<T>
 		where T : IComparable<T>
 	{
 		public T Start { get; }
 
-		public T EndInclusive { get; }
+		public T EndExclusive { get; }
 
-		/// <exception cref="ArgumentOutOfRangeException"><paramref name="endInclusive"/> &lt; <paramref name="start"/></exception>
-		protected NumericClosedRangeBase(T start, T endInclusive)
+		public abstract T EndInclusive { get; }
+
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="endExclusive"/> ≤ <paramref name="start"/> (empty ranges where <paramref name="start"/> = <paramref name="endExclusive"/> are not permitted)</exception>
+		protected NumericHalfOpenRangeBase(T start, T endExclusive)
 		{
-			if (endInclusive.CompareTo(start) < 0) throw new ArgumentOutOfRangeException(paramName: nameof(endInclusive), actualValue: endInclusive, message: "range end < start");
+			if (endExclusive.CompareTo(start) <= 0) throw new ArgumentOutOfRangeException(paramName: nameof(endExclusive), actualValue: endExclusive, message: "range end <= start");
 			Start = start;
-			EndInclusive = endInclusive;
+			EndExclusive = endExclusive;
 		}
 
 		public virtual void Clamp(ref T value)
 		{
 			if (Start.CompareTo(value) > 0) value = Start;
-			else if (EndInclusive.CompareTo(value) < 0) value = EndInclusive;
+			else if (EndExclusive.CompareTo(value) <= 0) value = EndInclusive;
 		}
 
 		public virtual bool Contains(in T value)
-			=> Start.CompareTo(value) <= 0 && EndInclusive.CompareTo(value) >= 0;
+			=> Start.CompareTo(value) <= 0 && EndExclusive.CompareTo(value) > 0;
 
-		public bool Equals(INumericClosedIntervalContra<T> other)
-			=> Start.CompareTo(other.Start) is 0 && EndInclusive.CompareTo(other.EndInclusive) is 0;
+		public bool Equals(INumericHalfOpenIntervalContra<T> other)
+			=> Start.CompareTo(other.Start) is 0 && EndExclusive.CompareTo(other.EndExclusive) is 0;
 
 		public override bool Equals(object? other)
-			=> other is INumericClosedIntervalContra<T> interval && Equals(interval);
+			=> other is INumericHalfOpenIntervalContra<T> interval && Equals(interval);
 
 		public override int GetHashCode()
-			=> HashCode.Combine(Start, EndInclusive);
+			=> HashCode.Combine(Start, EndExclusive);
 
 		public abstract override string ToString();
 	}
 
 	public static class RangeExtensions
 	{
-		private static ArithmeticException ExclusiveRangeMinValExc
-			=> new("exclusive range end is min value of integral type");
+		private const string ERR_MSG_EXCL_END_MIN_VAL = "exclusive range end is min. value of integral type";
+
+		private static OverflowException InclusiveRangeGTMaxValExc
+			=> new("inclusive range end is max. value of integral type");
 
 		/// <returns>
 		/// <paramref name="value"/> unchanged if it's contained in <paramref name="range"/>,
 		/// or else whichever bound of <paramref name="range"/> is closest to <paramref name="value"/>
 		/// </returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static T Clamp<T>(this INumericClosedInterval<T> range, T value)
+		public static T Clamp<T>(this INumericHalfOpenInterval<T> range, T value)
 			where T : IComparable<T>
 		{
 			range.Clamp(ref value);
@@ -169,7 +176,7 @@ namespace BizHawk.Common
 		/// or else whichever bound of <paramref name="range"/> is closest to <paramref name="value"/>
 		/// </returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static T ConstrainWithin<T>(this T value, INumericClosedInterval<T> range)
+		public static T ConstrainWithin<T>(this T value, INumericHalfOpenInterval<T> range)
 			where T : IComparable<T>
 		{
 			range.Clamp(ref value);
@@ -177,36 +184,41 @@ namespace BizHawk.Common
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Deconstruct<T>(this INumericClosedInterval<T> range, out T start, out T endInclusive)
+		public static void Deconstruct<T>(this INumericHalfOpenInterval<T> range, out T start, out T endExclusive)
 			where T : IComparable<T>
 		{
 			start = range.Start;
-			endInclusive = range.EndInclusive;
+			endExclusive = range.EndExclusive;
 		}
 
-		/// <inheritdoc cref="Int32ClosedRange(int,int)"/>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="endInclusive"/> &lt; <paramref name="start"/> (empty ranges are not permitted)</exception>
+		/// <exception cref="OverflowException"><paramref name="endInclusive"/> is <see cref="int.MaxValue"/> (it's incremented to be stored as an exclusive bound)</exception>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Int32ClosedRange RangeTo(this int start, int endInclusive)
-			=> new(start: start, endInclusive: endInclusive);
+		public static Int32HalfOpenRange RangeTo(this int start, int endInclusive)
+			=> endInclusive is int.MaxValue
+				? throw InclusiveRangeGTMaxValExc
+				: new(start: start, endExclusive: unchecked(endInclusive + 1));
 
-		/// <inheritdoc cref="Int64ClosedRange(long,long)"/>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="endInclusive"/> &lt; <paramref name="start"/> (empty ranges are not permitted)</exception>
+		/// <exception cref="OverflowException"><paramref name="endInclusive"/> is <see cref="long.MaxValue"/> (it's incremented to be stored as an exclusive bound)</exception>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Int64ClosedRange RangeTo(this long start, long endInclusive)
-			=> new(start: start, endInclusive: endInclusive);
+		public static Int64HalfOpenRange RangeTo(this long start, long endInclusive)
+			=> endInclusive is long.MaxValue
+				? throw InclusiveRangeGTMaxValExc
+				: new(start: start, endExclusive: unchecked(endInclusive + 1L));
 
-		/// <exception cref="ArgumentOutOfRangeException"><paramref name="endExclusive"/> ≤ <paramref name="start"/> (empty ranges where <paramref name="start"/> = <paramref name="endExclusive"/> are not permitted)</exception>
-		/// <exception cref="ArithmeticException"><paramref name="endExclusive"/> is min value of integral type (therefore <paramref name="endExclusive"/> ≤ <paramref name="start"/>)</exception>
+		/// <inheritdoc cref="Int32HalfOpenRange(int,int)"/>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Int32ClosedRange RangeToExclusive(this int start, int endExclusive)
+		public static Int32HalfOpenRange RangeToExclusive(this int start, int endExclusive)
 			=> endExclusive is int.MinValue
-				? throw ExclusiveRangeMinValExc
-				: new(start: start, endInclusive: endExclusive - 1);
+				? throw new ArgumentOutOfRangeException(paramName: nameof(endExclusive), endExclusive, message: ERR_MSG_EXCL_END_MIN_VAL)
+				: new(start: start, endExclusive: endExclusive);
 
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
+		/// <inheritdoc cref="Int64HalfOpenRange(long,long)"/>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Int64ClosedRange RangeToExclusive(this long start, long endExclusive)
+		public static Int64HalfOpenRange RangeToExclusive(this long start, long endExclusive)
 			=> endExclusive is long.MinValue
-				? throw ExclusiveRangeMinValExc
-				: new(start: start, endInclusive: endExclusive - 1L);
+				? throw new ArgumentOutOfRangeException(paramName: nameof(endExclusive), endExclusive, message: ERR_MSG_EXCL_END_MIN_VAL)
+				: new(start: start, endExclusive: endExclusive);
 	}
 }

--- a/src/BizHawk.Common/Ranges.cs
+++ b/src/BizHawk.Common/Ranges.cs
@@ -1,8 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-
-using BizHawk.Common.NumberExtensions;
-
 namespace BizHawk.Common
 {
 	/// <summary>represents a closed range of <typeparamref name="T"/> (class invariant: <see cref="Start"/> ≤ <see cref="EndInclusive"/>)</summary>
@@ -15,35 +10,23 @@ namespace BizHawk.Common
 		T EndInclusive { get; }
 	}
 
-	/// <summary>represents a closed range of <typeparamref name="T"/> which can be grown or shrunk (class invariant: <see cref="Start"/> ≤ <see cref="EndInclusive"/>)</summary>
-	public class MutableRange<T> : Range<T> where T : unmanaged, IComparable<T>
+	internal class MutableRange<T> : Range<T> where T : unmanaged, IComparable<T>
 	{
 		private (T Start, T EndInclusive) r;
 
-		/// <inheritdoc cref="Overwrite"/>
-		internal MutableRange(T start, T endInclusive) => Overwrite(start, endInclusive);
-
-		/// <exception cref="ArgumentOutOfRangeException">(from setter) <paramref name="value"/> > <see cref="EndInclusive"/></exception>
 		public T Start
 		{
 			get => r.Start;
-			set => r.Start = r.EndInclusive.CompareTo(value) < 0
-				? throw new ArgumentOutOfRangeException(nameof(value), value, "attempted to set start > end")
-				: value;
 		}
 
-		/// <exception cref="ArgumentOutOfRangeException">(from setter) <paramref name="value"/> &lt; <see cref="Start"/></exception>
 		public T EndInclusive
 		{
 			get => r.EndInclusive;
-			set => r.EndInclusive = value.CompareTo(r.Start) < 0
-				? throw new ArgumentOutOfRangeException(nameof(value), value, "attempted to set end < start")
-				: value;
 		}
 
 		/// <exception cref="ArgumentException"><typeparamref name="T"/> is <see langword="float"/>/<see langword="double"/> and either bound is <see cref="float.NaN"/></exception>
 		/// <exception cref="ArgumentOutOfRangeException"><paramref name="endInclusive"/> &lt; <paramref name="start"/></exception>
-		public void Overwrite(T start, T endInclusive)
+		internal MutableRange(T start, T endInclusive)
 		{
 			if (endInclusive.CompareTo(start) < 0) throw new ArgumentOutOfRangeException(nameof(endInclusive), endInclusive, "range end < start");
 			if (start is float fs)
@@ -62,8 +45,7 @@ namespace BizHawk.Common
 
 	/// <summary>contains most of the logic for ranges</summary>
 	/// <remarks>
-	/// non-generic overloads are used where the method requires an increment or decrement<br/>
-	/// TODO which Enumerate algorithm is faster - <c>yield return</c> in loop or <see cref="Enumerable.Range"/>?
+	/// non-generic overloads are used where the method requires an increment or decrement
 	/// </remarks>
 	public static class RangeExtensions
 	{
@@ -82,8 +64,6 @@ namespace BizHawk.Common
 		/// <returns>true iff <paramref name="value"/> is contained in <paramref name="range"/> (<paramref name="value"/> is considered to be in the range if it's exactly equal to either bound)</returns>
 		public static bool Contains<T>(this Range<T> range, T value) where T : unmanaged, IComparable<T> => !(value.CompareTo(range.Start) < 0 || range.EndInclusive.CompareTo(value) < 0);
 
-		public static uint Count(this Range<byte> range) => (uint) (range.EndInclusive - range.Start + 1);
-
 		/// <remarks>beware integer overflow when <paramref name="range"/> contains every value</remarks>
 		public static uint Count(this Range<int> range) => (uint) ((long) range.EndInclusive - range.Start) + 1U;
 
@@ -93,137 +73,21 @@ namespace BizHawk.Common
 			: (ulong) (range.EndInclusive - range.Start)
 		) + 1UL;
 
-		public static uint Count(this Range<sbyte> range) => (uint) (range.EndInclusive - range.Start + 1);
-
-		public static uint Count(this Range<short> range) => (uint) (range.EndInclusive - range.Start + 1);
-
-		/// <inheritdoc cref="Count(Range{int})"/>
-		public static uint Count(this Range<uint> range) => range.EndInclusive - range.Start + 1U;
-
-		/// <inheritdoc cref="Count(Range{int})"/>
-		public static ulong Count(this Range<ulong> range) => range.EndInclusive - range.Start + 1UL;
-
-		public static uint Count(this Range<ushort> range) => (uint) (range.EndInclusive - range.Start + 1);
-
-		public static void Deconstruct<T>(this Range<T> range, out T start, out T endInclusive)
-			where T : unmanaged, IComparable<T>
-		{
-			start = range.Start;
-			endInclusive = range.EndInclusive;
-		}
-
-		public static IEnumerable<byte> Enumerate(this Range<byte> range) => Enumerable.Range(range.Start, (int) range.Count()).Select(i => (byte) i);
-
-		/// <inheritdoc cref="Enumerate(Range{float},float)"/>
-		public static IEnumerable<double> Enumerate(this Range<double> range, double step)
-		{
-			var d = range.Start;
-			while (d < range.EndInclusive)
-			{
-				yield return d;
-				d += step;
-			}
-			if (d.HawkFloatEquality(range.EndInclusive)) yield return d;
-		}
-
-		/// <remarks>beware precision errors</remarks>
-		public static IEnumerable<float> Enumerate(this Range<float> range, float step)
-		{
-			var f = range.Start;
-			while (f < range.EndInclusive)
-			{
-				yield return f;
-				f += step;
-			}
-			if (f.HawkFloatEquality(range.EndInclusive)) yield return f;
-		}
-
-		public static IEnumerable<int> Enumerate(this Range<int> range)
-		{
-			var i = range.Start;
-			while (i < range.EndInclusive) yield return i++;
-			yield return i;
-		}
-
-		public static IEnumerable<long> Enumerate(this Range<long> range)
-		{
-			var l = range.Start;
-			while (l < range.EndInclusive) yield return l++;
-			yield return l;
-		}
-
-		public static IEnumerable<sbyte> Enumerate(this Range<sbyte> range) => Enumerable.Range(range.Start, (int) range.Count()).Select(i => (sbyte) i);
-
-		public static IEnumerable<short> Enumerate(this Range<short> range) => Enumerable.Range(range.Start, (int) range.Count()).Select(i => (short) i);
-
-		public static IEnumerable<uint> Enumerate(this Range<uint> range)
-		{
-			var i = range.Start;
-			while (i < range.EndInclusive) yield return i++;
-			yield return i;
-		}
-
-		public static IEnumerable<ulong> Enumerate(this Range<ulong> range)
-		{
-			var l = range.Start;
-			while (l < range.EndInclusive) yield return l++;
-			yield return l;
-		}
-
-		public static IEnumerable<ushort> Enumerate(this Range<ushort> range) => Enumerable.Range(range.Start, (int) range.Count()).Select(i => (ushort) i);
-
-		public static Range<T> GetImmutableCopy<T>(this Range<T> range) where T : unmanaged, IComparable<T> => GetMutableCopy(range);
-
-		public static MutableRange<T> GetMutableCopy<T>(this Range<T> range) where T : unmanaged, IComparable<T> => new MutableRange<T>(range.Start, range.EndInclusive);
-
 		/// <inheritdoc cref="MutableRange{T}(T,T)"/>
-		public static MutableRange<T> MutableRangeTo<T>(this T start, T endInclusive) where T : unmanaged, IComparable<T> => new MutableRange<T>(start, endInclusive);
+		private static MutableRange<T> MutableRangeTo<T>(this T start, T endInclusive) where T : unmanaged, IComparable<T> => new MutableRange<T>(start, endInclusive);
 
 		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static MutableRange<byte> MutableRangeToExclusive(this byte start, byte endExclusive) => endExclusive == byte.MinValue
-			? throw ExclusiveRangeMinValExc
-			: new MutableRange<byte>(start, (byte) (endExclusive - 1U));
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static MutableRange<int> MutableRangeToExclusive(this int start, int endExclusive) => endExclusive == int.MinValue
+		private static MutableRange<int> MutableRangeToExclusive(this int start, int endExclusive) => endExclusive == int.MinValue
 			? throw ExclusiveRangeMinValExc
 			: new MutableRange<int>(start, endExclusive - 1);
 
 		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static MutableRange<long> MutableRangeToExclusive(this long start, long endExclusive) => endExclusive == long.MinValue
+		private static MutableRange<long> MutableRangeToExclusive(this long start, long endExclusive) => endExclusive == long.MinValue
 			? throw ExclusiveRangeMinValExc
 			: new MutableRange<long>(start, endExclusive - 1L);
 
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static MutableRange<sbyte> MutableRangeToExclusive(this sbyte start, sbyte endExclusive) => endExclusive == sbyte.MinValue
-			? throw ExclusiveRangeMinValExc
-			: new MutableRange<sbyte>(start, (sbyte) (endExclusive - 1));
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static MutableRange<short> MutableRangeToExclusive(this short start, short endExclusive) => endExclusive == short.MinValue
-			? throw ExclusiveRangeMinValExc
-			: new MutableRange<short>(start, (short) (endExclusive - 1));
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static MutableRange<uint> MutableRangeToExclusive(this uint start, uint endExclusive) => endExclusive == uint.MinValue
-			? throw ExclusiveRangeMinValExc
-			: new MutableRange<uint>(start, endExclusive - 1U);
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static MutableRange<ulong> MutableRangeToExclusive(this ulong start, ulong endExclusive) => endExclusive == ulong.MinValue
-			? throw ExclusiveRangeMinValExc
-			: new MutableRange<ulong>(start, endExclusive - 1UL);
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static MutableRange<ushort> MutableRangeToExclusive(this ushort start, ushort endExclusive) => endExclusive == ushort.MinValue
-			? throw ExclusiveRangeMinValExc
-			: new MutableRange<ushort>(start, (ushort) (endExclusive - 1U));
-
 		/// <inheritdoc cref="MutableRange{T}(T,T)"/>
 		public static Range<T> RangeTo<T>(this T start, T endInclusive) where T : unmanaged, IComparable<T> => start.MutableRangeTo(endInclusive);
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static Range<byte> RangeToExclusive(this byte start, byte endExclusive) => MutableRangeToExclusive(start, endExclusive);
 
 		/// <exception cref="ArgumentOutOfRangeException"><paramref name="endExclusive"/> ≤ <paramref name="start"/> (empty ranges where <paramref name="start"/> = <paramref name="endExclusive"/> are not permitted)</exception>
 		/// <exception cref="ArithmeticException"><paramref name="endExclusive"/> is min value of integral type (therefore <paramref name="endExclusive"/> ≤ <paramref name="start"/>)</exception>
@@ -231,20 +95,5 @@ namespace BizHawk.Common
 
 		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
 		public static Range<long> RangeToExclusive(this long start, long endExclusive) => MutableRangeToExclusive(start, endExclusive);
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static Range<sbyte> RangeToExclusive(this sbyte start, sbyte endExclusive) => MutableRangeToExclusive(start, endExclusive);
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static Range<short> RangeToExclusive(this short start, short endExclusive) => MutableRangeToExclusive(start, endExclusive);
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static Range<uint> RangeToExclusive(this uint start, uint endExclusive) => MutableRangeToExclusive(start, endExclusive);
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static Range<ulong> RangeToExclusive(this ulong start, ulong endExclusive) => MutableRangeToExclusive(start, endExclusive);
-
-		/// <inheritdoc cref="RangeToExclusive(int,int)"/>
-		public static Range<ushort> RangeToExclusive(this ushort start, ushort endExclusive) => MutableRangeToExclusive(start, endExclusive);
 	}
 }

--- a/src/BizHawk.Emulation.Common/Base Implementations/Axes/AxisSpec.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/Axes/AxisSpec.cs
@@ -35,9 +35,9 @@ namespace BizHawk.Emulation.Common
 
 		public string? PairedAxis => Constraint?.PairedAxis;
 
-		public readonly Range<int> Range;
+		public readonly Int32ClosedRange Range;
 
-		public AxisSpec(Range<int> range, int neutral, bool isReversed = false, AxisConstraint? constraint = null)
+		public AxisSpec(Int32ClosedRange range, int neutral, bool isReversed = false, AxisConstraint? constraint = null)
 		{
 			Constraint = constraint;
 			IsReversed = isReversed;

--- a/src/BizHawk.Emulation.Common/Base Implementations/Axes/AxisSpec.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/Axes/AxisSpec.cs
@@ -35,9 +35,9 @@ namespace BizHawk.Emulation.Common
 
 		public string? PairedAxis => Constraint?.PairedAxis;
 
-		public readonly Int32ClosedRange Range;
+		public readonly Int32HalfOpenRange Range;
 
-		public AxisSpec(Int32ClosedRange range, int neutral, bool isReversed = false, AxisConstraint? constraint = null)
+		public AxisSpec(Int32HalfOpenRange range, int neutral, bool isReversed = false, AxisConstraint? constraint = null)
 		{
 			Constraint = constraint;
 			IsReversed = isReversed;
@@ -55,7 +55,7 @@ namespace BizHawk.Emulation.Common
 			=> obj is AxisSpec other && Equals(other);
 
 		public override int GetHashCode()
-			=> HashCode.Combine(Range.Start, Range.EndInclusive, Neutral, IsReversed, Constraint);
+			=> HashCode.Combine(Range.Start, Range.EndExclusive, Neutral, IsReversed, Constraint);
 
 		public override string ToString()
 		{

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -89,7 +89,7 @@ namespace BizHawk.Emulation.Common
 			PokeByte(addr + 3, scratch[3]);
 		}
 
-		public virtual void BulkPeekByte(Range<long> addresses, byte[] values)
+		public virtual void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
 		{
 			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 			if (values is null) throw new ArgumentNullException(paramName: nameof(values));
@@ -104,7 +104,7 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
-		public virtual void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
+		public virtual void BulkPeekUshort(Int64ClosedRange addresses, bool bigEndian, ushort[] values)
 		{
 			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 			if (values is null) throw new ArgumentNullException(paramName: nameof(values));
@@ -123,7 +123,7 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
-		public virtual void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+		public virtual void BulkPeekUint(Int64ClosedRange addresses, bool bigEndian, uint[] values)
 		{
 			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 			if (values is null) throw new ArgumentNullException(paramName: nameof(values));

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -89,7 +89,7 @@ namespace BizHawk.Emulation.Common
 			PokeByte(addr + 3, scratch[3]);
 		}
 
-		public virtual void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
+		public virtual void BulkPeekByte(Int64HalfOpenRange addresses, byte[] values)
 		{
 			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 			if (values is null) throw new ArgumentNullException(paramName: nameof(values));
@@ -97,20 +97,20 @@ namespace BizHawk.Emulation.Common
 
 			using (this.EnterExit())
 			{
-				for (var i = addresses.Start; i <= addresses.EndInclusive; i++)
+				for (var i = addresses.Start; i < addresses.EndExclusive; i++)
 				{
 					values[i - addresses.Start] = PeekByte(i);
 				}
 			}
 		}
 
-		public virtual void BulkPeekUshort(Int64ClosedRange addresses, bool bigEndian, ushort[] values)
+		public virtual void BulkPeekUshort(Int64HalfOpenRange addresses, bool bigEndian, ushort[] values)
 		{
 			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 			if (values is null) throw new ArgumentNullException(paramName: nameof(values));
 
 			var start = addresses.Start;
-			var end = addresses.EndInclusive + 1;
+			var end = addresses.EndExclusive;
 			if ((start & 0b1) is not 0 || (end & 0b1) is not 0) throw new InvalidOperationException(ERR_MSG_UNALIGNED);
 			if (values.LongLength * sizeof(ushort) != end - start) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE); // a longer array could be valid, but nothing needs that so don't support it for now
 
@@ -123,13 +123,13 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
-		public virtual void BulkPeekUint(Int64ClosedRange addresses, bool bigEndian, uint[] values)
+		public virtual void BulkPeekUint(Int64HalfOpenRange addresses, bool bigEndian, uint[] values)
 		{
 			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 			if (values is null) throw new ArgumentNullException(paramName: nameof(values));
 
 			var start = addresses.Start;
-			var end = addresses.EndInclusive + 1;
+			var end = addresses.EndExclusive;
 			if ((start & 0b11) is not 0 || (end & 0b11) is not 0) throw new InvalidOperationException(ERR_MSG_UNALIGNED);
 			if (values.LongLength * sizeof(uint) != end - start) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE); // `!=` not `<`, per `BulkPeekUshort`
 

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
@@ -11,9 +11,11 @@ namespace BizHawk.Emulation.Common
 		private Action<long, byte> _poke;
 
 		// TODO: use an array of Ranges
-		private Action<Range<long>, byte[]> _bulkPeekByte { get; set; }
-		private Action<Range<long>, bool, ushort[]> _bulkPeekUshort { get; set; }
-		private Action<Range<long>, bool, uint[]> _bulkPeekUint { get; set; }
+		private Action<Int64ClosedRange, byte[]> _bulkPeekByte { get; set; }
+
+		private Action<Int64ClosedRange, bool, ushort[]> _bulkPeekUshort { get; set; }
+
+		private Action<Int64ClosedRange, bool, uint[]> _bulkPeekUint { get; set; }
 
 		public Func<long, byte> Peek { get; set; }
 
@@ -37,7 +39,7 @@ namespace BizHawk.Emulation.Common
 			_poke?.Invoke(addr, val);
 		}
 
-		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
 		{
 			if (_bulkPeekByte != null)
 			{
@@ -49,7 +51,7 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
-		public override void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
+		public override void BulkPeekUshort(Int64ClosedRange addresses, bool bigEndian, ushort[] values)
 		{
 			if (_bulkPeekUshort != null)
 			{
@@ -61,7 +63,7 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
-		public override void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+		public override void BulkPeekUint(Int64ClosedRange addresses, bool bigEndian, uint[] values)
 		{
 			if (_bulkPeekUint != null)
 			{
@@ -80,9 +82,9 @@ namespace BizHawk.Emulation.Common
 			Func<long, byte> peek,
 			Action<long, byte> poke,
 			int wordSize,
-			Action<Range<long>, byte[]> bulkPeekByte = null,
-			Action<Range<long>, bool, ushort[]> bulkPeekUshort = null,
-			Action<Range<long>, bool, uint[]> bulkPeekUint = null)
+			Action<Int64ClosedRange, byte[]> bulkPeekByte = null,
+			Action<Int64ClosedRange, bool, ushort[]> bulkPeekUshort = null,
+			Action<Int64ClosedRange, bool, uint[]> bulkPeekUint = null)
 		{
 			Name = name;
 			EndianType = endian;
@@ -210,7 +212,7 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
-		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
 		{
 			var start = (ulong)addresses.Start;
 			var count = addresses.Count();

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
@@ -11,11 +11,11 @@ namespace BizHawk.Emulation.Common
 		private Action<long, byte> _poke;
 
 		// TODO: use an array of Ranges
-		private Action<Int64ClosedRange, byte[]> _bulkPeekByte { get; set; }
+		private Action<Int64HalfOpenRange, byte[]> _bulkPeekByte { get; set; }
 
-		private Action<Int64ClosedRange, bool, ushort[]> _bulkPeekUshort { get; set; }
+		private Action<Int64HalfOpenRange, bool, ushort[]> _bulkPeekUshort { get; set; }
 
-		private Action<Int64ClosedRange, bool, uint[]> _bulkPeekUint { get; set; }
+		private Action<Int64HalfOpenRange, bool, uint[]> _bulkPeekUint { get; set; }
 
 		public Func<long, byte> Peek { get; set; }
 
@@ -39,7 +39,7 @@ namespace BizHawk.Emulation.Common
 			_poke?.Invoke(addr, val);
 		}
 
-		public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
+		public override void BulkPeekByte(Int64HalfOpenRange addresses, byte[] values)
 		{
 			if (_bulkPeekByte != null)
 			{
@@ -51,7 +51,7 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
-		public override void BulkPeekUshort(Int64ClosedRange addresses, bool bigEndian, ushort[] values)
+		public override void BulkPeekUshort(Int64HalfOpenRange addresses, bool bigEndian, ushort[] values)
 		{
 			if (_bulkPeekUshort != null)
 			{
@@ -63,7 +63,7 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
-		public override void BulkPeekUint(Int64ClosedRange addresses, bool bigEndian, uint[] values)
+		public override void BulkPeekUint(Int64HalfOpenRange addresses, bool bigEndian, uint[] values)
 		{
 			if (_bulkPeekUint != null)
 			{
@@ -82,9 +82,9 @@ namespace BizHawk.Emulation.Common
 			Func<long, byte> peek,
 			Action<long, byte> poke,
 			int wordSize,
-			Action<Int64ClosedRange, byte[]> bulkPeekByte = null,
-			Action<Int64ClosedRange, bool, ushort[]> bulkPeekUshort = null,
-			Action<Int64ClosedRange, bool, uint[]> bulkPeekUint = null)
+			Action<Int64HalfOpenRange, byte[]> bulkPeekByte = null,
+			Action<Int64HalfOpenRange, bool, ushort[]> bulkPeekUshort = null,
+			Action<Int64HalfOpenRange, bool, uint[]> bulkPeekUint = null)
 		{
 			Name = name;
 			EndianType = endian;
@@ -212,7 +212,7 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
-		public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
+		public override void BulkPeekByte(Int64HalfOpenRange addresses, byte[] values)
 		{
 			var start = (ulong)addresses.Start;
 			var count = addresses.Count();

--- a/src/BizHawk.Emulation.Common/Extensions.cs
+++ b/src/BizHawk.Emulation.Common/Extensions.cs
@@ -441,7 +441,13 @@ namespace BizHawk.Emulation.Common
 		/// </summary>
 		/// <param name="constraint">pass only for one axis in a pair, by convention the X axis</param>
 		/// <returns>identical reference to <paramref name="def"/>; the object is mutated</returns>
-		public static ControllerDefinition AddAxis(this ControllerDefinition def, string name, Range<int> range, int neutral, bool isReversed = false, AxisConstraint constraint = null)
+		public static ControllerDefinition AddAxis(
+			this ControllerDefinition def,
+			string name,
+			Int32ClosedRange range,
+			int neutral,
+			bool isReversed = false,
+			AxisConstraint constraint = null)
 		{
 			def.Axes.Add(name, new AxisSpec(range, neutral, isReversed, constraint));
 			return def;
@@ -453,7 +459,15 @@ namespace BizHawk.Emulation.Common
 		/// </summary>
 		/// <param name="nameFormat">format string e.g. <c>"P1 Left {0}"</c> (will be used to interpolate <c>"X"</c> and <c>"Y"</c>)</param>
 		/// <returns>identical reference to <paramref name="def"/>; the object is mutated</returns>
-		public static ControllerDefinition AddXYPair(this ControllerDefinition def, string nameFormat, AxisPairOrientation pDir, Range<int> rangeX, int neutralX, Range<int> rangeY, int neutralY, AxisConstraint constraint = null)
+		public static ControllerDefinition AddXYPair(
+			this ControllerDefinition def,
+			string nameFormat,
+			AxisPairOrientation pDir,
+			Int32ClosedRange rangeX,
+			int neutralX,
+			Int32ClosedRange rangeY,
+			int neutralY,
+			AxisConstraint constraint = null)
 		{
 			var yAxisName = string.Format(nameFormat, "Y");
 			var finalConstraint = constraint ?? new NoOpAxisConstraint(yAxisName);
@@ -467,8 +481,14 @@ namespace BizHawk.Emulation.Common
 		/// </summary>
 		/// <param name="nameFormat">format string e.g. <c>"P1 Left {0}"</c> (will be used to interpolate <c>"X"</c> and <c>"Y"</c>)</param>
 		/// <returns>identical reference to <paramref name="def"/>; the object is mutated</returns>
-		public static ControllerDefinition AddXYPair(this ControllerDefinition def, string nameFormat, AxisPairOrientation pDir, Range<int> rangeBoth, int neutralBoth, AxisConstraint constraint = null)
-			=> def.AddXYPair(nameFormat, pDir, rangeBoth, neutralBoth, rangeBoth, neutralBoth, constraint);
+		public static ControllerDefinition AddXYPair(
+			this ControllerDefinition def,
+			string nameFormat,
+			AxisPairOrientation pDir,
+			Int32ClosedRange rangeBoth,
+			int neutralBoth,
+			AxisConstraint constraint = null)
+				=> def.AddXYPair(nameFormat, pDir, rangeBoth, neutralBoth, rangeBoth, neutralBoth, constraint);
 
 		/// <summary>
 		/// Adds an X/Y/Z triple of axes to the receiver <see cref="ControllerDefinition"/>, and returns it.
@@ -476,12 +496,13 @@ namespace BizHawk.Emulation.Common
 		/// </summary>
 		/// <param name="nameFormat">format string e.g. <c>"P1 Tilt {0}"</c> (will be used to interpolate <c>"X"</c>, <c>"Y"</c>, and <c>"Z"</c>)</param>
 		/// <returns>identical reference to <paramref name="def"/>; the object is mutated</returns>
-		public static ControllerDefinition AddXYZTriple(this ControllerDefinition def, string nameFormat, Range<int> rangeAll, int neutralAll)
+		public static ControllerDefinition AddXYZTriple(this ControllerDefinition def, string nameFormat, Int32ClosedRange rangeAll, int neutralAll)
 			=> def.AddAxis(string.Format(nameFormat, "X"), rangeAll, neutralAll)
 				.AddAxis(string.Format(nameFormat, "Y"), rangeAll, neutralAll)
 				.AddAxis(string.Format(nameFormat, "Z"), rangeAll, neutralAll);
 
-		public static AxisSpec With(this in AxisSpec spec, Range<int> range, int neutral) => new AxisSpec(range, neutral, spec.IsReversed, spec.Constraint);
+		public static AxisSpec With(this in AxisSpec spec, Int32ClosedRange range, int neutral)
+			=> new(range, neutral, spec.IsReversed, spec.Constraint);
 
 #pragma warning disable RCS1224 // don't want extension on nonspecific `string`
 		public static string SystemIDToDisplayName(string sysID)

--- a/src/BizHawk.Emulation.Common/Extensions.cs
+++ b/src/BizHawk.Emulation.Common/Extensions.cs
@@ -444,7 +444,7 @@ namespace BizHawk.Emulation.Common
 		public static ControllerDefinition AddAxis(
 			this ControllerDefinition def,
 			string name,
-			Int32ClosedRange range,
+			Int32HalfOpenRange range,
 			int neutral,
 			bool isReversed = false,
 			AxisConstraint constraint = null)
@@ -463,9 +463,9 @@ namespace BizHawk.Emulation.Common
 			this ControllerDefinition def,
 			string nameFormat,
 			AxisPairOrientation pDir,
-			Int32ClosedRange rangeX,
+			Int32HalfOpenRange rangeX,
 			int neutralX,
-			Int32ClosedRange rangeY,
+			Int32HalfOpenRange rangeY,
 			int neutralY,
 			AxisConstraint constraint = null)
 		{
@@ -485,7 +485,7 @@ namespace BizHawk.Emulation.Common
 			this ControllerDefinition def,
 			string nameFormat,
 			AxisPairOrientation pDir,
-			Int32ClosedRange rangeBoth,
+			Int32HalfOpenRange rangeBoth,
 			int neutralBoth,
 			AxisConstraint constraint = null)
 				=> def.AddXYPair(nameFormat, pDir, rangeBoth, neutralBoth, rangeBoth, neutralBoth, constraint);
@@ -496,12 +496,12 @@ namespace BizHawk.Emulation.Common
 		/// </summary>
 		/// <param name="nameFormat">format string e.g. <c>"P1 Tilt {0}"</c> (will be used to interpolate <c>"X"</c>, <c>"Y"</c>, and <c>"Z"</c>)</param>
 		/// <returns>identical reference to <paramref name="def"/>; the object is mutated</returns>
-		public static ControllerDefinition AddXYZTriple(this ControllerDefinition def, string nameFormat, Int32ClosedRange rangeAll, int neutralAll)
+		public static ControllerDefinition AddXYZTriple(this ControllerDefinition def, string nameFormat, Int32HalfOpenRange rangeAll, int neutralAll)
 			=> def.AddAxis(string.Format(nameFormat, "X"), rangeAll, neutralAll)
 				.AddAxis(string.Format(nameFormat, "Y"), rangeAll, neutralAll)
 				.AddAxis(string.Format(nameFormat, "Z"), rangeAll, neutralAll);
 
-		public static AxisSpec With(this in AxisSpec spec, Int32ClosedRange range, int neutral)
+		public static AxisSpec With(this in AxisSpec spec, Int32HalfOpenRange range, int neutral)
 			=> new(range, neutral, spec.IsReversed, spec.Constraint);
 
 #pragma warning disable RCS1224 // don't want extension on nonspecific `string`

--- a/src/BizHawk.Emulation.Cores/Computers/Doom/DSDA.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Doom/DSDA.IMemoryDomains.cs
@@ -207,7 +207,7 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				}
 			}
 
-			public override void BulkPeekByte(Range<long> addresses, byte[] values)
+			public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
 			{
 				if (addresses is null)
 					throw new ArgumentNullException(paramName: nameof(addresses));
@@ -222,7 +222,7 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				BulkPeekByte((uint) addresses.Start, values);
 			}
 
-			public override void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
+			public override void BulkPeekUshort(Int64ClosedRange addresses, bool bigEndian, ushort[] values)
 			{
 				if (addresses is null)
 					throw new ArgumentNullException(paramName: nameof(addresses));
@@ -252,7 +252,7 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				}
 			}
 
-			public override void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+			public override void BulkPeekUint(Int64ClosedRange addresses, bool bigEndian, uint[] values)
 			{
 				if (addresses is null)
 					throw new ArgumentNullException(paramName: nameof(addresses));

--- a/src/BizHawk.Emulation.Cores/Computers/Doom/DSDA.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Doom/DSDA.IMemoryDomains.cs
@@ -207,7 +207,7 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				}
 			}
 
-			public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
+			public override void BulkPeekByte(Int64HalfOpenRange addresses, byte[] values)
 			{
 				if (addresses is null)
 					throw new ArgumentNullException(paramName: nameof(addresses));
@@ -222,7 +222,7 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				BulkPeekByte((uint) addresses.Start, values);
 			}
 
-			public override void BulkPeekUshort(Int64ClosedRange addresses, bool bigEndian, ushort[] values)
+			public override void BulkPeekUshort(Int64HalfOpenRange addresses, bool bigEndian, ushort[] values)
 			{
 				if (addresses is null)
 					throw new ArgumentNullException(paramName: nameof(addresses));
@@ -230,7 +230,7 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 					throw new ArgumentNullException(paramName: nameof(values));
 
 				var start = addresses.Start;
-				var end = addresses.EndInclusive + 1;
+				var end = addresses.EndExclusive;
 
 				if ((start & 1) != 0 || (end & 1) != 0)
 					throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");
@@ -252,7 +252,7 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				}
 			}
 
-			public override void BulkPeekUint(Int64ClosedRange addresses, bool bigEndian, uint[] values)
+			public override void BulkPeekUint(Int64HalfOpenRange addresses, bool bigEndian, uint[] values)
 			{
 				if (addresses is null)
 					throw new ArgumentNullException(paramName: nameof(addresses));
@@ -260,7 +260,7 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 					throw new ArgumentNullException(paramName: nameof(values));
 
 				var start = addresses.Start;
-				var end = addresses.EndInclusive + 1;
+				var end = addresses.EndExclusive;
 
 				if ((start & 3) != 0 || (end & 3) != 0)
 					throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/3DS/Encore.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/3DS/Encore.IMemoryDomains.cs
@@ -201,7 +201,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				}
 			}
 
-			public override void BulkPeekByte(Range<long> addresses, byte[] values)
+			public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
 			{
 				if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 				if (values is null) throw new ArgumentNullException(paramName: nameof(values));
@@ -214,7 +214,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				BulkPeekByte((uint)addresses.Start, values);
 			}
 
-			public override void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
+			public override void BulkPeekUshort(Int64ClosedRange addresses, bool bigEndian, ushort[] values)
 			{
 				if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 				if (values is null) throw new ArgumentNullException(paramName: nameof(values));
@@ -242,7 +242,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				}
 			}
 
-			public override void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+			public override void BulkPeekUint(Int64ClosedRange addresses, bool bigEndian, uint[] values)
 			{
 				if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 				if (values is null) throw new ArgumentNullException(paramName: nameof(values));

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/3DS/Encore.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/3DS/Encore.IMemoryDomains.cs
@@ -201,7 +201,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				}
 			}
 
-			public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
+			public override void BulkPeekByte(Int64HalfOpenRange addresses, byte[] values)
 			{
 				if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 				if (values is null) throw new ArgumentNullException(paramName: nameof(values));
@@ -214,13 +214,13 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				BulkPeekByte((uint)addresses.Start, values);
 			}
 
-			public override void BulkPeekUshort(Int64ClosedRange addresses, bool bigEndian, ushort[] values)
+			public override void BulkPeekUshort(Int64HalfOpenRange addresses, bool bigEndian, ushort[] values)
 			{
 				if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 				if (values is null) throw new ArgumentNullException(paramName: nameof(values));
 
 				var start = addresses.Start;
-				var end = addresses.EndInclusive + 1;
+				var end = addresses.EndExclusive;
 
 				if ((start & 1) != 0 || (end & 1) != 0)
 					throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");
@@ -242,13 +242,13 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				}
 			}
 
-			public override void BulkPeekUint(Int64ClosedRange addresses, bool bigEndian, uint[] values)
+			public override void BulkPeekUint(Int64HalfOpenRange addresses, bool bigEndian, uint[] values)
 			{
 				if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 				if (values is null) throw new ArgumentNullException(paramName: nameof(values));
 
 				var start = addresses.Start;
-				var end = addresses.EndInclusive + 1;
+				var end = addresses.EndExclusive;
 
 				if ((start & 3) != 0 || (end & 3) != 0)
 					throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");

--- a/src/BizHawk.Emulation.Cores/Consoles/PC Engine/VPC.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/PC Engine/VPC.cs
@@ -355,15 +355,13 @@ namespace BizHawk.Emulation.Cores.PCEngine
 			// clear inter-sprite priority buffer
 			Array.Clear(InterSpritePriorityBuffer, 0, FrameWidth);
 
-			var testRange = 0.MutableRangeTo(vdc.ActiveLine + 1);
 			for (int i = 0; i < 64; i++)
 			{
 				int y = (vdc.SpriteAttributeTable[(i * 4) + 0] & 1023) - 64;
 				int x = (vdc.SpriteAttributeTable[(i * 4) + 1] & 1023) - 32;
 				ushort flags = vdc.SpriteAttributeTable[(i * 4) + 3];
 				byte height = heightTable[(flags >> 12) & 3];
-				testRange.Start = vdc.ActiveLine - height;
-				if (!y.StrictlyBoundedBy(testRange)) continue;
+				if (vdc.ActiveLine < y || y + height <= vdc.ActiveLine) continue;
 
 				int patternNo = (((vdc.SpriteAttributeTable[(i * 4) + 2]) >> 1) & 0x1FF);
 				int paletteBase = 256 + ((flags & 15) * 16);

--- a/src/BizHawk.Emulation.Cores/Waterbox/WaterboxMemoryDomain.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/WaterboxMemoryDomain.cs
@@ -102,7 +102,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			}
 		}
 
-		public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
+		public override void BulkPeekByte(Int64HalfOpenRange addresses, byte[] values)
 		{
 			if (_addressMangler != 0)
 			{
@@ -219,7 +219,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			}
 		}
 
-		public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
+		public override void BulkPeekByte(Int64HalfOpenRange addresses, byte[] values)
 		{
 			if (_addressMangler != 0)
 			{
@@ -329,7 +329,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			_write32.Access((IntPtr)(&val), addr, 1);
 		}
 
-		public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
+		public override void BulkPeekByte(Int64HalfOpenRange addresses, byte[] values)
 		{
 			if ((ulong)addresses.Start + addresses.Count() > (ulong)Size || addresses.Start < 0) throw new ArgumentOutOfRangeException(nameof(addresses), message: AddressRangeError);
 			if (addresses.Count() > (uint)values.Length) throw new ArgumentException(message: $"Length of {nameof(values)} must be at least {nameof(addresses)} count.", nameof(values));
@@ -346,7 +346,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				_write8.Access((IntPtr)p, addr, values.Length);
 		}
 
-		public override void BulkPeekUshort(Int64ClosedRange addresses, bool bigEndian, ushort[] values)
+		public override void BulkPeekUshort(Int64HalfOpenRange addresses, bool bigEndian, ushort[] values)
 		{
 			if ((ulong)addresses.Start + addresses.Count() > (ulong)Size || addresses.Start < 0) throw new ArgumentOutOfRangeException(nameof(addresses), message: AddressRangeError);
 			if (addresses.Count() > (uint)values.Length * sizeof(ushort)) throw new ArgumentException(message: $"Length of {nameof(values)} must be at least {nameof(addresses)} count.", nameof(values));
@@ -364,7 +364,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				_write16.Access((IntPtr)p, addr, values.Length);
 		}
 
-		public override void BulkPeekUint(Int64ClosedRange addresses, bool bigEndian, uint[] values)
+		public override void BulkPeekUint(Int64HalfOpenRange addresses, bool bigEndian, uint[] values)
 		{
 			if ((ulong)addresses.Start + addresses.Count() > (ulong)Size || addresses.Start < 0) throw new ArgumentOutOfRangeException(nameof(addresses), message: AddressRangeError);
 			if (addresses.Count() > (uint)values.Length * sizeof(uint)) throw new ArgumentException(message: $"Length of {nameof(values)} must be at least {nameof(addresses)} count.", nameof(values));

--- a/src/BizHawk.Emulation.Cores/Waterbox/WaterboxMemoryDomain.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/WaterboxMemoryDomain.cs
@@ -102,7 +102,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			}
 		}
 
-		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
 		{
 			if (_addressMangler != 0)
 			{
@@ -219,7 +219,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			}
 		}
 
-		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
 		{
 			if (_addressMangler != 0)
 			{
@@ -329,7 +329,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			_write32.Access((IntPtr)(&val), addr, 1);
 		}
 
-		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		public override void BulkPeekByte(Int64ClosedRange addresses, byte[] values)
 		{
 			if ((ulong)addresses.Start + addresses.Count() > (ulong)Size || addresses.Start < 0) throw new ArgumentOutOfRangeException(nameof(addresses), message: AddressRangeError);
 			if (addresses.Count() > (uint)values.Length) throw new ArgumentException(message: $"Length of {nameof(values)} must be at least {nameof(addresses)} count.", nameof(values));
@@ -346,7 +346,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				_write8.Access((IntPtr)p, addr, values.Length);
 		}
 
-		public override void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
+		public override void BulkPeekUshort(Int64ClosedRange addresses, bool bigEndian, ushort[] values)
 		{
 			if ((ulong)addresses.Start + addresses.Count() > (ulong)Size || addresses.Start < 0) throw new ArgumentOutOfRangeException(nameof(addresses), message: AddressRangeError);
 			if (addresses.Count() > (uint)values.Length * sizeof(ushort)) throw new ArgumentException(message: $"Length of {nameof(values)} must be at least {nameof(addresses)} count.", nameof(values));
@@ -364,7 +364,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				_write16.Access((IntPtr)p, addr, values.Length);
 		}
 
-		public override void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+		public override void BulkPeekUint(Int64ClosedRange addresses, bool bigEndian, uint[] values)
 		{
 			if ((ulong)addresses.Start + addresses.Count() > (ulong)Size || addresses.Start < 0) throw new ArgumentOutOfRangeException(nameof(addresses), message: AddressRangeError);
 			if (addresses.Count() > (uint)values.Length * sizeof(uint)) throw new ArgumentException(message: $"Length of {nameof(values)} must be at least {nameof(addresses)} count.", nameof(values));

--- a/src/BizHawk.Tests.Common/IntervalTests.cs
+++ b/src/BizHawk.Tests.Common/IntervalTests.cs
@@ -1,0 +1,143 @@
+﻿using BizHawk.Common;
+
+namespace BizHawk.Tests.Common;
+
+[TestClass]
+public class IntervalTests
+{
+	private Range<int> S32
+		=> (-3).RangeTo(4);
+
+	private Range<long> S64
+		=> (-3L).RangeTo(4L);
+
+	[TestMethod]
+	public void TestConstrainWithin()
+	{
+		Assert.AreEqual(-3, (-4).ConstrainWithin(S32), $"s32 -4.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(-3, (-3).ConstrainWithin(S32), $"s32 -3.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(-2, (-2).ConstrainWithin(S32), $"s32 -2.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(3, 3.ConstrainWithin(S32), $"s32 3.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(4, 4.ConstrainWithin(S32), $"s32 4.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(4, 5.ConstrainWithin(S32), $"s32 5.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+
+		Assert.AreEqual(-3L, (-4L).ConstrainWithin(S64), $"s64 -4.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(-3L, (-3L).ConstrainWithin(S64), $"s64 -3.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(-2L, (-2L).ConstrainWithin(S64), $"s64 -2.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(3L, 3L.ConstrainWithin(S64), $"s64 3.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(4L, 4L.ConstrainWithin(S64), $"s64 4.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(4L, 5L.ConstrainWithin(S64), $"s64 5.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+	}
+
+	[TestMethod]
+	public void TestContains()
+	{
+		Assert.IsFalse(S32.Contains(-4), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(-4)");
+		Assert.IsTrue(S32.Contains(-3), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(-3)");
+		Assert.IsTrue(S32.Contains(-2), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(-2)");
+		Assert.IsTrue(S32.Contains(3), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(3)");
+		Assert.IsTrue(S32.Contains(4), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(4)");
+		Assert.IsFalse(S32.Contains(5), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(5)");
+
+		Assert.IsFalse(S64.Contains(-4L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(-4L)");
+		Assert.IsTrue(S64.Contains(-3L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(-3L)");
+		Assert.IsTrue(S64.Contains(-2L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(-2L)");
+		Assert.IsTrue(S64.Contains(3L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(3L)");
+		Assert.IsTrue(S64.Contains(4L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(4L)");
+		Assert.IsFalse(S64.Contains(5L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(5L)");
+	}
+
+	[TestMethod]
+	public void TestCreationAroundZero()
+	{
+		for (int start = -3, endInclusive = -1; start <= 1;)
+		{
+			var interval = start.RangeTo(endInclusive);
+			Assert.AreEqual(start, interval.Start, $"s32 start of {interval} survives round trip");
+			Assert.AreEqual(endInclusive, interval.EndInclusive, $"s32 end of {interval} survives round trip");
+			Assert.AreEqual(3U, interval.Count(), $"s32 {interval} has 3 elems");
+			start++;
+			endInclusive++;
+		}
+		for (long start = -3L, endInclusive = -1L; start <= 1L;)
+		{
+			var interval = start.RangeTo(endInclusive);
+			Assert.AreEqual(start, interval.Start, $"s64 start of {interval} survives round trip");
+			Assert.AreEqual(endInclusive, interval.EndInclusive, $"s64 end of {interval} survives round trip");
+			Assert.AreEqual(3UL, interval.Count(), $"s64 {interval} has 3 elems");
+			start++;
+			endInclusive++;
+		}
+	}
+
+	[TestMethod]
+	public void TestCreationFailsIfEmpty()
+	{
+		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1.RangeTo(-2), $"s32, {nameof(RangeExtensions.RangeTo)}");
+		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1.RangeToExclusive(-1), $"s32, {nameof(RangeExtensions.RangeToExclusive)}");
+
+		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1L.RangeTo(-2L), $"s64, {nameof(RangeExtensions.RangeTo)}");
+		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1L.RangeToExclusive(-1L), $"s64, {nameof(RangeExtensions.RangeToExclusive)}");
+	}
+
+	[TestMethod]
+	public void TestCreationFullRange()
+	{
+		/*scope*/{
+			var interval = int.MinValue.RangeTo(int.MaxValue);
+			Assert.IsTrue(interval.Contains(0), $"every s32 {nameof(RangeExtensions.Contains)} 0");
+			Assert.AreEqual(0U, interval.Count(), $"every s32 {nameof(RangeExtensions.Count)} overflows");
+		}
+		/*scope*/{
+			var interval = long.MinValue.RangeTo(long.MaxValue);
+			Assert.IsTrue(interval.Contains(0L), $"every s64 {nameof(RangeExtensions.Contains)} 0");
+			Assert.AreEqual(0UL, interval.Count(), $"every s64 {nameof(RangeExtensions.Count)} overflows");
+		}
+	}
+
+	[TestMethod]
+	public void TestCreationNormal()
+	{
+		Assert.AreEqual((-3).RangeTo(4).ToString(), (-3).RangeToExclusive(5).ToString(), "s32");
+		Assert.AreEqual((-3L).RangeTo(4L).ToString(), (-3L).RangeToExclusive(5L).ToString(), "s64");
+	}
+
+	[TestMethod]
+	public void TestCreationSingleElem()
+	{
+		_ = Assert.ThrowsExactly<ArithmeticException>(() => _ = int.MinValue.RangeToExclusive(int.MinValue), $"s32 {nameof(int.MinValue)}.{nameof(RangeExtensions.RangeToExclusive)}({nameof(int.MinValue)})");
+		foreach (var (start, endExclusive) in new[]
+		{
+			(int.MinValue, int.MinValue + 1),
+			(int.MinValue + 1, int.MinValue + 2),
+			(-1, 0),
+			(0, 1),
+			(1, 2),
+			(int.MaxValue - 2, int.MaxValue - 1),
+			(int.MaxValue - 1, int.MaxValue),
+		})
+		{
+			var interval = start.RangeTo(start);
+			Assert.AreEqual(1U, interval.Count(), $"s32, {nameof(RangeExtensions.RangeTo)}, {interval}");
+			interval = start.RangeToExclusive(endExclusive);
+			Assert.AreEqual(1U, interval.Count(), $"s32, {nameof(RangeExtensions.RangeToExclusive)}, {interval}");
+		}
+		_ = Assert.ThrowsExactly<ArithmeticException>(() => _ = long.MinValue.RangeToExclusive(long.MinValue), $"s64 {nameof(long.MinValue)}.{nameof(RangeExtensions.RangeToExclusive)}({nameof(long.MinValue)})");
+		foreach (var (start, endExclusive) in new[]
+		{
+			(long.MinValue, long.MinValue + 1L),
+			(long.MinValue + 1L, long.MinValue + 2L),
+			(-1L, 0L),
+			(0L, 1L),
+			(1L, 2L),
+			(long.MaxValue - 2L, long.MaxValue - 1L),
+			(long.MaxValue - 1L, long.MaxValue),
+		})
+		{
+			var interval = start.RangeTo(start);
+			Assert.AreEqual(1UL, interval.Count(), $"s64, {nameof(RangeExtensions.RangeTo)}, {interval}");
+			interval = start.RangeToExclusive(endExclusive);
+			Assert.AreEqual(1UL, interval.Count(), $"s64, {nameof(RangeExtensions.RangeToExclusive)}, {interval}");
+		}
+	}
+}

--- a/src/BizHawk.Tests.Common/IntervalTests.cs
+++ b/src/BizHawk.Tests.Common/IntervalTests.cs
@@ -5,46 +5,56 @@ namespace BizHawk.Tests.Common;
 [TestClass]
 public class IntervalTests
 {
-	private Range<int> S32
+	private Int32ClosedRange S32
 		=> (-3).RangeTo(4);
 
-	private Range<long> S64
+	private Int64ClosedRange S64
 		=> (-3L).RangeTo(4L);
 
 	[TestMethod]
 	public void TestConstrainWithin()
 	{
-		Assert.AreEqual(-3, (-4).ConstrainWithin(S32), $"s32 -4.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
-		Assert.AreEqual(-3, (-3).ConstrainWithin(S32), $"s32 -3.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
-		Assert.AreEqual(-2, (-2).ConstrainWithin(S32), $"s32 -2.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
-		Assert.AreEqual(3, 3.ConstrainWithin(S32), $"s32 3.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
-		Assert.AreEqual(4, 4.ConstrainWithin(S32), $"s32 4.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
-		Assert.AreEqual(4, 5.ConstrainWithin(S32), $"s32 5.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(-3, (-4).ConstrainWithin(S32), $"-4.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(-3, (-3).ConstrainWithin(S32), $"-3.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(-2, (-2).ConstrainWithin(S32), $"-2.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(3, 3.ConstrainWithin(S32), $"3.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(4, 4.ConstrainWithin(S32), $"4.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
+		Assert.AreEqual(4, 5.ConstrainWithin(S32), $"5.{nameof(RangeExtensions.ConstrainWithin)}({S32})");
 
-		Assert.AreEqual(-3L, (-4L).ConstrainWithin(S64), $"s64 -4.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
-		Assert.AreEqual(-3L, (-3L).ConstrainWithin(S64), $"s64 -3.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
-		Assert.AreEqual(-2L, (-2L).ConstrainWithin(S64), $"s64 -2.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
-		Assert.AreEqual(3L, 3L.ConstrainWithin(S64), $"s64 3.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
-		Assert.AreEqual(4L, 4L.ConstrainWithin(S64), $"s64 4.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
-		Assert.AreEqual(4L, 5L.ConstrainWithin(S64), $"s64 5.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(-3L, (-4L).ConstrainWithin(S64), $"-4.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(-3L, (-3L).ConstrainWithin(S64), $"-3.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(-2L, (-2L).ConstrainWithin(S64), $"-2.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(3L, 3L.ConstrainWithin(S64), $"3.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(4L, 4L.ConstrainWithin(S64), $"4.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
+		Assert.AreEqual(4L, 5L.ConstrainWithin(S64), $"5.{nameof(RangeExtensions.ConstrainWithin)}({S64})");
 	}
 
 	[TestMethod]
 	public void TestContains()
 	{
-		Assert.IsFalse(S32.Contains(-4), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(-4)");
-		Assert.IsTrue(S32.Contains(-3), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(-3)");
-		Assert.IsTrue(S32.Contains(-2), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(-2)");
-		Assert.IsTrue(S32.Contains(3), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(3)");
-		Assert.IsTrue(S32.Contains(4), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(4)");
-		Assert.IsFalse(S32.Contains(5), $"s32 ({S32}).{nameof(RangeExtensions.Contains)}(5)");
+		Assert.IsFalse(S32.Contains(-4), $"({S32}).{nameof(Int32ClosedRange.Contains)}(-4)");
+		Assert.IsTrue(S32.Contains(-3), $"({S32}).{nameof(Int32ClosedRange.Contains)}(-3)");
+		Assert.IsTrue(S32.Contains(-2), $"({S32}).{nameof(Int32ClosedRange.Contains)}(-2)");
+		Assert.IsTrue(S32.Contains(3), $"({S32}).{nameof(Int32ClosedRange.Contains)}(3)");
+		Assert.IsTrue(S32.Contains(4), $"({S32}).{nameof(Int32ClosedRange.Contains)}(4)");
+		Assert.IsFalse(S32.Contains(5), $"({S32}).{nameof(Int32ClosedRange.Contains)}(5)");
 
-		Assert.IsFalse(S64.Contains(-4L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(-4L)");
-		Assert.IsTrue(S64.Contains(-3L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(-3L)");
-		Assert.IsTrue(S64.Contains(-2L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(-2L)");
-		Assert.IsTrue(S64.Contains(3L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(3L)");
-		Assert.IsTrue(S64.Contains(4L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(4L)");
-		Assert.IsFalse(S64.Contains(5L), $"s64 ({S64}).{nameof(RangeExtensions.Contains)}(5L)");
+		var i = -4;
+		Assert.IsFalse(S32.Contains(in i), $"({S32}).{nameof(Int32ClosedRange.Contains)}(-4)");
+		i = 4;
+		Assert.IsTrue(S32.Contains(in i), $"({S32}).{nameof(Int32ClosedRange.Contains)}(4)");
+
+		Assert.IsFalse(S64.Contains(-4L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(-4L)");
+		Assert.IsTrue(S64.Contains(-3L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(-3L)");
+		Assert.IsTrue(S64.Contains(-2L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(-2L)");
+		Assert.IsTrue(S64.Contains(3L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(3L)");
+		Assert.IsTrue(S64.Contains(4L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(4L)");
+		Assert.IsFalse(S64.Contains(5L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(5L)");
+
+		var l = -4L;
+		Assert.IsFalse(S64.Contains(in l), $"({S64}).{nameof(Int64ClosedRange.Contains)}(-4L)");
+		l = 4L;
+		Assert.IsTrue(S64.Contains(in l), $"({S64}).{nameof(Int64ClosedRange.Contains)}(4L)");
 	}
 
 	[TestMethod]
@@ -53,18 +63,18 @@ public class IntervalTests
 		for (int start = -3, endInclusive = -1; start <= 1;)
 		{
 			var interval = start.RangeTo(endInclusive);
-			Assert.AreEqual(start, interval.Start, $"s32 start of {interval} survives round trip");
-			Assert.AreEqual(endInclusive, interval.EndInclusive, $"s32 end of {interval} survives round trip");
-			Assert.AreEqual(3U, interval.Count(), $"s32 {interval} has 3 elems");
+			Assert.AreEqual(start, interval.Start, $"start of {interval} survives round trip");
+			Assert.AreEqual(endInclusive, interval.EndInclusive, $"end of {interval} survives round trip");
+			Assert.AreEqual(3U, interval.Count(), $"{interval} has 3 elems");
 			start++;
 			endInclusive++;
 		}
 		for (long start = -3L, endInclusive = -1L; start <= 1L;)
 		{
 			var interval = start.RangeTo(endInclusive);
-			Assert.AreEqual(start, interval.Start, $"s64 start of {interval} survives round trip");
-			Assert.AreEqual(endInclusive, interval.EndInclusive, $"s64 end of {interval} survives round trip");
-			Assert.AreEqual(3UL, interval.Count(), $"s64 {interval} has 3 elems");
+			Assert.AreEqual(start, interval.Start, $"start of {interval} survives round trip");
+			Assert.AreEqual(endInclusive, interval.EndInclusive, $"end of {interval} survives round trip");
+			Assert.AreEqual(3UL, interval.Count(), $"{interval} has 3 elems");
 			start++;
 			endInclusive++;
 		}
@@ -75,9 +85,11 @@ public class IntervalTests
 	{
 		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1.RangeTo(-2), $"s32, {nameof(RangeExtensions.RangeTo)}");
 		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1.RangeToExclusive(-1), $"s32, {nameof(RangeExtensions.RangeToExclusive)}");
+		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = new Int32ClosedRange(start: 1, endInclusive: -2), "s32, ctor");
 
 		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1L.RangeTo(-2L), $"s64, {nameof(RangeExtensions.RangeTo)}");
 		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1L.RangeToExclusive(-1L), $"s64, {nameof(RangeExtensions.RangeToExclusive)}");
+		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = new Int64ClosedRange(start: 1L, endInclusive: -2L), "s64, ctor");
 	}
 
 	[TestMethod]
@@ -85,21 +97,29 @@ public class IntervalTests
 	{
 		/*scope*/{
 			var interval = int.MinValue.RangeTo(int.MaxValue);
-			Assert.IsTrue(interval.Contains(0), $"every s32 {nameof(RangeExtensions.Contains)} 0");
-			Assert.AreEqual(0U, interval.Count(), $"every s32 {nameof(RangeExtensions.Count)} overflows");
+			Assert.IsTrue(interval.Contains(0), $"every s32 {nameof(Int32ClosedRange.Contains)} 0");
+			Assert.AreEqual(0U, interval.Count(), $"every s32 {nameof(Int32ClosedRange.Count)} overflows");
 		}
 		/*scope*/{
 			var interval = long.MinValue.RangeTo(long.MaxValue);
-			Assert.IsTrue(interval.Contains(0L), $"every s64 {nameof(RangeExtensions.Contains)} 0");
-			Assert.AreEqual(0UL, interval.Count(), $"every s64 {nameof(RangeExtensions.Count)} overflows");
+			Assert.IsTrue(interval.Contains(0L), $"every s64 {nameof(Int64ClosedRange.Contains)} 0");
+			Assert.AreEqual(0UL, interval.Count(), $"every s64 {nameof(Int64ClosedRange.Count)} overflows");
 		}
 	}
 
 	[TestMethod]
 	public void TestCreationNormal()
 	{
-		Assert.AreEqual((-3).RangeTo(4).ToString(), (-3).RangeToExclusive(5).ToString(), "s32");
-		Assert.AreEqual((-3L).RangeTo(4L).ToString(), (-3L).RangeToExclusive(5L).ToString(), "s64");
+		/*scope*/{
+			var interval = new Int32ClosedRange(start: -3, endInclusive: 4);
+			Assert.AreEqual(interval, (-3).RangeTo(4), $"s32, {nameof(RangeExtensions.RangeTo)}");
+			Assert.AreEqual(interval, (-3).RangeToExclusive(5), $"s32, {nameof(RangeExtensions.RangeToExclusive)}");
+		}
+		/*scope*/{
+			var interval = new Int64ClosedRange(start: -3L, endInclusive: 4L);
+			Assert.AreEqual(interval, (-3L).RangeTo(4L), $"s64, {nameof(RangeExtensions.RangeTo)}");
+			Assert.AreEqual(interval, (-3L).RangeToExclusive(5L), $"s64, {nameof(RangeExtensions.RangeToExclusive)}");
+		}
 	}
 
 	[TestMethod]
@@ -118,9 +138,11 @@ public class IntervalTests
 		})
 		{
 			var interval = start.RangeTo(start);
-			Assert.AreEqual(1U, interval.Count(), $"s32, {nameof(RangeExtensions.RangeTo)}, {interval}");
+			Assert.AreEqual(1U, interval.Count(), $"{nameof(RangeExtensions.RangeTo)}, {interval}");
 			interval = start.RangeToExclusive(endExclusive);
-			Assert.AreEqual(1U, interval.Count(), $"s32, {nameof(RangeExtensions.RangeToExclusive)}, {interval}");
+			Assert.AreEqual(1U, interval.Count(), $"{nameof(RangeExtensions.RangeToExclusive)}, {interval}");
+			interval = new Int32ClosedRange(start: start, endInclusive: start);
+			Assert.AreEqual(1U, interval.Count(), $"ctor, {interval}");
 		}
 		_ = Assert.ThrowsExactly<ArithmeticException>(() => _ = long.MinValue.RangeToExclusive(long.MinValue), $"s64 {nameof(long.MinValue)}.{nameof(RangeExtensions.RangeToExclusive)}({nameof(long.MinValue)})");
 		foreach (var (start, endExclusive) in new[]
@@ -135,9 +157,11 @@ public class IntervalTests
 		})
 		{
 			var interval = start.RangeTo(start);
-			Assert.AreEqual(1UL, interval.Count(), $"s64, {nameof(RangeExtensions.RangeTo)}, {interval}");
+			Assert.AreEqual(1UL, interval.Count(), $"{nameof(RangeExtensions.RangeTo)}, {interval}");
 			interval = start.RangeToExclusive(endExclusive);
-			Assert.AreEqual(1UL, interval.Count(), $"s64, {nameof(RangeExtensions.RangeToExclusive)}, {interval}");
+			Assert.AreEqual(1UL, interval.Count(), $"{nameof(RangeExtensions.RangeToExclusive)}, {interval}");
+			interval = new Int64ClosedRange(start: start, endInclusive: start);
+			Assert.AreEqual(1UL, interval.Count(), $"ctor, {interval}");
 		}
 	}
 }

--- a/src/BizHawk.Tests.Common/IntervalTests.cs
+++ b/src/BizHawk.Tests.Common/IntervalTests.cs
@@ -5,10 +5,10 @@ namespace BizHawk.Tests.Common;
 [TestClass]
 public class IntervalTests
 {
-	private Int32ClosedRange S32
+	private Int32HalfOpenRange S32
 		=> (-3).RangeTo(4);
 
-	private Int64ClosedRange S64
+	private Int64HalfOpenRange S64
 		=> (-3L).RangeTo(4L);
 
 	[TestMethod]
@@ -32,51 +32,51 @@ public class IntervalTests
 	[TestMethod]
 	public void TestContains()
 	{
-		Assert.IsFalse(S32.Contains(-4), $"({S32}).{nameof(Int32ClosedRange.Contains)}(-4)");
-		Assert.IsTrue(S32.Contains(-3), $"({S32}).{nameof(Int32ClosedRange.Contains)}(-3)");
-		Assert.IsTrue(S32.Contains(-2), $"({S32}).{nameof(Int32ClosedRange.Contains)}(-2)");
-		Assert.IsTrue(S32.Contains(3), $"({S32}).{nameof(Int32ClosedRange.Contains)}(3)");
-		Assert.IsTrue(S32.Contains(4), $"({S32}).{nameof(Int32ClosedRange.Contains)}(4)");
-		Assert.IsFalse(S32.Contains(5), $"({S32}).{nameof(Int32ClosedRange.Contains)}(5)");
+		Assert.IsFalse(S32.Contains(-4), $"({S32}).{nameof(Int32HalfOpenRange.Contains)}(-4)");
+		Assert.IsTrue(S32.Contains(-3), $"({S32}).{nameof(Int32HalfOpenRange.Contains)}(-3)");
+		Assert.IsTrue(S32.Contains(-2), $"({S32}).{nameof(Int32HalfOpenRange.Contains)}(-2)");
+		Assert.IsTrue(S32.Contains(3), $"({S32}).{nameof(Int32HalfOpenRange.Contains)}(3)");
+		Assert.IsTrue(S32.Contains(4), $"({S32}).{nameof(Int32HalfOpenRange.Contains)}(4)");
+		Assert.IsFalse(S32.Contains(5), $"({S32}).{nameof(Int32HalfOpenRange.Contains)}(5)");
 
 		var i = -4;
-		Assert.IsFalse(S32.Contains(in i), $"({S32}).{nameof(Int32ClosedRange.Contains)}(-4)");
+		Assert.IsFalse(S32.Contains(in i), $"({S32}).{nameof(Int32HalfOpenRange.Contains)}(-4)");
 		i = 4;
-		Assert.IsTrue(S32.Contains(in i), $"({S32}).{nameof(Int32ClosedRange.Contains)}(4)");
+		Assert.IsTrue(S32.Contains(in i), $"({S32}).{nameof(Int32HalfOpenRange.Contains)}(4)");
 
-		Assert.IsFalse(S64.Contains(-4L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(-4L)");
-		Assert.IsTrue(S64.Contains(-3L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(-3L)");
-		Assert.IsTrue(S64.Contains(-2L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(-2L)");
-		Assert.IsTrue(S64.Contains(3L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(3L)");
-		Assert.IsTrue(S64.Contains(4L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(4L)");
-		Assert.IsFalse(S64.Contains(5L), $"({S64}).{nameof(Int64ClosedRange.Contains)}(5L)");
+		Assert.IsFalse(S64.Contains(-4L), $"({S64}).{nameof(Int64HalfOpenRange.Contains)}(-4L)");
+		Assert.IsTrue(S64.Contains(-3L), $"({S64}).{nameof(Int64HalfOpenRange.Contains)}(-3L)");
+		Assert.IsTrue(S64.Contains(-2L), $"({S64}).{nameof(Int64HalfOpenRange.Contains)}(-2L)");
+		Assert.IsTrue(S64.Contains(3L), $"({S64}).{nameof(Int64HalfOpenRange.Contains)}(3L)");
+		Assert.IsTrue(S64.Contains(4L), $"({S64}).{nameof(Int64HalfOpenRange.Contains)}(4L)");
+		Assert.IsFalse(S64.Contains(5L), $"({S64}).{nameof(Int64HalfOpenRange.Contains)}(5L)");
 
 		var l = -4L;
-		Assert.IsFalse(S64.Contains(in l), $"({S64}).{nameof(Int64ClosedRange.Contains)}(-4L)");
+		Assert.IsFalse(S64.Contains(in l), $"({S64}).{nameof(Int32HalfOpenRange.Contains)}(-4L)");
 		l = 4L;
-		Assert.IsTrue(S64.Contains(in l), $"({S64}).{nameof(Int64ClosedRange.Contains)}(4L)");
+		Assert.IsTrue(S64.Contains(in l), $"({S64}).{nameof(Int32HalfOpenRange.Contains)}(4L)");
 	}
 
 	[TestMethod]
 	public void TestCreationAroundZero()
 	{
-		for (int start = -3, endInclusive = -1; start <= 1;)
+		for (int start = -3, endExclusive = 0; start <= 1;)
 		{
-			var interval = start.RangeTo(endInclusive);
+			var interval = start.RangeToExclusive(endExclusive);
 			Assert.AreEqual(start, interval.Start, $"start of {interval} survives round trip");
-			Assert.AreEqual(endInclusive, interval.EndInclusive, $"end of {interval} survives round trip");
+			Assert.AreEqual(endExclusive, interval.EndExclusive, $"end of {interval} survives round trip");
 			Assert.AreEqual(3U, interval.Count(), $"{interval} has 3 elems");
 			start++;
-			endInclusive++;
+			endExclusive++;
 		}
-		for (long start = -3L, endInclusive = -1L; start <= 1L;)
+		for (long start = -3L, endExclusive = 0L; start <= 1L;)
 		{
-			var interval = start.RangeTo(endInclusive);
+			var interval = start.RangeToExclusive(endExclusive);
 			Assert.AreEqual(start, interval.Start, $"start of {interval} survives round trip");
-			Assert.AreEqual(endInclusive, interval.EndInclusive, $"end of {interval} survives round trip");
+			Assert.AreEqual(endExclusive, interval.EndExclusive, $"end of {interval} survives round trip");
 			Assert.AreEqual(3UL, interval.Count(), $"{interval} has 3 elems");
 			start++;
-			endInclusive++;
+			endExclusive++;
 		}
 	}
 
@@ -85,25 +85,27 @@ public class IntervalTests
 	{
 		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1.RangeTo(-2), $"s32, {nameof(RangeExtensions.RangeTo)}");
 		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1.RangeToExclusive(-1), $"s32, {nameof(RangeExtensions.RangeToExclusive)}");
-		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = new Int32ClosedRange(start: 1, endInclusive: -2), "s32, ctor");
+		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = new Int32HalfOpenRange(start: 1, endExclusive: -1), "s32, ctor");
 
 		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1L.RangeTo(-2L), $"s64, {nameof(RangeExtensions.RangeTo)}");
 		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = 1L.RangeToExclusive(-1L), $"s64, {nameof(RangeExtensions.RangeToExclusive)}");
-		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = new Int64ClosedRange(start: 1L, endInclusive: -2L), "s64, ctor");
+		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = new Int64HalfOpenRange(start: 1L, endExclusive: -1L), "s64, ctor");
 	}
 
 	[TestMethod]
 	public void TestCreationFullRange()
 	{
+		_ = Assert.ThrowsExactly<OverflowException>(() => _ = int.MinValue.RangeTo(int.MaxValue), "every s32");
 		/*scope*/{
-			var interval = int.MinValue.RangeTo(int.MaxValue);
-			Assert.IsTrue(interval.Contains(0), $"every s32 {nameof(Int32ClosedRange.Contains)} 0");
-			Assert.AreEqual(0U, interval.Count(), $"every s32 {nameof(Int32ClosedRange.Count)} overflows");
+			var interval = int.MinValue.RangeTo(int.MaxValue - 1);
+			Assert.IsTrue(interval.Contains(0), $"almost every s32 {nameof(Int32HalfOpenRange.Contains)} 0");
+			Assert.AreEqual(uint.MaxValue, interval.Count(), $"almost every s32 {nameof(Int32HalfOpenRange.Count)} has {nameof(uint.MaxValue)} elems");
 		}
+		_ = Assert.ThrowsExactly<OverflowException>(() => _ = long.MinValue.RangeTo(long.MaxValue), "every s64");
 		/*scope*/{
-			var interval = long.MinValue.RangeTo(long.MaxValue);
-			Assert.IsTrue(interval.Contains(0L), $"every s64 {nameof(Int64ClosedRange.Contains)} 0");
-			Assert.AreEqual(0UL, interval.Count(), $"every s64 {nameof(Int64ClosedRange.Count)} overflows");
+			var interval = long.MinValue.RangeTo(long.MaxValue - 1L);
+			Assert.IsTrue(interval.Contains(0L), $"almost every s64 {nameof(Int64HalfOpenRange.Contains)} 0");
+			Assert.AreEqual(ulong.MaxValue, interval.Count(), $"almost every s64 {nameof(Int64HalfOpenRange.Count)} has {nameof(ulong.MaxValue)} elems");
 		}
 	}
 
@@ -111,12 +113,12 @@ public class IntervalTests
 	public void TestCreationNormal()
 	{
 		/*scope*/{
-			var interval = new Int32ClosedRange(start: -3, endInclusive: 4);
+			var interval = new Int32HalfOpenRange(start: -3, endExclusive: 5);
 			Assert.AreEqual(interval, (-3).RangeTo(4), $"s32, {nameof(RangeExtensions.RangeTo)}");
 			Assert.AreEqual(interval, (-3).RangeToExclusive(5), $"s32, {nameof(RangeExtensions.RangeToExclusive)}");
 		}
 		/*scope*/{
-			var interval = new Int64ClosedRange(start: -3L, endInclusive: 4L);
+			var interval = new Int64HalfOpenRange(start: -3L, endExclusive: 5L);
 			Assert.AreEqual(interval, (-3L).RangeTo(4L), $"s64, {nameof(RangeExtensions.RangeTo)}");
 			Assert.AreEqual(interval, (-3L).RangeToExclusive(5L), $"s64, {nameof(RangeExtensions.RangeToExclusive)}");
 		}
@@ -125,7 +127,7 @@ public class IntervalTests
 	[TestMethod]
 	public void TestCreationSingleElem()
 	{
-		_ = Assert.ThrowsExactly<ArithmeticException>(() => _ = int.MinValue.RangeToExclusive(int.MinValue), $"s32 {nameof(int.MinValue)}.{nameof(RangeExtensions.RangeToExclusive)}({nameof(int.MinValue)})");
+		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = int.MinValue.RangeToExclusive(int.MinValue), $"s32 {nameof(int.MinValue)}.{nameof(RangeExtensions.RangeToExclusive)}({nameof(int.MinValue)})");
 		foreach (var (start, endExclusive) in new[]
 		{
 			(int.MinValue, int.MinValue + 1),
@@ -141,10 +143,10 @@ public class IntervalTests
 			Assert.AreEqual(1U, interval.Count(), $"{nameof(RangeExtensions.RangeTo)}, {interval}");
 			interval = start.RangeToExclusive(endExclusive);
 			Assert.AreEqual(1U, interval.Count(), $"{nameof(RangeExtensions.RangeToExclusive)}, {interval}");
-			interval = new Int32ClosedRange(start: start, endInclusive: start);
+			interval = new Int32HalfOpenRange(start: start, endExclusive: endExclusive);
 			Assert.AreEqual(1U, interval.Count(), $"ctor, {interval}");
 		}
-		_ = Assert.ThrowsExactly<ArithmeticException>(() => _ = long.MinValue.RangeToExclusive(long.MinValue), $"s64 {nameof(long.MinValue)}.{nameof(RangeExtensions.RangeToExclusive)}({nameof(long.MinValue)})");
+		_ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = long.MinValue.RangeToExclusive(long.MinValue), $"s64 {nameof(long.MinValue)}.{nameof(RangeExtensions.RangeToExclusive)}({nameof(long.MinValue)})");
 		foreach (var (start, endExclusive) in new[]
 		{
 			(long.MinValue, long.MinValue + 1L),
@@ -160,7 +162,7 @@ public class IntervalTests
 			Assert.AreEqual(1UL, interval.Count(), $"{nameof(RangeExtensions.RangeTo)}, {interval}");
 			interval = start.RangeToExclusive(endExclusive);
 			Assert.AreEqual(1UL, interval.Count(), $"{nameof(RangeExtensions.RangeToExclusive)}, {interval}");
-			interval = new Int64ClosedRange(start: start, endInclusive: start);
+			interval = new Int64HalfOpenRange(start: start, endExclusive: endExclusive);
 			Assert.AreEqual(1UL, interval.Count(), $"ctor, {interval}");
 		}
 	}


### PR DESCRIPTION
Done, including the change to half-open. The implementation was messy before 6ceb0c900f76514193187772507ee7dbe91f4c24 and messy afterwards. (IMO closed is the lesser of two evils, but the BCL chose half-open, so half-open it is.) Call-sites are free to choose whichever is simpler.
Branch name ended up being a misnomer since the generic interface is still there, ready for float intervals should the need arise. But all call-sites use either `Int32HalfOpenRange` or `Int64HalfOpenRange`.

After merge, need to remember to update https://github.com/TASEmulators/BizHawk/wiki/Available-C%23-and-.NET-features