### PR TITLE
Simplified identification of PlayStation EXE for RA hash.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.GameVerification.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.GameVerification.cs
@@ -123,22 +123,16 @@ namespace BizHawk.Client.EmuHawk
 							dsr.ReadLBA_2048(sector, buf2048, 0);
 							exePath = Encoding.ASCII.GetString(buf2048);
 
-							// replace any tab characters with space characters to normalize exePath
-							exePath = exePath.Replace('\t', ' ');
-
-							// "BOOT = cdrom:" precedes the path
-							var index = exePath.IndexOf("BOOT = cdrom:", StringComparison.Ordinal);
-							if (index < -1) break;
-							exePath = exePath.Remove(0, index + 13);
+							// the boot exe parameter has the following format "drive:\path\name.ext;version"
+							// and can be extracted as the substring between colon ':' and semicolon ';'
+							var pathStartIndex = exePath.IndexOf(':') + 1;
+							if (pathStartIndex < 1) break;
+							var pathLength = exePath.IndexOf(';') - pathStartIndex;
+							if (pathLength < 1) break;
+							exePath = exePath.Substring(startIndex: pathStartIndex, length: pathLength);
 
 							// the path might start with a number of slashes, remove these
-							index = 0;
-							while (index < exePath.Length && exePath[index] is '\\') index++;
-
-							// end of the path has ;
-							var end = exePath.IndexOf(';');
-							if (end < 0) break;
-							exePath = exePath.Substring(startIndex: index, length: end - index);
+							exePath = exePath.TrimStart('\\');
 						}
 
 						buffer.AddRange(Encoding.ASCII.GetBytes(exePath));

--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.GameVerification.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.GameVerification.cs
@@ -125,9 +125,10 @@ namespace BizHawk.Client.EmuHawk
 
 							// the boot exe parameter has the following format "drive:\path\name.ext;version"
 							// and can be extracted as the substring between colon ':' and semicolon ';'
+							// if there is no semicolon in the string use carriage return '\r' to terminate the path
 							var pathStartIndex = exePath.IndexOf(':') + 1;
 							if (pathStartIndex < 1) break;
-							var pathLength = exePath.IndexOf(';') - pathStartIndex;
+							var pathLength = (exePath.Contains(';') ? exePath.IndexOf(';') : exePath.IndexOf('\r')) - pathStartIndex;
 							if (pathLength < 1) break;
 							exePath = exePath.Substring(startIndex: pathStartIndex, length: pathLength);
 


### PR DESCRIPTION
I found another instance of the BOOT line in SYSTEM.CNF containing unexpected characters.  This is similar to the issue with Chrono Cross mentioned in #4085, but this time it's an extra space character with the game Grandia:
```
"BOOT  = cdrom:" vs
"BOOT\t= cdrom:" vs
"BOOT = cdrom:"
```

Normalizing the string again is an option, but I think something different would be better.  According to the following documentation:

https://psx-spx.consoledev.net/cdromfileformats/#cdrom-file-playstation-exe-and-systemcnf

the PlayStation executable path will have the following format:

`"drive:\path\name.ext;version"`

I think we can just pull the executable path from this part of the string by using ':' and ';' as indexes without trying to match "BOOT =" since that part of the string could contain unexpected whitespace characters.  If this is an oversimplification that won't work (in the long run) please let me know, but these changes have been working fine with Grandia, Chrono Cross and the other games I've been testing like Tekken 3 and Wild Arms.