### PR TITLE
Add config flag for using `InvariantCulture` across all threads

### DIFF
--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -438,5 +438,7 @@ namespace BizHawk.Client.Common
 		public int AVWriterResizeHeight { get; set; } = 0;
 
 		public int AVWriterResizeWidth { get; set; } = 0;
+
+		public bool SetInvariantCulture { get; set; } = false;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/Program.cs
+++ b/src/BizHawk.Client.EmuHawk/Program.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -182,6 +183,12 @@ namespace BizHawk.Client.EmuHawk
 			initialConfig.ResolveDefaults();
 			if (initialConfig.SaveSlot is 0) initialConfig.SaveSlot = 10; //TODO remove after a while
 			// initialConfig should really be globalConfig as it's mutable
+
+			//TODO ideally this should happen as early as possible, which means parsing the config earlier, which means parsing the command-line flags earlier... actually there's not that much else above this --yoshi
+			if (initialConfig.SetInvariantCulture)
+			{
+				CultureInfo.CurrentCulture = CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+			}
 
 			StringLogUtil.DefaultToDisk = initialConfig.Movies.MoviesOnDisk;
 


### PR DESCRIPTION
This subject has come up a few times, so I wanted to explore it further. The thinking goes that this would force stacktraces to be in English (localised stacktraces are a mild annoyance), and prevent some BCL internals from choking on certain user-generated strings, especially paths. How much of an impact that will have remains to be seen.

I believe this changeset will work as-is, but I've only tested it under Mono with an English locale. There's also no GUI for it.