### PR TITLE
Auto-generate preferred cores from source

### DIFF
--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -18,50 +18,15 @@ namespace BizHawk.Client.Common
 	{
 		public static string ControlDefaultPath => Path.Combine(PathUtils.ExeDirectoryPath, "defctrl.json");
 
-		/// <remarks>
-		/// <c>CoreNames[0]</c> is the default (out-of-the-box) core.<br/>
-		/// <c>AppliesTo</c> are concatenated to make the submenu's label, and
-		/// <c>Config.PreferredCores[AppliesTo[0]]</c> (lookup on global <see cref="Config"/> instance) determines which option is shown as checked.<br/>
-		/// The order within submenus and the order of the submenus themselves are determined by the declaration order here.
-		/// </remarks>
-		public static readonly IReadOnlyList<(string[] AppliesTo, string[] CoreNames)> CorePickerUIData = new List<(string[], string[])>
-		{
-			([ VSystemID.Raw.A26 ],
-				[ CoreNames.Atari2600Hawk, CoreNames.Stella ]),
-			([ VSystemID.Raw.Satellaview ],
-				[ CoreNames.Bsnes115, CoreNames.SubBsnes115 ]),
-			([ VSystemID.Raw.GB, VSystemID.Raw.GBC ],
-				[ CoreNames.Gambatte, CoreNames.Sameboy, CoreNames.GbHawk, CoreNames.SubGbHawk ]),
-			([ VSystemID.Raw.GBL ],
-				[ CoreNames.GambatteLink, CoreNames.GBHawkLink, CoreNames.GBHawkLink3x, CoreNames.GBHawkLink4x ]),
-			([ VSystemID.Raw.SGB ],
-				[ CoreNames.Gambatte, CoreNames.Bsnes115, CoreNames.SubBsnes115, CoreNames.Bsnes ]),
-			([ VSystemID.Raw.GEN ],
-				[ CoreNames.Gpgx, CoreNames.PicoDrive ]),
-			([ VSystemID.Raw.N64 ],
-				[ CoreNames.Mupen64Plus, CoreNames.Ares64 ]),
-			([ VSystemID.Raw.NES ],
-				[ CoreNames.QuickNes, CoreNames.NesHawk, CoreNames.SubNesHawk ]),
-			([ VSystemID.Raw.PCE, VSystemID.Raw.PCECD, VSystemID.Raw.SGX, VSystemID.Raw.SGXCD ],
-				[ CoreNames.TurboNyma, CoreNames.HyperNyma, CoreNames.PceHawk ]),
-			([ VSystemID.Raw.PSX ],
-				[ CoreNames.Nymashock, CoreNames.Octoshock ]),
-			([ VSystemID.Raw.SMS, VSystemID.Raw.GG, VSystemID.Raw.SG ],
-				[ CoreNames.Gpgx, CoreNames.SMSHawk ]),
-			([ VSystemID.Raw.SNES ],
-				[ CoreNames.Snes9X, CoreNames.Bsnes115, CoreNames.SubBsnes115, CoreNames.Faust, CoreNames.Bsnes ]),
-			([ VSystemID.Raw.TI83 ],
-				[ CoreNames.Emu83, CoreNames.TI83Hawk ]),
-		};
-
 		public static Dictionary<string, string> GenDefaultCorePreferences()
 		{
 			Dictionary<string, string> dict = new();
-			foreach (var (appliesTo, coreNames) in CorePickerUIData)
+			foreach(var (systemId, cores) in CoreInventory.Instance.AllCores)
 			{
-				var defaultCore = coreNames[0];
-				foreach (var sysID in appliesTo) dict[sysID] = defaultCore;
+				if (cores.Count > 1)
+					dict[systemId] = cores.Find(core => core.Priority == CorePriority.DefaultPreference)?.Name;
 			}
+
 			return dict;
 		}
 

--- a/src/BizHawk.Emulation.Cores/Calculators/Emu83/Emu83.cs
+++ b/src/BizHawk.Emulation.Cores/Calculators/Emu83/Emu83.cs
@@ -26,7 +26,7 @@ namespace BizHawk.Emulation.Cores.Calculators.Emu83
 
 		private readonly TI83Disassembler _disassembler = new();
 
-		[CoreConstructor(VSystemID.Raw.TI83)]
+		[CoreConstructor(VSystemID.Raw.TI83, Priority = CorePriority.DefaultPreference)]
 		public Emu83(CoreLoadParameters<TI83CommonSettings, object> lp)
 		{
 			try

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.cs
@@ -18,7 +18,7 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 			public const string Tapper = "SHA1:E986E1818E747BEB9B33CE4DFF1CDC6B55BDB620";
 		}
 
-		[CoreConstructor(VSystemID.Raw.A26)]
+		[CoreConstructor(VSystemID.Raw.A26, Priority = CorePriority.DefaultPreference)]
 		public Atari2600(GameInfo game, byte[] rom, Atari2600.A2600Settings settings, Atari2600.A2600SyncSettings syncSettings)
 		{
 			var ser = new BasicServiceProvider(this);

--- a/src/BizHawk.Emulation.Cores/Consoles/NEC/PCE/HyperNyma.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/NEC/PCE/HyperNyma.cs
@@ -34,10 +34,10 @@ namespace BizHawk.Emulation.Cores.Consoles.NEC.PCE
 		private readonly LibHyperNyma _hyperNyma;
 		private readonly bool _hasCds;
 
-		[CoreConstructor(VSystemID.Raw.PCE, Priority = CorePriority.Low)]
-		[CoreConstructor(VSystemID.Raw.SGX, Priority = CorePriority.Low)]
-		[CoreConstructor(VSystemID.Raw.PCECD, Priority = CorePriority.Low)]
-		[CoreConstructor(VSystemID.Raw.SGXCD, Priority = CorePriority.Low)]
+		[CoreConstructor(VSystemID.Raw.PCE)]
+		[CoreConstructor(VSystemID.Raw.SGX)]
+		[CoreConstructor(VSystemID.Raw.PCECD)]
+		[CoreConstructor(VSystemID.Raw.SGXCD)]
 		public HyperNyma(CoreLoadParameters<NymaSettings, NymaSyncSettings> lp)
 			: base(lp.Comm, VSystemID.Raw.PCE, "PC Engine Controller", lp.Settings, lp.SyncSettings)
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/NEC/PCE/TurboNyma.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/NEC/PCE/TurboNyma.cs
@@ -36,10 +36,10 @@ namespace BizHawk.Emulation.Cores.Consoles.NEC.PCE
 		private readonly LibTurboNyma _turboNyma;
 		private readonly bool _hasCds;
 
-		[CoreConstructor(VSystemID.Raw.PCE)]
-		[CoreConstructor(VSystemID.Raw.SGX)]
-		[CoreConstructor(VSystemID.Raw.PCECD)]
-		[CoreConstructor(VSystemID.Raw.SGXCD)]
+		[CoreConstructor(VSystemID.Raw.PCE, Priority = CorePriority.DefaultPreference)]
+		[CoreConstructor(VSystemID.Raw.SGX, Priority = CorePriority.DefaultPreference)]
+		[CoreConstructor(VSystemID.Raw.PCECD, Priority = CorePriority.DefaultPreference)]
+		[CoreConstructor(VSystemID.Raw.SGXCD, Priority = CorePriority.DefaultPreference)]
 		public TurboNyma(CoreLoadParameters<NymaSettings, NymaSyncSettings> lp)
 			: base(lp.Comm, VSystemID.Raw.PCE, "PC Engine Controller", lp.Settings, lp.SyncSettings)
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.cs
@@ -17,8 +17,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 	[ServiceNotApplicable(new[] { typeof(IDriveLight) })]
 	public partial class BsnesCore : IEmulator, IDebuggable, IVideoProvider, ISaveRam, IStatable, IInputPollable, IRegionable, ISettable<BsnesCore.SnesSettings, BsnesCore.SnesSyncSettings>, IBSNESForGfxDebugger, IBoardInfo
 	{
-		[CoreConstructor(VSystemID.Raw.Satellaview)]
-		[CoreConstructor(VSystemID.Raw.SGB)]
+		[CoreConstructor(VSystemID.Raw.Satellaview, Priority = CorePriority.DefaultPreference)]
+		[CoreConstructor(VSystemID.Raw.SGB, Priority = CorePriority.DefaultPreference)]
 		[CoreConstructor(VSystemID.Raw.SNES)]
 		public BsnesCore(CoreLoadParameters<SnesSettings, SnesSyncSettings> loadParameters) : this(loadParameters, false) { }
 		public BsnesCore(CoreLoadParameters<SnesSettings, SnesSyncSettings> loadParameters, bool subframe = false)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
@@ -19,8 +19,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 		/// <remarks>HACK disables BIOS requirement if the environment looks like a test runner...</remarks>
 		private static readonly bool TestromsBIOSDisableHack = Type.GetType("Microsoft.VisualStudio.TestTools.UnitTesting.Assert, Microsoft.VisualStudio.TestPlatform.TestFramework") is not null;
 
-		[CoreConstructor(VSystemID.Raw.GB)]
-		[CoreConstructor(VSystemID.Raw.GBC)]
+		[CoreConstructor(VSystemID.Raw.GB, Priority = CorePriority.DefaultPreference)]
+		[CoreConstructor(VSystemID.Raw.GBC, Priority = CorePriority.DefaultPreference)]
 		[CoreConstructor(VSystemID.Raw.SGB)]
 		public Gameboy(CoreComm comm, IGameInfo game, byte[] file, GambatteSettings settings, GambatteSyncSettings syncSettings, bool deterministic)
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/GambatteLink.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/GambatteLink.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 	[ServiceNotApplicable(new[] { typeof(IDriveLight) })]
 	public partial class GambatteLink : ILinkable, ILinkedGameBoyCommon, IRomInfo
 	{
-		[CoreConstructor(VSystemID.Raw.GBL)]
+		[CoreConstructor(VSystemID.Raw.GBL, Priority = CorePriority.DefaultPreference)]
 		public GambatteLink(CoreLoadParameters<GambatteLinkSettings, GambatteLinkSyncSettings> lp)
 		{
 			if (lp.Roms.Count < MIN_PLAYERS || lp.Roms.Count > MAX_PLAYERS)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.cs
@@ -18,7 +18,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 		/// <param name="file">Rom that should be loaded</param>
 		/// <param name="rom">rom data with consistent endianness/order</param>
 		/// <param name="syncSettings">N64SyncSettings object</param>
-		[CoreConstructor(VSystemID.Raw.N64)]
+		[CoreConstructor(VSystemID.Raw.N64, Priority = CorePriority.DefaultPreference)]
 		public N64(GameInfo game, byte[] file, byte[] rom, N64Settings settings, N64SyncSettings syncSettings)
 		{
 			if (OSTailoredCode.IsUnixHost) throw new NotImplementedException();

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.cs
@@ -28,7 +28,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 			QN = BizInvoker.GetInvoker<LibQuickNES>(resolver, CallingConventionAdapters.Native);
 		}
 
-		[CoreConstructor(VSystemID.Raw.NES)]
+		[CoreConstructor(VSystemID.Raw.NES, Priority = CorePriority.DefaultPreference)]
 		public QuickNES(byte[] file, QuickNESSettings settings, QuickNESSyncSettings syncSettings)
 		{
 			ServiceProvider = new BasicServiceProvider(this);

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES9X/Snes9x.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES9X/Snes9x.cs
@@ -14,7 +14,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES9X
 	{
 		private readonly LibSnes9x _core;
 
-		[CoreConstructor(VSystemID.Raw.SNES)]
+		[CoreConstructor(VSystemID.Raw.SNES, Priority = CorePriority.DefaultPreference)]
 		public Snes9x(CoreLoadParameters<Settings, SyncSettings> loadParameters)
 			:base(loadParameters.Comm, new Configuration
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.cs
@@ -19,10 +19,10 @@ namespace BizHawk.Emulation.Cores.PCEngine
 
 		int IVideoLogicalOffsets.ScreenY => Settings.TopLine;
 
-		[CoreConstructor(VSystemID.Raw.PCE, Priority = CorePriority.Low)]
-		[CoreConstructor(VSystemID.Raw.SGX, Priority = CorePriority.Low)]
-		[CoreConstructor(VSystemID.Raw.PCECD, Priority = CorePriority.Low)]
-		[CoreConstructor(VSystemID.Raw.SGXCD, Priority = CorePriority.Low)]
+		[CoreConstructor(VSystemID.Raw.PCE)]
+		[CoreConstructor(VSystemID.Raw.SGX)]
+		[CoreConstructor(VSystemID.Raw.PCECD)]
+		[CoreConstructor(VSystemID.Raw.SGXCD)]
 		public PCEngine(CoreLoadParameters<PCESettings, PCESyncSettings> lp)
 		{
 			if (lp.Discs.Count == 1 && lp.Roms.Count == 0)

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/PicoDrive/PicoDrive.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/PicoDrive/PicoDrive.cs
@@ -18,7 +18,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.PicoDrive
 		private readonly DiscSectorReader _cdReader;
 		private readonly bool _isPal;
 
-		[CoreConstructor(VSystemID.Raw.GEN, Priority = CorePriority.Low)]
+		[CoreConstructor(VSystemID.Raw.GEN)]
 		[CoreConstructor(VSystemID.Raw.Sega32X)]
 		public PicoDrive(CoreComm comm, GameInfo game, byte[] rom, bool deterministic, SyncSettings syncSettings)
 			: this(comm, game, rom, null, deterministic, syncSettings)

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.cs
@@ -18,10 +18,10 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 	public partial class GPGX : IEmulator, IVideoProvider, ISaveRam, IStatable, IRegionable,
 		IInputPollable, IDebuggable, IDriveLight, ICodeDataLogger, IDisassemblable
 	{
-		[CoreConstructor(VSystemID.Raw.GEN)]
-		[CoreConstructor(VSystemID.Raw.SMS)]
-		[CoreConstructor(VSystemID.Raw.GG)]
-		[CoreConstructor(VSystemID.Raw.SG)]
+		[CoreConstructor(VSystemID.Raw.GEN, Priority = CorePriority.DefaultPreference)]
+		[CoreConstructor(VSystemID.Raw.SMS, Priority = CorePriority.DefaultPreference)]
+		[CoreConstructor(VSystemID.Raw.GG, Priority = CorePriority.DefaultPreference)]
+		[CoreConstructor(VSystemID.Raw.SG, Priority = CorePriority.DefaultPreference)]
 		public GPGX(CoreLoadParameters<GPGXSettings, GPGXSyncSettings> lp)
 		{
 			LoadCallback = LoadArchive;

--- a/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Nymashock.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Nymashock.cs
@@ -57,7 +57,7 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 			return _cachedSettingsInfo;
 		}
 
-		[CoreConstructor(VSystemID.Raw.PSX)]
+		[CoreConstructor(VSystemID.Raw.PSX, Priority = CorePriority.DefaultPreference)]
 		public Nymashock(CoreLoadParameters<NymaSettings, NymaSyncSettings> lp)
 			: base(lp.Comm, VSystemID.Raw.PSX, "PSX Front Panel", lp.Settings, lp.SyncSettings)
 		{

--- a/src/BizHawk.Tests/Client.Common/config/CorePickerStabilityTests.cs
+++ b/src/BizHawk.Tests/Client.Common/config/CorePickerStabilityTests.cs
@@ -56,5 +56,20 @@ namespace BizHawk.Tests.Client.Common.config
 				}
 			}
 		}
+
+		[TestMethod]
+		public void AssertNoConflictingPreferenceInGroup()
+		{
+			foreach(var (systemIds, cores) in CoreInventory.Instance.SystemGroups.Where(tuple => tuple.CoreNames.Count > 1))
+			{
+				var preferredCoreForGroup = DefaultCorePrefDict[systemIds[0]];
+				foreach (var systemId in systemIds)
+				{
+					var preferredCore = DefaultCorePrefDict[systemId];
+
+					Assert.AreEqual(preferredCoreForGroup, preferredCore, $"Default core preference for {systemId} does not match the preferred core for the whole group ({string.Join(" | ", systemIds)})");
+				}
+			}
+		}
 	}
 }

--- a/src/BizHawk.Tests/Client.Common/config/CorePickerStabilityTests.cs
+++ b/src/BizHawk.Tests/Client.Common/config/CorePickerStabilityTests.cs
@@ -13,22 +13,24 @@ namespace BizHawk.Tests.Client.Common.config
 		private static readonly IReadOnlyDictionary<string, string> DefaultCorePrefDict = new Config().PreferredCores;
 
 		[TestMethod]
-		public void AssertAllChoicesInMenu()
+		public void AssertAllPrefencesExist()
 		{
 			var multiCoreSystems = CoreInventory.Instance.AllCores.Where(kvp => kvp.Value.Count != 1)
-				.Select(kvp => kvp.Key)
-				.ToHashSet();
-			foreach (var sysID in DefaultCorePrefDict.Keys)
+				.Select(kvp => kvp.Key);
+			foreach (var sysID in multiCoreSystems)
 			{
-				Assert.IsTrue(multiCoreSystems.Contains(sysID), $"a default core preference exists for {sysID} but that system doesn't have alternate cores");
+				Assert.IsTrue(DefaultCorePrefDict.ContainsKey(sysID), $"{sysID} has multiple cores, but no default core preference exists for it!");
 			}
-			foreach (var (appliesTo, _) in Config.CorePickerUIData)
+		}
+
+		[TestMethod]
+		public void AssertNoExtraPreferences()
+		{
+			var singleCoreSystems = CoreInventory.Instance.AllCores.Where(kvp => kvp.Value.Count == 1)
+				.Select(kvp => kvp.Key);
+			foreach (var sysID in singleCoreSystems)
 			{
-				Assert.IsTrue(
-					appliesTo.Any(multiCoreSystems.Contains),
-					appliesTo.Length is 1
-						? $"core picker has submenu for {appliesTo[0]}, but that system doesn't have alternate cores"
-						: $"core picker has submenu for {appliesTo[0]} ({string.Join("/", appliesTo)}), but none of those systems have alternate cores");
+				Assert.IsFalse(DefaultCorePrefDict.ContainsKey(sysID), $"{sysID} only has one core implementing it, but an unnecessary preference choice exists for it!");
 			}
 		}
 
@@ -40,26 +42,18 @@ namespace BizHawk.Tests.Client.Common.config
 			{
 				Assert.IsTrue(allCoreNames.Contains(coreName), $"default core preference for {sysID} is \"{coreName}\", which doesn't exist");
 			}
-			foreach (var (appliesTo, coreNames) in Config.CorePickerUIData) foreach (var coreName in coreNames)
-			{
-				Assert.IsTrue(allCoreNames.Contains(coreName), $"core picker includes nonexistant core \"{coreName}\" under {appliesTo[0]} group");
-			}
 		}
 
-		/// <remarks>this really shouldn't be necessary</remarks>
 		[TestMethod]
-		public void AssertNoMissingSystems()
+		public void AssertExactlyOnePreferredCore()
 		{
-			var allSysIDs = CoreInventory.Instance.AllCores.Keys.ToHashSet();
-#if false // already covered by AssertAllChoicesInMenu
-			foreach (var sysID in DefaultCorePrefDict.Keys)
+			foreach(var (systemId, cores) in CoreInventory.Instance.AllCores)
 			{
-				Assert.IsTrue(allSysIDs.Contains(sysID), $"a default core preference exists for {sysID}, which isn't emulated by any core");
-			}
-#endif
-			foreach (var (appliesTo, _) in Config.CorePickerUIData) foreach (var sysID in appliesTo)
-			{
-				Assert.IsTrue(allSysIDs.Contains(sysID), $"core picker has choices for {sysID}, which isn't emulated by any core");
+				if (cores.Count >= 2)
+				{
+					int preferredCoresCount = cores.Count(core => core.Priority == CorePriority.DefaultPreference);
+					Assert.IsTrue(preferredCoresCount == 1, $"{systemId} has {preferredCoresCount} preferred cores, expected exactly 1.");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- closes #3960

RFC.

This auto-generates the UI options for the core preferences picker from the list of available cores. This also requires changing the core attribute for many cores to signal that they are the preferred core for a specific system.
Basically, instead of having the core preference list stored entangled with the UI picker data and having to be manually maintained, the list is now based purely on the available cores.

This and the added tests ensure that all system ids with multiple core choices have an entry in the core picker (preventing mistakes like what d74b130c22a8e877cbf6ecec45a1ab714bb2f77f fixed) and that the default preference is always known, even when the user has configured a different preferred core for a given system id.

This will also make it impossible for fa08002fbf2d8481b6558630c2f57f51953b771e to occur, where quick(er)nes was both the preferred core and had lower than default priority. In reality this doesn't really show itself, but it's best to fix it nonetheless.