### PR TITLE
HexEditor "File on Disk" fixes

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -235,20 +235,22 @@ namespace BizHawk.Client.EmuHawk
 			{
 				_rom = GetRomBytes();
 				_romDomain = new MemoryDomainByteArray(ROM_DOMAIN_NAME, MemoryDomain.Endian.Little, _rom, writable: true, wordSize: 1);
-
-				if (_domain.Name == _romDomain.Name)
-				{
-					_domain = _romDomain;
-				}
 			}
 			else
 			{
 				_romDomain = null;
 			}
-			
-			_domain = MemoryDomains.Any(x => x.Name == _domain.Name)
-				? MemoryDomains[_domain.Name]
-				: MemoryDomains.MainMemory;
+
+			if (_domain.Name == ROM_DOMAIN_NAME && _romDomain is not null)
+			{
+				_domain = _romDomain;
+			}
+			else
+			{ 
+				_domain = MemoryDomains.Any(x => x.Name == _domain.Name)
+					? MemoryDomains[_domain.Name]
+					: MemoryDomains.MainMemory;
+			}
 
 			BigEndian = _domain.EndianType == MemoryDomain.Endian.Big;
 

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -110,7 +110,6 @@ namespace BizHawk.Client.EmuHawk
 
 		private string _findStr = "";
 		private bool _mouseIsDown;
-		private byte[] _rom;
 		private MemoryDomain _romDomain;
 		private HexFind _hexFind;
 		private string _lastRom = "";
@@ -233,8 +232,8 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (Emulator.SystemId is not VSystemID.Raw.Arcade)
 			{
-				_rom = GetRomBytes();
-				_romDomain = new MemoryDomainByteArray(ROM_DOMAIN_NAME, MemoryDomain.Endian.Little, _rom, writable: true, wordSize: 1);
+				var rom = GetRomBytes();
+				_romDomain = new MemoryDomainByteArray(ROM_DOMAIN_NAME, MemoryDomain.Endian.Little, rom, writable: true, wordSize: 1);
 			}
 			else
 			{

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -460,10 +460,18 @@ namespace BizHawk.Client.EmuHawk
 				return null;
 			}
 
-			using var file = new HawkFile(path);
-			if (file.Exists)
+			try
 			{
-				return file.ReadAllBytes();
+				using var file = new HawkFile(path);
+				if (file.Exists)
+				{
+					return file.ReadAllBytes();
+				}
+			}
+			catch (Exception ex)
+			{
+				using var exceptionBox = new ExceptionBox(ex);
+				this.ShowDialogWithTempMute(exceptionBox);
 			}
 
 			return null;

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -230,14 +230,14 @@ namespace BizHawk.Client.EmuHawk
 
 		public override void Restart()
 		{
+			_romDomain = null;
 			if (Emulator.SystemId is not VSystemID.Raw.Arcade)
 			{
 				var rom = GetRomBytes();
-				_romDomain = new MemoryDomainByteArray(ROM_DOMAIN_NAME, MemoryDomain.Endian.Little, rom, writable: true, wordSize: 1);
-			}
-			else
-			{
-				_romDomain = null;
+				if (rom is not null)
+				{
+					_romDomain = new MemoryDomainByteArray(ROM_DOMAIN_NAME, MemoryDomain.Endian.Little, rom, writable: true, wordSize: 1);
+				}
 			}
 
 			if (_domain.Name == ROM_DOMAIN_NAME && _romDomain is not null)

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -10,7 +10,6 @@ using System.Windows.Forms;
 using BizHawk.Common;
 using BizHawk.Common.NumberExtensions;
 using BizHawk.Common.StringExtensions;
-using BizHawk.Common.IOExtensions;
 using BizHawk.Emulation.Common;
 using BizHawk.Client.Common;
 using BizHawk.Client.EmuHawk.Properties;
@@ -458,23 +457,16 @@ namespace BizHawk.Client.EmuHawk
 			var path = MainForm.CurrentlyOpenRomArgs.OpenAdvanced.SimplePath;
 			if (string.IsNullOrEmpty(path))
 			{
-				return new byte[] { 0xFF };
-			}
-
-			using var file = new HawkFile(path);
-
-			if (!file.Exists)
-			{
 				return null;
 			}
 
-			if (file.IsArchive)
+			using var file = new HawkFile(path);
+			if (file.Exists)
 			{
-				var stream = file.GetStream();
-				return stream.ReadAllBytes();
+				return file.ReadAllBytes();
 			}
 
-			return File.ReadAllBytes(path);
+			return null;
 		}
 
 		private static int GetNumDigits(long i)


### PR DESCRIPTION
Changes to loading the rom file for the "File on Disk" memory domain.

- Fix "File on Disk" domain not staying selected after core restart
- Fix NRE when file is missing
- Catch other errors (e.g. file in use) so hex editor can still be opened
- Little bit of code cleanup

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
