### PR TITLE
Dispose input files in DiscoHawk

### DIFF
--- a/src/BizHawk.Emulation.DiscSystem/DiscoHawkLogic/DiscoHawkLogic.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscoHawkLogic/DiscoHawkLogic.cs
@@ -257,12 +257,12 @@ namespace BizHawk.Emulation.DiscSystem
 		{
 			DiscMountJob job = new(inputPath, discInterface);
 			job.Run();
-			var disc = job.OUT_Disc;
 			if (job.OUT_ErrorLevel)
 			{
 				errorCallback(job.OUT_Log);
 				return false;
 			}
+			using var disc = job.OUT_Disc;
 			var (dir, baseName, _) = inputPath.SplitPathToDirFileAndExt();
 			var ext = hawkedFormat switch
 			{


### PR DESCRIPTION
Add `using` statement to stop DiscoHawk from holding on to file handles.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
