### PR TITLE
Disk Drive Activity LED ToolTip enhancement

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2679,6 +2679,7 @@ namespace BizHawk.Client.EmuHawk
 			if (Emulator.HasDriveLight() && Emulator.AsDriveLight() is { DriveLightEnabled: true } diskLEDCore)
 			{
 				LedLightStatusLabel.Image = diskLEDCore.DriveLightOn ? _statusBarDiskLightOnImage : _statusBarDiskLightOffImage;
+				LedLightStatusLabel.ToolTipText = Emulator.AsDriveLight().DriveLightIconDescription;
 				LedLightStatusLabel.Visible = true;
 			}
 			else

--- a/src/BizHawk.Emulation.Common/Interfaces/Services/IDriveLight.cs
+++ b/src/BizHawk.Emulation.Common/Interfaces/Services/IDriveLight.cs
@@ -16,9 +16,7 @@
 		/// </summary>
 		bool DriveLightOn { get; }
 
-		/// <summary>
-		/// Gets a value indicating the description of the drive light icon (that will be displayed as a ToolTip on MainForm
-		/// </summary>
+		/// <value>description of the drive light icon (used in MainForm for the tooltip of the status bar icon)</value>
 		string DriveLightIconDescription { get; }
 	}
 }

--- a/src/BizHawk.Emulation.Common/Interfaces/Services/IDriveLight.cs
+++ b/src/BizHawk.Emulation.Common/Interfaces/Services/IDriveLight.cs
@@ -15,5 +15,10 @@
 		/// Gets a value indicating whether the light is currently lit
 		/// </summary>
 		bool DriveLightOn { get; }
+
+		/// <summary>
+		/// Gets a value indicating the description of the drive light icon (that will be displayed as a ToolTip on MainForm
+		/// </summary>
+		string DriveLightIconDescription { get; }
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Calculators/Emu83/Emu83.IDriveLight.cs
+++ b/src/BizHawk.Emulation.Cores/Calculators/Emu83/Emu83.IDriveLight.cs
@@ -6,5 +6,7 @@ namespace BizHawk.Emulation.Cores.Calculators.Emu83
 	{
 		public bool DriveLightEnabled => true;
 		public bool DriveLightOn => LibEmu83.TI83_GetLinkActive(Context);
+
+		public string DriveLightIconDescription => "Link Activity";
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.cs
@@ -189,5 +189,7 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 		public bool DriveLightOn =>
 			(_machine?.TapeDevice != null && _machine.TapeDevice.TapeIsPlaying)
 			|| (_machine?.UPDDiskDevice != null && _machine.UPDDiskDevice.DriveLight);
+
+		public string DriveLightIconDescription => "Disc Drive Activity";
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Computers/AppleII/AppleII.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/AppleII/AppleII.cs
@@ -130,6 +130,8 @@ namespace BizHawk.Emulation.Cores.Computers.AppleII
 		public bool DriveLightEnabled => true;
 		public bool DriveLightOn => _machine.DiskIIController.DriveLight;
 
+		public string DriveLightIconDescription => "Disk Drive Activity LED";
+
 		private bool _nextPressed;
 		private bool _prevPressed;
 

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/C64.IDriveLight.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/C64.IDriveLight.cs
@@ -6,5 +6,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 	{
 		public bool DriveLightEnabled => _board != null && (_board.CartPort.DriveLightEnabled || _board.Serial.DriveLightEnabled);
 		public bool DriveLightOn => _board != null && (_board.CartPort.DriveLightOn || _board.Serial.DriveLightOn);
+
+		public string DriveLightIconDescription => "Cart or Disk Activity LED";
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/CartridgeDevice.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/CartridgeDevice.cs
@@ -270,5 +270,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 			get => _driveLightOn;
 			protected set => _driveLightOn = value;
 		}
+
+		public string DriveLightIconDescription => "Cart Activity";
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/CartridgePort.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/CartridgePort.cs
@@ -135,5 +135,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 
 		public bool DriveLightEnabled => _connected && _cartridgeDevice.DriveLightEnabled;
 		public bool DriveLightOn => _connected && _cartridgeDevice.DriveLightOn;
+
+		public string DriveLightIconDescription => "Cart Activity";
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/SerialPort.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/SerialPort.cs
@@ -75,5 +75,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
 		public bool DriveLightEnabled => true;
 		public bool DriveLightOn => ReadDeviceLight();
 		public bool IsConnected => _connected;
+
+		public string DriveLightIconDescription => "Serial Activity";
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.cs
@@ -280,5 +280,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 		public bool DriveLightOn =>
 			_machine?.TapeDevice?.TapeIsPlaying == true
 			|| _machine?.UPDDiskDevice?.DriveLight == true;
+
+		public string DriveLightIconDescription => "Disc Drive Activity";
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/jaguar/VirtualJaguar.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/jaguar/VirtualJaguar.cs
@@ -243,6 +243,8 @@ namespace BizHawk.Emulation.Cores.Atari.Jaguar
 		public bool DriveLightEnabled => IsJaguarCD;
 		public bool DriveLightOn { get; private set; }
 
+		public string DriveLightIconDescription => "CD Drive Activity";
+
 		private readonly LibVirtualJaguar.CDTOCCallback _cdTocCallback;
 		private readonly LibVirtualJaguar.CDReadCallback _cdReadCallback;
 		

--- a/src/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.cs
@@ -82,5 +82,7 @@ namespace BizHawk.Emulation.Cores.Consoles.ChannelF
 		public bool DriveLightEnabled => Cartridge.HasActivityLED;
 
 		public bool DriveLightOn => Cartridge.ActivityLED;
+
+		public string DriveLightIconDescription => "Computer thinking activity";
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IDriveLight.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IDriveLight.cs
@@ -7,5 +7,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		public bool DriveLightEnabled { get; }
 
 		public bool DriveLightOn { get; private set; }
+
+		public string DriveLightIconDescription => "Disk Drive Activity";
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.IDriveLight.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.IDriveLight.cs
@@ -7,5 +7,7 @@ namespace BizHawk.Emulation.Cores.PCEngine
 		public bool DriveLightEnabled { get; } = true;
 
 		public bool DriveLightOn { get; internal set; }
+
+		public string DriveLightIconDescription => "CD Drive Activity";
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/PicoDrive/PicoDrive.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/PicoDrive/PicoDrive.cs
@@ -281,6 +281,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.PicoDrive
 		public bool DriveLightEnabled { get; }
 		public bool DriveLightOn { get; private set; }
 
+		public string DriveLightIconDescription => "CD Drive Activity";
+
 		public DisplayType Region => _isPal ? DisplayType.PAL : DisplayType.NTSC;
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IDriveLight.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IDriveLight.cs
@@ -7,6 +7,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 		public bool DriveLightEnabled { get; }
 		public bool DriveLightOn { get; private set; }
 
+		public string DriveLightIconDescription => "CD Drive Activity";
+
 		private bool _driveLight;
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
@@ -453,6 +453,7 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 
 		public bool DriveLightEnabled { get; private set; }
 		public bool DriveLightOn { get; private set; }
+		public string DriveLightIconDescription => "CD Drive Activity";
 
 		private void Attach()
 		{

--- a/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.Cd.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.Cd.cs
@@ -47,5 +47,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 
 		public bool DriveLightEnabled => _disks?.Length > 0;
 		public bool DriveLightOn { get; private set; }
+
+		public string DriveLightIconDescription => "CD Drive Activity";
 	}
 }


### PR DESCRIPTION
A number of cores are using the IDriveLight interface, but many of them aren't using it for disk drive activity. We have disks, CDs, carts and other things hooked up.

This PR adds a DriveLightIconDescription string to the IDriveLight interface, allowing for cores to set their own ToolTip on the drive light icon.

I was planning on using a default implementation in the interface (so that cores didn't have to explicitly set a value and we could use the default), but it looks like this might require a higher version of C#.

Thoughts?

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [ ] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
