### PR TITLE
Move ZwinderBuffer invalidation logic into the class

### DIFF
--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -437,7 +437,7 @@ namespace BizHawk.Client.Common
 				else
 					StateCache.Remove(lastGap.Frame);
 
-				_gapFiller.InvalidateEnd(i);
+				_gapFiller.InvalidateLast();
 			}
 
 			_gapFiller.Capture(
@@ -461,9 +461,9 @@ namespace BizHawk.Client.Common
 
 		public void Clear()
 		{
-			_current.InvalidateEnd(0);
-			_recent.InvalidateEnd(0);
-			_gapFiller.InvalidateEnd(0);
+			_current.InvalidateAfter(-1);
+			_recent.InvalidateAfter(-1);
+			_gapFiller.InvalidateAfter(-1);
 			StateCache.Clear();
 			AddStateCache(0);
 			_reserved = _reserved.Where(static kvp => kvp.Key is 0).ToDictionary(); //TODO clone needed?
@@ -485,39 +485,18 @@ namespace BizHawk.Client.Common
 
 		private bool InvalidateGaps(int frame)
 		{
-			for (var i = 0; i < _gapFiller.Count; i++)
-			{
-				var state = _gapFiller.GetState(i);
-				if (state.Frame > frame)
-				{
-					_gapFiller.InvalidateEnd(i);
-					return true;
-				}
-			}
-			return false;
+			return _gapFiller.InvalidateAfter(frame);
 		}
 
 		private bool InvalidateNormal(int frame)
 		{
-			for (var i = 0; i < _recent.Count; i++)
+			if (_recent.InvalidateAfter(frame))
 			{
-				if (_recent.GetState(i).Frame > frame)
-				{
-					_recent.InvalidateEnd(i);
-					_current.InvalidateEnd(0);
-					return true;
-				}
+				_current.InvalidateAfter(-1);
+				return true;
 			}
 
-			for (var i = 0; i < _current.Count; i++)
-			{
-				if (_current.GetState(i).Frame > frame)
-				{
-					_current.InvalidateEnd(i);
-					return true;
-				}
-			}
-			return false;
+			return _current.InvalidateAfter(frame);
 		}
 
 		private bool InvalidateReserved(int frame)

--- a/src/BizHawk.Client.Common/rewind/ZeldaWinder.cs
+++ b/src/BizHawk.Client.Common/rewind/ZeldaWinder.cs
@@ -84,7 +84,7 @@ namespace BizHawk.Client.Common
 		public void Clear()
 		{
 			Sync();
-			_buffer.InvalidateEnd(0);
+			_buffer.InvalidateAfter(-1);
 			_count = 0;
 			_masterFrame = -1;
 		}
@@ -236,7 +236,7 @@ namespace BizHawk.Client.Common
 				{
 					var index = _buffer.Count - 1;
 					RefillMaster(_buffer.GetState(index));
-					_buffer.InvalidateEnd(index);
+					_buffer.InvalidateLast();
 					_stateSource.LoadStateBinary(new BinaryReader(new MemoryStream(_master, 0, _masterLength, false)));
 				}
 				else

--- a/src/BizHawk.Client.Common/rewind/Zwinder.cs
+++ b/src/BizHawk.Client.Common/rewind/Zwinder.cs
@@ -74,7 +74,7 @@ namespace BizHawk.Client.Common
 				}
 				using var br = new BinaryReader(state.GetReadStream());
 				_stateSource.LoadStateBinary(br);
-				_buffer.InvalidateEnd(index);
+				_buffer.InvalidateLast();
 			}
 			else
 			{
@@ -103,7 +103,7 @@ namespace BizHawk.Client.Common
 
 		public void Clear()
 		{
-			_buffer.InvalidateEnd(0);
+			_buffer.InvalidateAfter(-1);
 		}
 	}
 }


### PR DESCRIPTION
Addresses the slowdown concerns mentioned in https://github.com/TASEmulators/BizHawk/issues/4058#issuecomment-2381383751.

This changeset increases my fps in recording mode from ~3700 fps to ~5500 fps.
PRing because this touches state invalidation logic and I'd like to get at least a second pair of eyes on this to make sure it's correct and doesn't change any logic.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
