### PR TITLE
Main window auto-size fixes

### DIFF
--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -142,6 +142,7 @@ namespace BizHawk.Client.Common
 		public bool StartFullscreen { get; set; }
 		public Point? MainWindowPosition { get; set; }
 		public Size? MainWindowSize { get; set; }
+		public bool MainWindowMaximized { get; set; }
 		public bool RunInBackground { get; set; } = true;
 		public bool AcceptBackgroundInput { get; set; }
 		public bool AcceptBackgroundInputControllerOnly { get; set; }

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1585,6 +1585,11 @@ namespace BizHawk.Client.EmuHawk
 		private void MainForm_Resize(object sender, EventArgs e)
 		{
 			_presentationPanel.Resized = true;
+			if (_framebufferResizedPending && WindowState is FormWindowState.Normal)
+			{
+				_framebufferResizedPending = false;
+				FrameBufferResized();
+			}
 		}
 
 		private void MainForm_Shown(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1433,14 +1433,17 @@ namespace BizHawk.Client.EmuHawk
 				// Is window off the screen at this size?
 				if (!area.Contains(Bounds))
 				{
+					// At large framebuffer sizes/low screen resolutions, the window may be too large to fit the screen even at 1x scale
+					// Prioritize that the top-left of the window is on-screen so the title bar and menu stay accessible
+
 					if (Bounds.Right > area.Right) // Window is off the right edge
 					{
-						Location = new Point(area.Right - Size.Width, Location.Y);
+						Left = Math.Max(area.Right - Size.Width, area.Left);
 					}
 
 					if (Bounds.Bottom > area.Bottom) // Window is off the bottom edge
 					{
-						Location = new Point(Location.X, area.Bottom - Size.Height);
+						Top = Math.Max(area.Bottom - Size.Height, area.Top);
 					}
 				}
 			}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -610,6 +610,11 @@ namespace BizHawk.Client.EmuHawk
 				{
 					Size = size;
 				}
+
+				if (Config.MainWindowMaximized)
+				{
+					WindowState = FormWindowState.Maximized;
+				}
 			}
 
 			if (Config.MainFormStayOnTop) TopMost = true;
@@ -2434,6 +2439,7 @@ namespace BizHawk.Client.EmuHawk
 					Config.MainWindowPosition = Location;
 					Config.MainWindowSize = Size;
 				}
+				Config.MainWindowMaximized = WindowState is FormWindowState.Maximized && !_inFullscreen;
 			}
 			else
 			{

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1390,6 +1390,12 @@ namespace BizHawk.Client.EmuHawk
 
 		public void FrameBufferResized(bool forceWindowResize = false)
 		{
+			if (WindowState is not FormWindowState.Normal)
+			{
+				// Wait until no longer maximized/minimized to get correct size/location values
+				_framebufferResizedPending = true;
+				return;
+			}
 			if (!Config.ResizeWithFramebuffer && !forceWindowResize)
 			{
 				return;
@@ -1692,6 +1698,7 @@ namespace BizHawk.Client.EmuHawk
 		private bool _inFullscreen;
 		private Point _windowedLocation;
 		private bool _needsFullscreenOnLoad;
+		private bool _framebufferResizedPending;
 
 		private int _lastOpenRomFilter;
 


### PR DESCRIPTION
- Ensure that the top left corner of the window remains on screen if the entire window cannot fit at 1x scale
  - Fix title bar/menu moving off-screen with unusually large framebuffer sizes
  - The bottom/right edge may move off-screen instead, but that seems like the lesser evil
- When `MainWindow.FrameBufferResized` is called while the window is minimized or maximized, defer the resize until the window is restored to normal again
  - Fix window being disproportioned or moving erratically because the resize logic was working off of the minimized/maximized window sizes
- Remember window maximized state after restart
  - This was intended to be part of #4011, but it depends on the previous fix to work properly

Resolves #2850

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
