### PR TITLE
HexEditor

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexColor.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexColor.Designer.cs
@@ -41,7 +41,9 @@
             this.HexMenubar = new System.Windows.Forms.Panel();
             this.label2 = new BizHawk.WinForms.Controls.LocLabelEx();
             this.HexBackgrnd = new System.Windows.Forms.Panel();
-            this.colorDialog1 = new System.Windows.Forms.ColorDialog();
+			this.label7 = new BizHawk.WinForms.Controls.LocLabelEx();
+			this.Hex00 = new System.Windows.Forms.Panel();
+			this.colorDialog1 = new System.Windows.Forms.ColorDialog();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -59,9 +61,11 @@
             this.groupBox1.Controls.Add(this.HexMenubar);
             this.groupBox1.Controls.Add(this.label2);
             this.groupBox1.Controls.Add(this.HexBackgrnd);
-            this.groupBox1.Location = new System.Drawing.Point(3, 2);
+			this.groupBox1.Controls.Add(this.label7);
+			this.groupBox1.Controls.Add(this.Hex00);
+			this.groupBox1.Location = new System.Drawing.Point(3, 2);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(144, 192);
+            this.groupBox1.Size = new System.Drawing.Size(144, 222);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             // 
@@ -154,12 +158,27 @@
             this.HexBackgrnd.Size = new System.Drawing.Size(20, 20);
             this.HexBackgrnd.TabIndex = 6;
             this.HexBackgrnd.MouseClick += new System.Windows.Forms.MouseEventHandler(this.HexBackground_Click);
-            // 
-            // HexColors_Form
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			// 
+			// label7
+			// 
+			this.label7.Location = new System.Drawing.Point(30, 200);
+			this.label7.Name = "label7";
+			this.label7.Text = "Zero Color";
+			// 
+			// Hex00
+			// 
+			this.Hex00.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.Hex00.Location = new System.Drawing.Point(5, 196);
+			this.Hex00.Name = "Hex00";
+			this.Hex00.Size = new System.Drawing.Size(20, 20);
+			this.Hex00.TabIndex = 18;
+			this.Hex00.MouseClick += new System.Windows.Forms.MouseEventHandler(this.Hex00_Click);
+			// 
+			// HexColors_Form
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(149, 197);
+            this.ClientSize = new System.Drawing.Size(149, 230);
             this.Controls.Add(this.groupBox1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
@@ -190,6 +209,7 @@
 		private System.Windows.Forms.Panel HexFreeze;
 		private BizHawk.WinForms.Controls.LocLabelEx label4;
 		private System.Windows.Forms.Panel HexHighlight;
-
-    }
+		private BizHawk.WinForms.Controls.LocLabelEx label7;
+		private System.Windows.Forms.Panel Hex00;
+	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexColor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexColor.cs
@@ -20,6 +20,7 @@ namespace BizHawk.Client.EmuHawk
 			HexFreeze.BackColor = _hexEditor.Colors.Freeze;
 			HexFreezeHL.BackColor = _hexEditor.Colors.HighlightFreeze;
 			HexHighlight.BackColor = _hexEditor.Colors.Highlight;
+			Hex00.BackColor = _hexEditor.Colors.Foreground00;
 		}
 
 		private void HexBackground_Click(object sender, MouseEventArgs e)
@@ -30,6 +31,15 @@ namespace BizHawk.Client.EmuHawk
 				_hexEditor.Header.BackColor = colorDialog1.Color;
 				_hexEditor.MemoryViewerBox.BackColor = _hexEditor.Colors.Background;
 				HexBackgrnd.BackColor = colorDialog1.Color;
+			}
+		}
+
+		private void Hex00_Click(object sender, MouseEventArgs e)
+		{
+			if (colorDialog1.ShowDialog().IsOk())
+			{
+				_hexEditor.Colors.Foreground00 = colorDialog1.Color;
+				Hex00.BackColor = colorDialog1.Color;
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.Designer.cs
@@ -89,7 +89,7 @@ namespace BizHawk.Client.EmuHawk
 			this.MemoryViewerBox = new System.Windows.Forms.GroupBox();
 			this.HexScrollBar = new System.Windows.Forms.VScrollBar();
 			this.AddressLabel = new BizHawk.WinForms.Controls.LocLabelEx();
-			this.AddressesLabel = new BizHawk.WinForms.Controls.LocLabelEx();
+			this.AddressesLabel = new BizHawk.WinForms.Controls.HexLabelEx();
 			this.Header = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.HexMenuStrip.SuspendLayout();
 			this.ViewerContextMenuStrip.SuspendLayout();
@@ -454,6 +454,7 @@ namespace BizHawk.Client.EmuHawk
 			this.AddressesLabel.MouseLeave += new System.EventHandler(this.AddressesLabel_MouseLeave);
 			this.AddressesLabel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.AddressesLabel_MouseMove);
 			this.AddressesLabel.MouseUp += new System.Windows.Forms.MouseEventHandler(this.AddressesLabel_MouseUp);
+			this.AddressesLabel.Paint += new System.Windows.Forms.PaintEventHandler(this.AddressesLabel_Paint);
 			// 
 			// Header
 			// 
@@ -511,7 +512,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddToRamWatchMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeAddressMenuItem;
 		public System.Windows.Forms.GroupBox MemoryViewerBox;
-		private BizHawk.WinForms.Controls.LocLabelEx AddressesLabel;
+		private BizHawk.WinForms.Controls.HexLabelEx AddressesLabel;
 		private System.Windows.Forms.VScrollBar HexScrollBar;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UnfreezeAllMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UnfreezeAllContextItem;

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.Designer.cs
@@ -454,7 +454,6 @@ namespace BizHawk.Client.EmuHawk
 			this.AddressesLabel.MouseLeave += new System.EventHandler(this.AddressesLabel_MouseLeave);
 			this.AddressesLabel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.AddressesLabel_MouseMove);
 			this.AddressesLabel.MouseUp += new System.Windows.Forms.MouseEventHandler(this.AddressesLabel_MouseUp);
-			this.AddressesLabel.Paint += new System.Windows.Forms.PaintEventHandler(this.AddressesLabel_Paint);
 			// 
 			// Header
 			// 

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -133,6 +133,7 @@ namespace BizHawk.Client.EmuHawk
 			public Color Freeze { get; set;  }= Color.LightBlue;
 			public Color Highlight { get; set; } = Color.Pink;
 			public Color HighlightFreeze { get; set; } = Color.Violet;
+			public Color Foreground00 { get; set; } = Color.SlateGray;
 		}
 
 		[ConfigPersist]
@@ -219,11 +220,21 @@ namespace BizHawk.Client.EmuHawk
 
 		protected override void UpdateAfter()
 		{
+			if (AddressesLabel.ZeroColor != Colors.Foreground00)
+			{
+				AddressesLabel.ZeroColor = Colors.Foreground00;
+			}
+
 			AddressesLabel.Text = GenerateMemoryViewString(true);
 		}
 
 		protected override void GeneralUpdate()
 		{
+			if (AddressesLabel.ZeroColor != Colors.Foreground00)
+			{
+				AddressesLabel.ZeroColor = Colors.Foreground00;
+			}
+
 			AddressesLabel.Text = GenerateMemoryViewString(true);
 			AddressLabel.Text = GenerateAddressString();
 		}
@@ -2052,54 +2063,6 @@ namespace BizHawk.Client.EmuHawk
 			{
 				HexScrollBar.Value = newValue;
 				MemoryViewerBox.Refresh();
-			}
-		}
-
-		private void AddressesLabel_Paint(object sender, PaintEventArgs e)
-		{
-			return;
-
-			if (sender is not Label label)
-				return;
-
-			char gap = ' ';
-
-			//PointF point = new PointF(label.Location.X, label.Location.Y);
-			PointF point = new PointF(0, 0);
-			string text = label.Text;
-			Font font = label.Font;
-
-			string[] lines = text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-
-			Color color = label.ForeColor;
-
-			foreach (string line in lines)
-			{
-				string[] words = line.Split(gap);
-
-				foreach (string word in words)
-				{
-					if (word == "00")
-					{
-						color = Color.SlateGray;
-					}
-					else
-					{
-						color = label.ForeColor;
-					}
-
-					SizeF size = e.Graphics.MeasureString(word, font);
-
-					using (Brush brush = new SolidBrush(color))
-					{
-						e.Graphics.DrawString(word, font, brush, point);
-					}
-
-					point.X += size.Width + e.Graphics.MeasureString(gap.ToString(), font).Width;
-				}
-
-				point.X = label.Location.X;
-				point.Y += e.Graphics.MeasureString(line, font).Height;
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -2055,6 +2055,54 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		private void AddressesLabel_Paint(object sender, PaintEventArgs e)
+		{
+			return;
+
+			if (sender is not Label label)
+				return;
+
+			char gap = ' ';
+
+			//PointF point = new PointF(label.Location.X, label.Location.Y);
+			PointF point = new PointF(0, 0);
+			string text = label.Text;
+			Font font = label.Font;
+
+			string[] lines = text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+
+			Color color = label.ForeColor;
+
+			foreach (string line in lines)
+			{
+				string[] words = line.Split(gap);
+
+				foreach (string word in words)
+				{
+					if (word == "00")
+					{
+						color = Color.SlateGray;
+					}
+					else
+					{
+						color = label.ForeColor;
+					}
+
+					SizeF size = e.Graphics.MeasureString(word, font);
+
+					using (Brush brush = new SolidBrush(color))
+					{
+						e.Graphics.DrawString(word, font, brush, point);
+					}
+
+					point.X += size.Width + e.Graphics.MeasureString(gap.ToString(), font).Width;
+				}
+
+				point.X = label.Location.X;
+				point.Y += e.Graphics.MeasureString(line, font).Height;
+			}
+		}
+
 		private void MemoryViewerBox_Paint(object sender, PaintEventArgs e)
 		{
 			var activeCheats = MainForm.CheatList.Where(x => x.Enabled);

--- a/src/BizHawk.WinForms.Controls/BizHawk.WinForms.Controls.csproj
+++ b/src/BizHawk.WinForms.Controls/BizHawk.WinForms.Controls.csproj
@@ -10,4 +10,9 @@
 		<PackageReference Include="System.Drawing.Common" />
 		<ProjectReference Include="$(ProjectDir)../BizHawk.Common/BizHawk.Common.csproj" />
 	</ItemGroup>
+	<ItemGroup>
+	  <Compile Update="LabelEx\HexLabelEx.cs">
+	    <SubType>Component</SubType>
+	  </Compile>
+	</ItemGroup>
 </Project>

--- a/src/BizHawk.WinForms.Controls/LabelEx/HexLabelEx.cs
+++ b/src/BizHawk.WinForms.Controls/LabelEx/HexLabelEx.cs
@@ -1,0 +1,121 @@
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+using BizHawk.Common;
+
+
+namespace BizHawk.WinForms.Controls
+{
+	/// <inheritdoc cref="Docs.LabelOrLinkLabel"/>
+	public class HexLabelEx : LabelExBase
+	{
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public new bool AutoSize => base.AutoSize;
+
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public new Size Size => base.Size;
+
+		public Color ZeroColor { get; set; } = Color.SlateGray;
+
+		private float spacingHexModifier;
+		private float spacingPreDivider;
+		private float spacingPostDividerModifier;
+		private float spacingAscii;
+		private float spacingLineModifier;
+
+		public HexLabelEx()
+		{
+			base.AutoSize = true;
+			this.BackColor = Color.Transparent;
+
+			spacingHexModifier = 0.7F;
+			spacingPreDivider = 3.0F;
+			spacingPostDividerModifier = 3.5F;
+			spacingAscii = 7.0F;
+			spacingLineModifier = 0.56F;
+
+			if (OSTailoredCode.IsUnixHost)
+			{
+				// TODO: spacing values will probably be different on linux
+			}
+		}
+
+		protected override void OnPaint(PaintEventArgs e)
+		{
+			string text = this.Text;
+			Font font = this.Font;
+			PointF point = new PointF(0, 0);
+			char gap = ' ';
+
+			string[] lines = text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+
+			Color color00 = this.ForeColor;
+			Color color = this.ForeColor;
+
+			foreach (string line in lines)
+			{
+				// split left and right panes
+				string[] panes = line.Split('|');
+
+				if (panes.Length < 2)
+				{
+					// skip - last line appears to be empty
+					continue;
+				}
+
+				// hex pane
+				string[] words = panes[0].Split(gap);
+				foreach (var word in words)
+				{
+					SizeF size = e.Graphics.MeasureString(word, font);
+
+					switch (word)
+					{
+						case "00":
+							color = ZeroColor;
+							break;
+
+						default:
+							color = this.ForeColor;
+							break;
+					}
+					using (Brush brush = new SolidBrush(color))
+					{
+						e.Graphics.DrawString(word, font, brush, point);
+					}
+
+					point.X += size.Width + e.Graphics.MeasureString(gap.ToString(), font).Width + spacingHexModifier;
+				}
+
+				// divider
+				string div = "|";
+				point.X -= spacingPreDivider;
+				SizeF sizeDiv = e.Graphics.MeasureString(div, font);
+				using (Brush brush = new SolidBrush(this.ForeColor))
+				{
+					e.Graphics.DrawString(div, font, brush, point);					
+				}
+
+				point.X += e.Graphics.MeasureString(gap.ToString(), font).Width + spacingPostDividerModifier;
+
+				// ascii pane
+				char[] chars = panes[1].ToCharArray();
+				foreach (var c in chars)
+				{
+					string str = c.ToString();
+
+					using (Brush brush = new SolidBrush(this.ForeColor))
+					{
+						e.Graphics.DrawString(str, font, brush, point);
+					}
+
+					// fixed size
+					point.X += spacingAscii;
+				}
+
+				point.X = 0;
+				point.Y += e.Graphics.MeasureString(line, font).Height + spacingLineModifier;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This implements a HexLabelEx control that replaces the LocaLabelEx 'AddressesLabel' control in HexEditor.cs.
It overrides OnPaint(), parses the incoming string and draws the string out using different colours depending on whether the hex value is '00' or not.
A new colour selector is also implemented within HexColor.cs so the user can choose which colour they want displayed for 00 values.

This addresses #3769 and the duplicate #3930 

Notes:

1. I could not find a way to have all this stuff directly within HexEditor.cs itself. Maybe it's just a lack of knowledge, but I needed to intercept the OnPaint control method and NOT call base.OnPaint(). But if I disable base.OnPaint() in the control, the PaintEventHandler is never called. *shrug*.
2. I'm only able to test this on Windows currently. The various arbtrary spacing floats used in HexLabelEx would have to be tested on linux and modified accordingly (there is already an OSTailoredCode.IsUnixHost check in the constructor ready to be added to).

I'm sure it can all be cleaned up, but I'm stuck at the moment on the 'how'.
