### PR TITLE
Make external tools path independent of working directory

### DIFF
--- a/src/BizHawk.Client.Common/config/PathEntryCollectionExtensions.cs
+++ b/src/BizHawk.Client.Common/config/PathEntryCollectionExtensions.cs
@@ -180,6 +180,12 @@ namespace BizHawk.Client.Common
 			return collection.AbsolutePathFor(path, null);
 		}
 
+		public static string ExternalToolsAbsolutePath(this PathEntryCollection collection)
+		{
+			var path = collection[PathEntryCollection.GLOBAL, "External Tools"].Path;
+			return collection.AbsolutePathFor(path, null);
+		}
+
 		public static string MultiDiskAbsolutePath(this PathEntryCollection collection)
 		{
 			var path = collection.ResolveToolsPath(collection[PathEntryCollection.GLOBAL, "Multi-Disk Bundles"].Path);

--- a/src/BizHawk.Client.EmuHawk/tools/ExternalToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ExternalToolManager.cs
@@ -88,7 +88,7 @@ namespace BizHawk.Client.EmuHawk
 				DirectoryMonitor.Created -= DirectoryMonitor_Created;
 				DirectoryMonitor.Dispose();
 			}
-			var path = _config.PathEntries.AbsolutePathFor(_config.PathEntries[PathEntryCollection.GLOBAL, "External Tools"].Path, null);
+			var path = _config.PathEntries.ExternalToolsAbsolutePath();
 			if (Directory.Exists(path))
 			{
 				DirectoryMonitor = new FileSystemWatcher(path, "*.dll")

--- a/src/BizHawk.Client.EmuHawk/tools/ExternalToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ExternalToolManager.cs
@@ -88,7 +88,7 @@ namespace BizHawk.Client.EmuHawk
 				DirectoryMonitor.Created -= DirectoryMonitor_Created;
 				DirectoryMonitor.Dispose();
 			}
-			var path = _config.PathEntries[PathEntryCollection.GLOBAL, "External Tools"].Path;
+			var path = _config.PathEntries.AbsolutePathFor(_config.PathEntries[PathEntryCollection.GLOBAL, "External Tools"].Path, null);
 			if (Directory.Exists(path))
 			{
 				DirectoryMonitor = new FileSystemWatcher(path, "*.dll")

--- a/src/BizHawk.Client.EmuHawk/tools/ExternalToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ExternalToolManager.cs
@@ -153,7 +153,7 @@ namespace BizHawk.Client.EmuHawk
 				{
 					foreach (var depFilename in toolAttribute.LoadAssemblyFiles)
 					{
-						var depFilePath = $"{_config.PathEntries[PathEntryCollection.GLOBAL, "External Tools"].Path}/{depFilename}";
+						var depFilePath = Path.Combine(_config.PathEntries.ExternalToolsAbsolutePath(), depFilename);
 						Console.WriteLine($"preloading assembly {depFilePath} requested by ext. tool {toolAttribute.Name}");
 						Assembly.LoadFrom(depFilePath);
 					}


### PR DESCRIPTION
Fixes default external tools directory not being found if BizHawk is launched with a working directory other than the exe directory.

- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
