### PR TITLE
Update ffmpeg presets

### DIFF
--- a/src/BizHawk.Client.EmuHawk/AVOut/FFmpegWriterForm.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/FFmpegWriterForm.cs
@@ -46,32 +46,18 @@ namespace BizHawk.Client.EmuHawk
 			{
 				return new[]
 				{
-					new FormatPreset("AVI Lossless UT Video", "Lossless UT video and uncompressed audio in an AVI container. Compatible with AVISource(), if UT Video decoder is installed. Fast, but low compression.",
+					new FormatPreset("Social Media — MP4", "Optimized for quick and easy sharing. Produces small, highly compatible and streamable files. AVC video and Opus audio in a MP4 container.",
+						"-c:a libopus -c:v libx264 -pix_fmt yuv420p -movflags +faststart -f mp4", false, "mp4"),
+					new FormatPreset("[ Custom ]", "Write your own FFmpeg command. For advanced users only.",
+						customCommand, true, "foobar"),
+					new FormatPreset("Lossless AVC — MKV", "Lossless AVC video and lossless FLAC audio in a Matroska container. High speed and compression. Compatible with AVISource() if x264vfw or FFmpeg based decoder is installed. Seeking may be unstable.",
+						"-c:a flac -c:v libx264rgb -qp 0 -pix_fmt rgb24 -f matroska", false, "mkv"),
+					new FormatPreset("Lossless Ut Video — AVI", "Lossless Ut Video and uncompressed audio in an AVI container. Fast, but low compression. Compatible with AVISource(), if Ut Video decoder is installed.",
 						"-c:a pcm_s16le -c:v utvideo -pred median -pix_fmt gbrp -f avi", false, "avi"),
-					new FormatPreset("AVI Lossless FFV1", "Lossless FFV1 video and uncompressed audio in an AVI container. Compatible with AVISource(), if ffmpeg based decoder is installed. Slow, but high compression.",
+					new FormatPreset("Lossless FFV1 — AVI", "Lossless FFV1 video and uncompressed audio in an AVI container. Slow, but high compression. Compatible with AVISource(), if FFmpeg based decoder is installed.",
 						"-c:a pcm_s16le -c:v ffv1 -pix_fmt bgr0 -level 1 -g 1 -coder 1 -context 1 -f avi", false, "avi"),
-					new FormatPreset("AVI Lossless AVC", "Lossless AVC video and uncompressed audio in an AVI container. High speed and compression, compatible with AVISource() if x264vfw or ffmpeg based decoder is installed. Seeking may be unstable.",
-						"-c:a pcm_s16le -c:v libx264rgb -qp 0 -preset ultrafast -g 10 -pix_fmt rgb24 -f avi", false, "avi"),
-					new FormatPreset("AVI Uncompressed", "Uncompressed video and audio in an AVI container. Very large, don't use!",
-						"-c:a pcm_s16le -c:v rawvideo -f avi", false, "avi"),
-					new FormatPreset("Matroska Lossless", "Lossless AVC video and uncompressed audio in a Matroska container.",
-						"-c:a pcm_s16le -c:v libx264rgb -qp 0 -pix_fmt rgb24 -f matroska", false, "mkv"),
-					new FormatPreset("Matroska", "AVC video and Vorbis audio in a Matroska container.",
-						"-c:a libvorbis -c:v libx264 -f matroska", false, "mkv"),
-					new FormatPreset("MP4", "AVC video and AAC audio in an MP4 container.",
-						"-c:a aac -c:v libx264 -f mp4", false, "mp4"),
-					new FormatPreset("WebM", "VP8 video and Vorbis audio in a WebM container.",
-						"-c:a libvorbis -c:v libvpx -auto-alt-ref 0 -f webm", false, "webm"),
-					new FormatPreset("Ogg", "Theora video and Vorbis audio in an Ogg container.",
-						"-c:a libvorbis -c:v libtheora -f ogg", false, "ogg"),
-					new FormatPreset("Xvid", "Xvid video and MP3 audio in an AVI container.",
-						"-c:a libmp3lame -c:v libxvid -f avi", false, "avi"),
-					new FormatPreset("QuickTime", "AVC video and AAC audio in a QuickTime container.",
-						"-c:a aac -c:v libx264 -f mov", false, "mov"),
-					new FormatPreset("FLV", "AVC video and AAC audio in a Flash Video container.",
-						"-c:a aac -c:v libx264 -f flv", false, "flv"),
-					new FormatPreset("[Custom]", "Write your own ffmpeg command. For advanced users only.",
-						customCommand, true, "foobar")
+					new FormatPreset("Uncompressed — AVI", "Uncompressed video and audio in an AVI container. Extremely large files, don't use!",
+						"-c:a pcm_s16le -c:v rawvideo -f avi", false, "avi")
 				};
 			}
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fb03071e-ee97-4b7c-9ec6-4b80d52575d6)

- Removes presets that are likely completely unused and/or very outdated.
- Moves presets that are more likely to be used to the top
- MP4 becomes a "Social Media" preset with better compatibility and streaming support. Previously playback across social media platforms and clients was very unreliable. This is at the top because it's the most likely to be used. The audio codec has also been changed to Opus. At the default settings it offers comparable quality at a lower bitrate.  
Notable: It defaults to a sample rate of 48kHz. I know that deviates from the 44.1kHz that BizHawk uses but i don't think that is really a concern for this use case.
- AVC MKV now uses FLAC instead of uncompressed audio. This is the lossless preset that is most likely to be used and going for lossless compression reduces file sizes a bit.
- Ut Video and FFmpeg capitalization now match what is used in their repositories

All presets decode without issue in VLC, MPV, Handbrake and when uploaded to YouTube.

Sidenote: Custom is the only preset that accepts changes but you can still edit the command of the other presets. That is kind of misleading because those changes are not applied when starting the encode.