### PR TITLE
Fixes for PlayStation RetroAchievements hashing

### DIFF
--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.GameVerification.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.GameVerification.cs
@@ -114,6 +114,9 @@ namespace BizHawk.Client.EmuHawk
 							dsr.ReadLBA_2048(sector, buf2048, 0);
 							exePath = Encoding.ASCII.GetString(buf2048);
 
+							// replace any tab characters with space characters to normalize exePath
+							exePath = exePath.Replace('\t', ' ');
+
 							// "BOOT = cdrom:" precedes the path
 							var index = exePath.IndexOf("BOOT = cdrom:", StringComparison.Ordinal);
 							if (index < -1) break;

--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.GameVerification.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.GameVerification.cs
@@ -97,6 +97,15 @@ namespace BizHawk.Client.EmuHawk
 										return (buf2048[index + 4] << 16) | (buf2048[index + 3] << 8) | buf2048[index + 2];
 									}
 								}
+
+								// move on to next sector if filename not found in current sector due to subdirectory
+								if (buf2048[index] == 0)
+								{
+									dsr.ReadLBA_2048(++sector, buf2048, 0);
+									index = 0;
+									continue;
+								}
+
 								index += buf2048[index];
 							}
 


### PR DESCRIPTION
Minor fix for games like Chrono Cross where the SYSTEM.CNF file contains a slightly different BOOT line than expected:
"BOOT\t= cdrom:" vs
"BOOT = cdrom:"

Additional fix for games like Tekken 3 and Wild Arms where the PlayStation executable is in a subdirectory.  For example:
BOOT = cdrom:\TEKKEN3\SLUS_004.02;1 or
BOOT = cdrom:\EXE\SCUS_946.08;1

In these cases, the application would get stuck in an infinite loop while looking for the executable filename in the same disc sector.  I believe this is related to a previously closed issue (#3863).