### PR TITLE
Cheat load/save fixes

### DIFF
--- a/src/BizHawk.Client.Common/tools/Cheat.cs
+++ b/src/BizHawk.Client.Common/tools/Cheat.cs
@@ -73,7 +73,11 @@ namespace BizHawk.Client.Common
 
 		public int? Compare => _compare.HasValue && !IsSeparator ? _compare : null;
 
-		public MemoryDomain Domain => _watch.Domain;
+		public MemoryDomain Domain
+		{
+			get =>	_watch.Domain;
+			set => _watch.Domain = value;
+		}
 
 		public WatchSize Size => _watch.Size;
 

--- a/src/BizHawk.Client.Common/tools/CheatList.cs
+++ b/src/BizHawk.Client.Common/tools/CheatList.cs
@@ -205,12 +205,6 @@ namespace BizHawk.Client.Common
 			Changes = true;
 		}
 
-		public void RemoveAll()
-		{
-			_cheatList.Clear();
-			Changes = true;
-		}
-
 		public void Clear()
 		{
 			_cheatList.Clear();

--- a/src/BizHawk.Client.Common/tools/CheatList.cs
+++ b/src/BizHawk.Client.Common/tools/CheatList.cs
@@ -404,6 +404,24 @@ namespace BizHawk.Client.Common
 			return true;
 		}
 
+		public void UpdateDomains(IMemoryDomains domains)
+		{
+			for (int i = _cheatList.Count - 1; i >= 0; i--)
+			{
+				var cheat = _cheatList[i];
+				var newDomain = domains[cheat.Domain.Name];
+				if (newDomain is not null)
+				{
+					cheat.Domain = newDomain;
+				}
+				else
+				{
+					_cheatList.RemoveAt(i);
+					Changes = true;
+				}
+			}
+		}
+
 		private static readonly RigidMultiPredicateSort<Cheat> ColumnSorts
 			= new RigidMultiPredicateSort<Cheat>(new Dictionary<string, Func<Cheat, IComparable>>
 			{

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3774,21 +3774,32 @@ namespace BizHawk.Client.EmuHawk
 						}
 					}
 
+					var previousRom = CurrentlyOpenRom;
 					CurrentlyOpenRom = oaOpenrom?.Path ?? openAdvancedArgs;
 					CurrentlyOpenRomArgs = args;
 
 					Tools.Restart(Config, Emulator, Game);
 
-					if (Config.Cheats.LoadFileByGame && Emulator.HasMemoryDomains())
+					if (previousRom != CurrentlyOpenRom)
 					{
-						CheatList.SetDefaultFileName(Tools.GenerateDefaultCheatFilename());
-						if (CheatList.AttemptToLoadCheatFile(Emulator.AsMemoryDomains()))
+						CheatList.NewList(Tools.GenerateDefaultCheatFilename(), autosave: true);
+						if (Config.Cheats.LoadFileByGame && Emulator.HasMemoryDomains())
 						{
-							AddOnScreenMessage("Cheats file loaded");
+							if (CheatList.AttemptToLoadCheatFile(Emulator.AsMemoryDomains()))
+							{
+								AddOnScreenMessage("Cheats file loaded");
+							}
 						}
-						else if (CheatList.Any())
+					}
+					else
+					{
+						if (Emulator.HasMemoryDomains())
 						{
-							CheatList.Clear();
+							CheatList.UpdateDomains(Emulator.AsMemoryDomains());
+						}
+						else
+						{
+							CheatList.NewList(Tools.GenerateDefaultCheatFilename(), autosave: true);
 						}
 					}
 
@@ -3829,6 +3840,7 @@ namespace BizHawk.Client.EmuHawk
 					DisplayManager.UpdateGlobals(Config, Emulator);
 					DisplayManager.Blank();
 					ExtToolManager.BuildToolStrip();
+					CheatList.NewList("", autosave: true);
 					OnRomChanged();
 					return false;
 				}
@@ -3964,6 +3976,7 @@ namespace BizHawk.Client.EmuHawk
 				PauseOnFrame = null;
 				CurrentlyOpenRom = null;
 				CurrentlyOpenRomArgs = null;
+				CheatList.NewList("", autosave: true);
 				OnRomChanged();
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -1638,7 +1638,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void UnfreezeAllMenuItem_Click(object sender, EventArgs e)
 		{
-			MainForm.CheatList.RemoveAll();
+			MainForm.CheatList.Clear();
 		}
 
 		private void PokeAddressMenuItem_Click(object sender, EventArgs e)
@@ -1884,7 +1884,7 @@ namespace BizHawk.Client.EmuHawk
 				case Keys.Delete:
 					if (e.Modifiers == Keys.Shift)
 					{
-						MainForm.CheatList.RemoveAll();
+						MainForm.CheatList.Clear();
 					}
 					else
 					{

--- a/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -586,11 +586,6 @@ namespace BizHawk.Client.EmuHawk
 			_emulator = emulator;
 			_game = game;
 			_apiProvider = null;
-			// If Cheat tool is loaded, restarting will restart the list too anyway
-			if (!Has<Cheats>())
-			{
-				_owner.CheatList.NewList(GenerateDefaultCheatFilename(), autosave: true);
-			}
 
 			var unavailable = new List<IToolForm>();
 

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
@@ -1377,7 +1377,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void UnfreezeAllContextMenuItem_Click(object sender, EventArgs e)
 		{
-			MainForm.CheatList.RemoveAll();
+			MainForm.CheatList.Clear();
 		}
 
 		private void ViewInHexEditorContextMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -1169,7 +1169,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void UnfreezeAllContextMenuItem_Click(object sender, EventArgs e)
 		{
-			MainForm.CheatList.RemoveAll();
+			MainForm.CheatList.Clear();
 		}
 
 		private void ViewInHexEditorContextMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
Some fixes to how the cheat list is saved/loaded during rom load/close

- Fix cheat file for different game being deleted when switching roms while the Cheat window is open (resolve #3085)
- Ensure that cheats referencing disposed memory domains are either cleared or updated
  - Fix access violation when closing rom while the Cheat window is open
  - Fix access violation when loading rom while the Cheat window is open and `Config.Cheats.LoadFileByGame` is disabled

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
