### PR TITLE
Fix fuzzy cue file resolving

### DIFF
--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CueFileResolver.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CueFileResolver.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
-using BizHawk.Common.PathExtensions;
 
 namespace BizHawk.Emulation.DiscSystem.CUE
 {
@@ -72,7 +71,9 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 		/// </summary>
 		public List<string> Resolve(string path)
 		{
-			var (targetFile, targetFragment, _) = path.SplitPathToDirFileAndExt();
+			string targetFile = Path.GetFileName(path);
+			string targetFragment = Path.GetFileNameWithoutExtension(path);
+
 			DirectoryInfo di = null;
 			MyFileInfo[] fileInfos;
 			if (!string.IsNullOrEmpty(Path.GetDirectoryName(path)))


### PR DESCRIPTION
Partially revert 7cde8bb466c34c3c9fae213c196a0a0602a60aab. Original code split the path into both filename and filename without extension, to match files with a different file extension as well as files with an added file extension (`foo.bin` -> `foo.bin.ecm`). 7cde8bb accidentally changed it so `targetFile` contains the directory part (probably `""`) instead of the file name with extension.

- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
