### PR TITLE
Add option to disable automatic resize of main window

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
@@ -197,7 +197,7 @@ namespace BizHawk.Client.Common
 			if (size == 1 || size == 2 || size == 3 || size == 4 || size == 5 || size == 10)
 			{
 				_config.SetWindowScaleFor(Emulator.SystemId, size);
-				_mainForm.FrameBufferResized();
+				_mainForm.FrameBufferResized(true);
 				_displayManager.OSD.AddMessage($"Window size set to {size}x");
 			}
 			else

--- a/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
@@ -197,7 +197,7 @@ namespace BizHawk.Client.Common
 			if (size == 1 || size == 2 || size == 3 || size == 4 || size == 5 || size == 10)
 			{
 				_config.SetWindowScaleFor(Emulator.SystemId, size);
-				_mainForm.FrameBufferResized(true);
+				_mainForm.FrameBufferResized(forceWindowResize: true);
 				_displayManager.OSD.AddMessage($"Window size set to {size}x");
 			}
 			else

--- a/src/BizHawk.Client.Common/IMainFormForApi.cs
+++ b/src/BizHawk.Client.Common/IMainFormForApi.cs
@@ -53,7 +53,7 @@ namespace BizHawk.Client.Common
 		/// <remarks>only referenced from <c>EmuClientApi</c></remarks>
 		void FrameAdvance(bool discardApiHawkSurfaces = true);
 
-		void FrameBufferResized(bool forceResize = false);
+		void FrameBufferResized(bool forceWindowResize = false);
 
 		void FrameSkipMessage();
 

--- a/src/BizHawk.Client.Common/IMainFormForApi.cs
+++ b/src/BizHawk.Client.Common/IMainFormForApi.cs
@@ -53,7 +53,7 @@ namespace BizHawk.Client.Common
 		/// <remarks>only referenced from <c>EmuClientApi</c></remarks>
 		void FrameAdvance(bool discardApiHawkSurfaces = true);
 
-		void FrameBufferResized();
+		void FrameBufferResized(bool forceResize = false);
 
 		void FrameSkipMessage();
 

--- a/src/BizHawk.Client.Common/IMainFormForApi.cs
+++ b/src/BizHawk.Client.Common/IMainFormForApi.cs
@@ -53,6 +53,7 @@ namespace BizHawk.Client.Common
 		/// <remarks>only referenced from <c>EmuClientApi</c></remarks>
 		void FrameAdvance(bool discardApiHawkSurfaces = true);
 
+		/// <param name="forceWindowResize">Override <see cref="Common.Config.ResizeWithFramebuffer"/></param>
 		void FrameBufferResized(bool forceWindowResize = false);
 
 		void FrameSkipMessage();

--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -136,8 +136,8 @@ namespace BizHawk.Client.Common
 		public bool MainFormStayOnTop { get; set; }
 		public bool StartPaused { get; set; }
 		public bool StartFullscreen { get; set; }
-		public int MainWndx { get; set; } = -1; // Negative numbers will be ignored
-		public int MainWndy { get; set; } = -1;
+		public int? MainWndx { get; set; }
+		public int? MainWndy { get; set; }
 		public int? MainWindowWidth { get; set; }
 		public int? MainWindowHeight { get; set; }
 		public bool RunInBackground { get; set; } = true;

--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 
 using BizHawk.Bizware.Graphics;
@@ -136,10 +137,8 @@ namespace BizHawk.Client.Common
 		public bool MainFormStayOnTop { get; set; }
 		public bool StartPaused { get; set; }
 		public bool StartFullscreen { get; set; }
-		public int? MainWndx { get; set; }
-		public int? MainWndy { get; set; }
-		public int? MainWindowWidth { get; set; }
-		public int? MainWindowHeight { get; set; }
+		public Point? MainWindowPosition { get; set; }
+		public Size? MainWindowSize { get; set; }
 		public bool RunInBackground { get; set; } = true;
 		public bool AcceptBackgroundInput { get; set; }
 		public bool AcceptBackgroundInputControllerOnly { get; set; }

--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -274,6 +274,8 @@ namespace BizHawk.Client.Common
 		public int DispCropRight { get; set; } = 0;
 		public int DispCropBottom { get; set; } = 0;
 
+		public bool ResizeWithFramebuffer { get; set; } = true;
+
 		// Sound options
 		public ESoundOutputMethod SoundOutputMethod { get; set; } = HostCapabilityDetector.HasXAudio2 ? ESoundOutputMethod.XAudio2 : ESoundOutputMethod.OpenAL;
 

--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -138,6 +138,8 @@ namespace BizHawk.Client.Common
 		public bool StartFullscreen { get; set; }
 		public int MainWndx { get; set; } = -1; // Negative numbers will be ignored
 		public int MainWndy { get; set; } = -1;
+		public int? MainWindowWidth { get; set; }
+		public int? MainWindowHeight { get; set; }
 		public bool RunInBackground { get; set; } = true;
 		public bool AcceptBackgroundInput { get; set; }
 		public bool AcceptBackgroundInputControllerOnly { get; set; }

--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -274,6 +274,9 @@ namespace BizHawk.Client.Common
 		public int DispCropRight { get; set; } = 0;
 		public int DispCropBottom { get; set; } = 0;
 
+		/// <summary>
+		/// Automatically resize main window when framebuffer size changes (default behavior)
+		/// </summary>
 		public bool ResizeWithFramebuffer { get; set; } = true;
 
 		// Sound options

--- a/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
+++ b/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
@@ -57,7 +57,7 @@ namespace BizHawk.Client.EmuHawk
 		void FrameAdvance(bool discardApiHawkSurfaces = true);
 
 		/// <remarks>only referenced from <see cref="LuaConsole"/></remarks>
-		void FrameBufferResized();
+		void FrameBufferResized(bool forceResize = false);
 
 		/// <remarks>only referenced from <see cref="BasicBot"/></remarks>
 		bool LoadQuickSave(int slot, bool suppressOSD = false);

--- a/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
+++ b/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
@@ -57,6 +57,7 @@ namespace BizHawk.Client.EmuHawk
 		void FrameAdvance(bool discardApiHawkSurfaces = true);
 
 		/// <remarks>only referenced from <see cref="LuaConsole"/></remarks>
+		/// <param name="forceWindowResize">Override <see cref="Common.Config.ResizeWithFramebuffer"/></param>
 		void FrameBufferResized(bool forceWindowResize = false);
 
 		/// <remarks>only referenced from <see cref="BasicBot"/></remarks>

--- a/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
+++ b/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
@@ -57,7 +57,7 @@ namespace BizHawk.Client.EmuHawk
 		void FrameAdvance(bool discardApiHawkSurfaces = true);
 
 		/// <remarks>only referenced from <see cref="LuaConsole"/></remarks>
-		void FrameBufferResized(bool forceResize = false);
+		void FrameBufferResized(bool forceWindowResize = false);
 
 		/// <remarks>only referenced from <see cref="BasicBot"/></remarks>
 		bool LoadQuickSave(int slot, bool suppressOSD = false);

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -123,6 +123,8 @@ namespace BizHawk.Client.EmuHawk
 			this.LoadedCoreNameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ViewSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.WindowSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator26 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.DisableResizeWithFramebufferMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SwitchToFullscreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DisplayFPSMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -978,8 +980,17 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// WindowSizeSubMenu
 			// 
+			this.WindowSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripSeparator26,
+            this.DisableResizeWithFramebufferMenuItem});
 			this.WindowSizeSubMenu.Text = "&Window Size";
 			this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
+			// 
+			// ResizeWithFramebufferMenuItem
+			// 
+			this.DisableResizeWithFramebufferMenuItem.CheckOnClick = true;
+			this.DisableResizeWithFramebufferMenuItem.Text = "&Static Size";
+			this.DisableResizeWithFramebufferMenuItem.Click += new System.EventHandler(this.DisableResizeWithFramebufferMenuItem_Click);
 			// 
 			// SwitchToFullscreenMenuItem
 			// 
@@ -2767,5 +2778,7 @@ namespace BizHawk.Client.EmuHawk
 		private ToolStripSeparatorEx toolStripSeparator24;
 		private ToolStripMenuItemEx AutosaveLastSlotMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator25;
+		private ToolStripMenuItemEx DisableResizeWithFramebufferMenuItem;
+		private ToolStripSeparatorEx toolStripSeparator26;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -628,7 +628,7 @@ namespace BizHawk.Client.EmuHawk
 		private void WindowSize_Click(object sender, EventArgs e)
 		{
 			Config.SetWindowScaleFor(Emulator.SystemId, (int) ((ToolStripMenuItem) sender).Tag);
-			FrameBufferResized(true);
+			FrameBufferResized(forceWindowResize: true);
 		}
 
 		private void DisableResizeWithFramebufferMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -625,16 +625,16 @@ namespace BizHawk.Client.EmuHawk
 			DisableResizeWithFramebufferMenuItem.Checked = !Config.ResizeWithFramebuffer;
 		}
 
-		private void WindowSize_Click(object sender, EventArgs e)
-		{
-			Config.SetWindowScaleFor(Emulator.SystemId, (int) ((ToolStripMenuItem) sender).Tag);
-			FrameBufferResized(forceWindowResize: true);
-		}
-
 		private void DisableResizeWithFramebufferMenuItem_Click(object sender, EventArgs e)
 		{
 			Config.ResizeWithFramebuffer = !DisableResizeWithFramebufferMenuItem.Checked;
 			FrameBufferResized();
+		}
+
+		private void WindowSize_Click(object sender, EventArgs e)
+		{
+			Config.SetWindowScaleFor(Emulator.SystemId, (int) ((ToolStripMenuItem) sender).Tag);
+			FrameBufferResized(forceWindowResize: true);
 		}
 
 		private void SwitchToFullscreenMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -615,11 +615,12 @@ namespace BizHawk.Client.EmuHawk
 		private void WindowSizeSubMenu_DropDownOpened(object sender, EventArgs e)
 		{
 			var windowScale = Config.GetWindowScaleFor(Emulator.SystemId);
-			foreach (ToolStripMenuItem item in WindowSizeSubMenu.DropDownItems.OfType<ToolStripMenuItem>())
+			foreach (var item in WindowSizeSubMenu.DropDownItems)
 			{
-				if (item.Tag is int itemScale)
+				// filter out separators
+				if (item is ToolStripMenuItem menuItem && menuItem.Tag is int itemScale)
 				{
-					item.Checked = itemScale == windowScale && Config.ResizeWithFramebuffer;
+					menuItem.Checked = itemScale == windowScale && Config.ResizeWithFramebuffer;
 				}
 			}
 			DisableResizeWithFramebufferMenuItem.Checked = !Config.ResizeWithFramebuffer;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -615,16 +615,26 @@ namespace BizHawk.Client.EmuHawk
 		private void WindowSizeSubMenu_DropDownOpened(object sender, EventArgs e)
 		{
 			var windowScale = Config.GetWindowScaleFor(Emulator.SystemId);
-			foreach (ToolStripMenuItem item in WindowSizeSubMenu.DropDownItems)
+			foreach (ToolStripMenuItem item in WindowSizeSubMenu.DropDownItems.OfType<ToolStripMenuItem>())
 			{
-				item.Checked = (int) item.Tag == windowScale;
+				if (item.Tag is int itemScale)
+				{
+					item.Checked = itemScale == windowScale && Config.ResizeWithFramebuffer;
+				}
 			}
+			DisableResizeWithFramebufferMenuItem.Checked = !Config.ResizeWithFramebuffer;
 		}
 
 		private void WindowSize_Click(object sender, EventArgs e)
 		{
 			Config.SetWindowScaleFor(Emulator.SystemId, (int) ((ToolStripMenuItem) sender).Tag);
 			FrameBufferResized(true);
+		}
+
+		private void DisableResizeWithFramebufferMenuItem_Click(object sender, EventArgs e)
+		{
+			Config.ResizeWithFramebuffer = !DisableResizeWithFramebufferMenuItem.Checked;
+			FrameBufferResized();
 		}
 
 		private void SwitchToFullscreenMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -624,7 +624,7 @@ namespace BizHawk.Client.EmuHawk
 		private void WindowSize_Click(object sender, EventArgs e)
 		{
 			Config.SetWindowScaleFor(Emulator.SystemId, (int) ((ToolStripMenuItem) sender).Tag);
-			FrameBufferResized();
+			FrameBufferResized(true);
 		}
 
 		private void SwitchToFullscreenMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -60,16 +60,18 @@ namespace BizHawk.Client.EmuHawk
 		{	
 			UpdateWindowTitle();
 			
-			for (int i = 1; i <= WINDOW_SCALE_MAX; i++)
 			{
-				long quotient = Math.DivRem(i, 10, out long remainder);
-				var temp = new ToolStripMenuItemEx
+				for (int i = 1; i <= WINDOW_SCALE_MAX; i++)
 				{
-					Tag = i,
-					Text = $"{(quotient > 0 ? quotient : "")}&{remainder}x"
-				};
-				temp.Click += this.WindowSize_Click;
-				WindowSizeSubMenu.DropDownItems.Insert(i - 1, temp);
+					long quotient = Math.DivRem(i, 10, out long remainder);
+					var temp = new ToolStripMenuItemEx
+					{
+						Tag = i,
+						Text = $"{(quotient > 0 ? quotient : "")}&{remainder}x"
+					};
+					temp.Click += this.WindowSize_Click;
+					WindowSizeSubMenu.DropDownItems.Insert(i - 1, temp);
+				}
 			}
 
 			foreach (var (appliesTo, coreNames) in Config.CorePickerUIData)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -606,14 +606,14 @@ namespace BizHawk.Client.EmuHawk
 
 			if (Config.SaveWindowPosition)
 			{
-				if (Config.MainWndx is int x && Config.MainWndy is int y)
+				if (Config.MainWindowPosition is Point position)
 				{
-					Location = new Point(x, y);
+					Location = position;
 				}
 
-				if (Config.MainWindowWidth is int width && Config.MainWindowHeight is int height && !Config.ResizeWithFramebuffer)
+				if (Config.MainWindowSize is Size size && !Config.ResizeWithFramebuffer)
 				{
-					Size = new(width, height);
+					Size = size;
 				}
 			}
 
@@ -2399,18 +2399,14 @@ namespace BizHawk.Client.EmuHawk
 			{
 				if (WindowState is FormWindowState.Normal)
 				{
-					Config.MainWndx = Location.X;
-					Config.MainWndy = Location.Y;
-					Config.MainWindowWidth = Width;
-					Config.MainWindowHeight = Height;
+					Config.MainWindowPosition = Location;
+					Config.MainWindowSize = Size;
 				}
 			}
 			else
 			{
-				Config.MainWndx = null;
-				Config.MainWndy = null;
-				Config.MainWindowWidth = null;
-				Config.MainWindowHeight = null;
+				Config.MainWindowPosition = null;
+				Config.MainWindowSize = null;
 			}
 
 			Config.LastWrittenFrom = VersionInfo.MainVersion;

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -60,23 +60,17 @@ namespace BizHawk.Client.EmuHawk
 		{	
 			UpdateWindowTitle();
 			
-			ToolStripItem[] CreateWindowSizeFactorSubmenus()
+			for (int i = 1; i <= WINDOW_SCALE_MAX; i++)
 			{
-				var items = new ToolStripItem[WINDOW_SCALE_MAX];
-				for (int i = 1; i <= WINDOW_SCALE_MAX; i++)
+				long quotient = Math.DivRem(i, 10, out long remainder);
+				var temp = new ToolStripMenuItemEx
 				{
-					long quotient = Math.DivRem(i, 10, out long remainder);
-					var temp = new ToolStripMenuItemEx
-					{
-						Tag = i,
-						Text = $"{(quotient > 0 ? quotient : "")}&{remainder}x"
-					};
-					temp.Click += this.WindowSize_Click;
-					items[i - 1] = temp;
-				}
-				return items;
+					Tag = i,
+					Text = $"{(quotient > 0 ? quotient : "")}&{remainder}x"
+				};
+				temp.Click += this.WindowSize_Click;
+				WindowSizeSubMenu.DropDownItems.Insert(i - 1, temp);
 			}
-			WindowSizeSubMenu.DropDownItems.AddRange(CreateWindowSizeFactorSubmenus());
 
 			foreach (var (appliesTo, coreNames) in Config.CorePickerUIData)
 			{

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1372,8 +1372,12 @@ namespace BizHawk.Client.EmuHawk
 			AddOnScreenMessage($"{fi.Name} saved.");
 		}
 
-		public void FrameBufferResized()
+		public void FrameBufferResized(bool forceResize = false)
 		{
+			if (!Config.ResizeWithFramebuffer && !forceResize)
+			{
+				return;
+			}
 			// run this entire thing exactly twice, since the first resize may adjust the menu stacking
 			for (int i = 0; i < 2; i++)
 			{
@@ -2568,7 +2572,7 @@ namespace BizHawk.Client.EmuHawk
 				Config.SetWindowScaleFor(Emulator.SystemId, windowScale);
 			}
 			AddOnScreenMessage($"Screensize set to {windowScale}x");
-			FrameBufferResized();
+			FrameBufferResized(true);
 		}
 
 		private void DecreaseWindowSize()
@@ -2580,7 +2584,7 @@ namespace BizHawk.Client.EmuHawk
 				Config.SetWindowScaleFor(Emulator.SystemId, windowScale);
 			}
 			AddOnScreenMessage($"Screensize set to {windowScale}x");
-			FrameBufferResized();
+			FrameBufferResized(true);
 		}
 
 		private static readonly int[] SpeedPercents = { 1, 3, 6, 12, 25, 50, 75, 100, 150, 200, 300, 400, 800, 1600, 3200, 6400 };

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -615,9 +615,9 @@ namespace BizHawk.Client.EmuHawk
 
 			if (Config.SaveWindowPosition)
 			{
-				if (Config.MainWndx != -1 && Config.MainWndy != -1)
+				if (Config.MainWndx is int x && Config.MainWndy is int y)
 				{
-					Location = new Point(Config.MainWndx, Config.MainWndy);
+					Location = new Point(x, y);
 				}
 
 				if (Config.MainWindowWidth is int width && Config.MainWindowHeight is int height && !Config.ResizeWithFramebuffer)
@@ -2416,8 +2416,8 @@ namespace BizHawk.Client.EmuHawk
 			}
 			else
 			{
-				Config.MainWndx = -1;
-				Config.MainWndy = -1;
+				Config.MainWndx = null;
+				Config.MainWndy = null;
 				Config.MainWindowWidth = null;
 				Config.MainWindowHeight = null;
 			}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -604,17 +604,6 @@ namespace BizHawk.Client.EmuHawk
 			CheatList.Changed += Tools.UpdateCheatRelatedTools;
 			RewireSound();
 
-			// Workaround for windows, location is -32000 when minimized, if they close it during this time, that's what gets saved
-			if (Config.MainWndx == -32000)
-			{
-				Config.MainWndx = 0;
-			}
-
-			if (Config.MainWndy == -32000)
-			{
-				Config.MainWndy = 0;
-			}
-
 			if (Config.SaveWindowPosition)
 			{
 				if (Config.MainWndx is int x && Config.MainWndy is int y)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1365,7 +1365,6 @@ namespace BizHawk.Client.EmuHawk
 			AddOnScreenMessage($"{fi.Name} saved.");
 		}
 
-		/// <param name="forceWindowResize">Override <see cref="Common.Config.ResizeWithFramebuffer"/></param>
 		public void FrameBufferResized(bool forceWindowResize = false)
 		{
 			if (!Config.ResizeWithFramebuffer && !forceWindowResize)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -613,9 +613,17 @@ namespace BizHawk.Client.EmuHawk
 				Config.MainWndy = 0;
 			}
 
-			if (Config.MainWndx != -1 && Config.MainWndy != -1 && Config.SaveWindowPosition)
+			if (Config.SaveWindowPosition)
 			{
-				Location = new Point(Config.MainWndx, Config.MainWndy);
+				if (Config.MainWndx != -1 && Config.MainWndy != -1)
+				{
+					Location = new Point(Config.MainWndx, Config.MainWndy);
+				}
+
+				if (Config.MainWindowWidth is int width && Config.MainWindowHeight is int height && !Config.ResizeWithFramebuffer)
+				{
+					Size = new(width, height);
+				}
 			}
 
 			if (Config.MainFormStayOnTop) TopMost = true;
@@ -2398,20 +2406,20 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (Config.SaveWindowPosition)
 			{
-				if (Config.MainWndx != -32000) // When minimized location is -32000, don't save this into the config file!
+				if (WindowState is FormWindowState.Normal)
 				{
 					Config.MainWndx = Location.X;
-				}
-
-				if (Config.MainWndy != -32000)
-				{
 					Config.MainWndy = Location.Y;
+					Config.MainWindowWidth = Width;
+					Config.MainWindowHeight = Height;
 				}
 			}
 			else
 			{
 				Config.MainWndx = -1;
 				Config.MainWndy = -1;
+				Config.MainWindowWidth = null;
+				Config.MainWindowHeight = null;
 			}
 
 			Config.LastWrittenFrom = VersionInfo.MainVersion;

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1366,6 +1366,7 @@ namespace BizHawk.Client.EmuHawk
 			AddOnScreenMessage($"{fi.Name} saved.");
 		}
 
+		/// <param name="forceWindowResize">Override <see cref="Common.Config.ResizeWithFramebuffer"/></param>
 		public void FrameBufferResized(bool forceWindowResize = false)
 		{
 			if (!Config.ResizeWithFramebuffer && !forceWindowResize)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1366,9 +1366,9 @@ namespace BizHawk.Client.EmuHawk
 			AddOnScreenMessage($"{fi.Name} saved.");
 		}
 
-		public void FrameBufferResized(bool forceResize = false)
+		public void FrameBufferResized(bool forceWindowResize = false)
 		{
-			if (!Config.ResizeWithFramebuffer && !forceResize)
+			if (!Config.ResizeWithFramebuffer && !forceWindowResize)
 			{
 				return;
 			}
@@ -2566,7 +2566,7 @@ namespace BizHawk.Client.EmuHawk
 				Config.SetWindowScaleFor(Emulator.SystemId, windowScale);
 			}
 			AddOnScreenMessage($"Screensize set to {windowScale}x");
-			FrameBufferResized(true);
+			FrameBufferResized(forceWindowResize: true);
 		}
 
 		private void DecreaseWindowSize()
@@ -2578,7 +2578,7 @@ namespace BizHawk.Client.EmuHawk
 				Config.SetWindowScaleFor(Emulator.SystemId, windowScale);
 			}
 			AddOnScreenMessage($"Screensize set to {windowScale}x");
-			FrameBufferResized(true);
+			FrameBufferResized(forceWindowResize: true);
 		}
 
 		private static readonly int[] SpeedPercents = { 1, 3, 6, 12, 25, 50, 75, 100, 150, 200, 300, 400, 800, 1600, 3200, 6400 };

--- a/src/BizHawk.Tests/Client.Common/config/SerializationStabilityTests.cs
+++ b/src/BizHawk.Tests/Client.Common/config/SerializationStabilityTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Drawing;
 using System.Reflection;
 
 using BizHawk.Client.Common;
@@ -32,8 +33,10 @@ namespace BizHawk.Tests.Client.Common.config
 			typeof(List<>),
 			typeof(Nullable<>),
 			typeof(object),
+			typeof(Point),
 			typeof(Queue<>),
 			typeof(float),
+			typeof(Size),
 			typeof(string),
 		};
 


### PR DESCRIPTION
- Add option to disable the automatic resizing of the main window whenever the framebuffer size changes
  - Window can be resized arbitrarily and stays that size
  - Selecting a standard scale through the menu/keybinds/API still works
- Restore last window size after restart (if automatic resize is disabled)
- Minor changes to saved window position
  - Make config values nullable instead of magic `-1` value
  - Don't save window position if minimized (this didn't quite work as intended) or maximized

This feature is useful for streamers who want a consistent capture size, as well as for people who want to fit the BizHawk window into a fixed layout with other windows (corner snapping etc.).

This is not the same functionality as the custom resolution in the display settings, which stretches the framebuffer to the specified size and fits the window to that size exactly.

With the feature in this PR, the window/client area stays a consistent size while automatic letterboxing/pillarboxing, integer resizing, 1:1 pixels etc. still work. This is preferable for working with multiple games, resolution changes mid-game, changing DS/WS screen rotation/layouts and similar, where squeezing everything into the same resolution is undesirable. It's also just more convenient than figuring out a resolution in the right aspect ratio and entering that in the display settings all the time.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant

resolves #1560, #3039, and #3410