### PR TITLE
Improve Lua REPL handling of statements

### DIFF
--- a/src/BizHawk.Client.Common/lua/ILuaLibraries.cs
+++ b/src/BizHawk.Client.Common/lua/ILuaLibraries.cs
@@ -51,7 +51,7 @@ namespace BizHawk.Client.Common
 
 		void SpawnAndSetFileThread(string pathToLoad, LuaFile lf);
 
-		void ExecuteString(string command);
+		object[] ExecuteString(string command);
 
 		(bool WaitForFrame, bool Terminated) ResumeScript(LuaFile lf);
 	}

--- a/src/BizHawk.Client.Common/lua/ILuaLibraries.cs
+++ b/src/BizHawk.Client.Common/lua/ILuaLibraries.cs
@@ -51,6 +51,12 @@ namespace BizHawk.Client.Common
 
 		void SpawnAndSetFileThread(string pathToLoad, LuaFile lf);
 
+		/// <summary>
+		/// Executes Lua code. Automatically prepends <see langword="return"/> statement if possible.
+		/// </summary>
+		/// <returns>
+		/// Values returned by the Lua script, if any.
+		/// </returns>
 		object[] ExecuteString(string command);
 
 		(bool WaitForFrame, bool Terminated) ResumeScript(LuaFile lf);

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -1388,18 +1388,14 @@ namespace BizHawk.Client.EmuHawk
 
 					LuaSandbox.Sandbox(null, () =>
 					{
-						LuaImp.ExecuteString($"console.log({rawCommand})");
-					}, () =>
-					{
-						LuaSandbox.Sandbox(null, () =>
+						var results = LuaImp.ExecuteString(rawCommand);
+						// empty array if the command was e.g. a variable assignment or a loop without return statement
+						// "void" functions return a single null
+						// if output didn't change, Print will take care of writing out "(no return)"
+						if (results is not [ ] and not [ null ] || OutputBox.Text == consoleBeforeCall)
 						{
-							LuaImp.ExecuteString(rawCommand);
-
-							if (OutputBox.Text == consoleBeforeCall)
-							{
-								WriteLine("Command successfully executed");
-							}
-						});
+							LuaLibraries.Print(results);
+						}
 					});
 
 					_messageCount = 0;

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -1392,7 +1392,7 @@ namespace BizHawk.Client.EmuHawk
 						// empty array if the command was e.g. a variable assignment or a loop without return statement
 						// "void" functions return a single null
 						// if output didn't change, Print will take care of writing out "(no return)"
-						if (results is not ([ ] or [ null ]) || OutputBox.Text == consoleBeforeCall)
+						if (results is not ([ ] or [ null ]) || ReferenceEquals(OutputBox.Text, consoleBeforeCall))
 						{
 							LuaLibraries.Print(results);
 						}

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -1392,7 +1392,7 @@ namespace BizHawk.Client.EmuHawk
 						// empty array if the command was e.g. a variable assignment or a loop without return statement
 						// "void" functions return a single null
 						// if output didn't change, Print will take care of writing out "(no return)"
-						if (results is not [ ] and not [ null ] || OutputBox.Text == consoleBeforeCall)
+						if (results is not ([ ] or [ null ]) || OutputBox.Text == consoleBeforeCall)
 						{
 							LuaLibraries.Print(results);
 						}

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -1392,7 +1392,7 @@ namespace BizHawk.Client.EmuHawk
 						// empty array if the command was e.g. a variable assignment or a loop without return statement
 						// "void" functions return a single null
 						// if output didn't change, Print will take care of writing out "(no return)"
-						if (results is not ([ ] or [ null ]) || ReferenceEquals(OutputBox.Text, consoleBeforeCall))
+						if (results is not ([ ] or [ null ]) || OutputBox.Text == consoleBeforeCall)
 						{
 							LuaLibraries.Print(results);
 						}

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -1373,7 +1373,6 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (e.KeyCode == Keys.Enter)
 			{
-				string consoleBeforeCall = OutputBox.Text;
 				var rawCommand = InputBox.Text;
 				InputBox.Clear();
 				InputBox.Refresh(); // if the command is something like `client.seekframe`, the Lua Console (and MainForm) will freeze until it finishes, so at least make it obvious that the Enter press was received
@@ -1388,11 +1387,12 @@ namespace BizHawk.Client.EmuHawk
 
 					LuaSandbox.Sandbox(null, () =>
 					{
+						var prevMessageCount = _messageCount;
 						var results = LuaImp.ExecuteString(rawCommand);
 						// empty array if the command was e.g. a variable assignment or a loop without return statement
 						// "void" functions return a single null
 						// if output didn't change, Print will take care of writing out "(no return)"
-						if (results is not ([ ] or [ null ]) || OutputBox.Text == consoleBeforeCall)
+						if (results is not ([ ] or [ null ]) || _messageCount == prevMessageCount)
 						{
 							LuaLibraries.Print(results);
 						}

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaLibraries.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaLibraries.cs
@@ -323,8 +323,35 @@ namespace BizHawk.Client.EmuHawk
 		public void SpawnAndSetFileThread(string pathToLoad, LuaFile lf)
 			=> lf.Thread = SpawnCoroutine(pathToLoad);
 
-		public void ExecuteString(string command)
-			=> _lua.DoString(command);
+		/// <summary>
+		/// Executes Lua code. Automatically prepends <see langword="return"/> statement if possible.
+		/// </summary>
+		/// <returns>
+		/// Values returned by the Lua script, if any.
+		/// </returns>
+		public object[] ExecuteString(string command)
+		{
+			const string ChunkName = "input"; // shows up in error messages
+
+			// Use LoadString to separate parsing and execution, to tell syntax errors and runtime errors apart
+			LuaFunction func;
+			try
+			{
+				// Adding a return is necessary to get out return values of functions and turn expressions ("1+1" etc.) into valid statements
+				func = _lua.LoadString($"return {command}", ChunkName);
+			}
+			catch (Exception)
+			{
+				// command may be a valid statement without the added "return"
+				// if previous attempt couldn't be parsed, run the raw command
+				return _lua.DoString(command, ChunkName);
+			}
+
+			using (func)
+			{
+				return func.Call();
+			}
+		}
 
 		public (bool WaitForFrame, bool Terminated) ResumeScript(LuaFile lf)
 		{

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaLibraries.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaLibraries.cs
@@ -323,12 +323,6 @@ namespace BizHawk.Client.EmuHawk
 		public void SpawnAndSetFileThread(string pathToLoad, LuaFile lf)
 			=> lf.Thread = SpawnCoroutine(pathToLoad);
 
-		/// <summary>
-		/// Executes Lua code. Automatically prepends <see langword="return"/> statement if possible.
-		/// </summary>
-		/// <returns>
-		/// Values returned by the Lua script, if any.
-		/// </returns>
 		public object[] ExecuteString(string command)
 		{
 			const string ChunkName = "input"; // shows up in error messages


### PR DESCRIPTION
Rework the way the Lua console REPL executes commands

The old way first tries to execute `$"console.log({rawCommand})"`, which prints out the values of an entered expression, but results in a syntax error if the command is a statement such as `foo = 1`. If the first attempt errors, it executes the raw command without the log call, so the command still works, but it's printing out confusing syntax error messages anyway. If the expression itself causes an error like `"a" + 1` or `string.format("%error")`, it tries to run it twice and prints out two different errors.

The PR changes it so `LuaLibraries.ExecuteString` attempts to first parse the modified command without running it, and then only executes either the modified command or the raw command. This avoids unnecessary error messages, double execution of certain commands etc.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
