### PR TITLE
websocket improvements

### DIFF
--- a/src/BizHawk.Client.Common/Api/Interfaces/ICommApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/ICommApi.cs
@@ -10,9 +10,7 @@ namespace BizHawk.Client.Common
 
 		SocketServer? Sockets { get; }
 
-#if ENABLE_WEBSOCKETS
 		WebSocketServer WebSockets { get; }
-#endif
 
 		string? HttpTest();
 

--- a/src/BizHawk.Client.Common/Api/WebSocketServer.cs
+++ b/src/BizHawk.Client.Common/Api/WebSocketServer.cs
@@ -1,14 +1,9 @@
 ﻿#nullable enable
 
-using System.Threading;
-
 namespace BizHawk.Client.Common
 {
 	public sealed class WebSocketServer
 	{
-		public ClientWebSocketWrapper Open(
-			Uri uri,
-			CancellationToken cancellationToken = default/* == CancellationToken.None */)
-				=> new(uri, cancellationToken);
+		public ClientWebSocketWrapper Open(Uri uri) => new(uri);
 	}
 }

--- a/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Text;
-using System.Threading.Tasks;
 using NLua;
 
 namespace BizHawk.Client.Common
@@ -254,9 +253,13 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		[LuaMethod("ws_open", "Opens a websocket and returns the id so that it can be retrieved later. If an id is provided, reconnects to the ")]
+		[LuaMethod("ws_open", "Opens a websocket and returns the id so that it can be retrieved later. If an id is provided, reconnects to the server")]
 		[LuaMethodExample("local ws_id = comm.ws_open(\"wss://echo.websocket.org\");")]
-		public async Task<string> WebSocketOpen(string uri, string guid = null, int bufferSize = 1024, int maxMessages = 20)
+		public string WebSocketOpen(
+			string uri,
+			string guid = null,
+			int bufferSize = 1024,
+			int maxMessages = 20)
 		{
 			var wsServer = APIs.Comm.WebSockets;
 			if (wsServer == null)
@@ -264,15 +267,9 @@ namespace BizHawk.Client.Common
 				return null;
 			}
 			var localGuid = guid == null ? Guid.NewGuid() : Guid.Parse(guid);
-			if (guid == null)
-			{
-				_websockets[localGuid] = wsServer.Open(new Uri(uri));
-				await _websockets[localGuid].Connect(bufferSize, maxMessages);
-			}
-			else
-			{
-				await _websockets[localGuid].Connect(bufferSize, maxMessages);
-			}
+
+			_websockets[localGuid] ??= wsServer.Open(new Uri(uri));
+			_websockets[localGuid].Connect(bufferSize, maxMessages).Wait(500);
 			return localGuid.ToString();
 		}
 

--- a/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
@@ -258,24 +258,19 @@ namespace BizHawk.Client.Common
 		[LuaMethodExample("local ws_id = comm.ws_open(\"wss://echo.websocket.org\");")]
 		public async Task<string> WebSocketOpen(string uri, string guid = null, int bufferSize = 1024, int maxMessages = 20)
 		{
-			Log($"Opening websocket server {uri}");
 			var wsServer = APIs.Comm.WebSockets;
 			if (wsServer == null)
 			{
-				Log("WebSocket server is not available");
 				return null;
 			}
 			var localGuid = guid == null ? Guid.NewGuid() : Guid.Parse(guid);
-			Log($"Server ID is {localGuid}");
 			if (guid == null)
 			{
-				Log($"OK here we go, connecting in pt 1");
 				_websockets[localGuid] = wsServer.Open(new Uri(uri));
 				await _websockets[localGuid].Connect(bufferSize, maxMessages);
 			}
 			else
 			{
-				Log($"OK here we go, connecting in pt 2");
 				await _websockets[localGuid].Connect(bufferSize, maxMessages);
 			}
 			return localGuid.ToString();


### PR DESCRIPTION
This PR primarily recreates #3773, which you should read to understand the original contributor's (@jtigues) motivations and justifications. I have adapted some of those changes in a way that makes more sense to me. In particular, I added overloads that allow a callback function to be given that is called when response messages are received.

I realized while writing this code that my own needs are to have EmuHawk act as a websocket server (rather than as a client which this PR addresses), and so I will follow up this PR with another that serves my needs.

## Main Changes
Refer to #3773 for primary changes. Below I record only those that deviate from #3773 
- added two overloads that enable a callback to be used to consume messages from the server, rather than caching messages and popping from the queue (`ClientWebSocketWrapper.cs`). These overloads could be used, for instance, within `CommonLuaLibrary.cs` to create a Lua `ws_send_and_receive` to automatically perform bidirectional communication with the server.
- rather than connect and wait in the instantiation of `ClientWebSocketWrapper` I defer the async connection process to `Connect`, which better fits with its usage and avoids the awkward behavior in the constructor (`ClientWebSocketWrapper.cs`, `WebsocketServer.cs`, `CommonLuaLibrary.cs`)

## Other Changes
- use a FIFO queue for caching messages rather than a regular List, since the queue better matches the use case (`ClientWebSocketWrapper.cs`, `CommonLuaLibrary.cs`)

## Contributor Checklist

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [ ] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
