### PR TITLE
websocket server

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/CommApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/CommApi.cs
@@ -4,9 +4,9 @@ namespace BizHawk.Client.Common
 {
 	public sealed class CommApi : ICommApi
 	{
-		private static readonly WebSocketServer _wsServer = new WebSocketServer();
+		private static readonly WebSocketClient _wsClient = new();
 
-		private readonly (HttpCommunication? HTTP, MemoryMappedFiles MMF, SocketServer? Sockets) _networkingHelpers;
+		private readonly (HttpCommunication? HTTP, MemoryMappedFiles MMF, SocketServer? Sockets, WebSocketServer? WebSocketServer) _networkingHelpers;
 
 		public HttpCommunication? HTTP => _networkingHelpers.HTTP;
 
@@ -14,7 +14,9 @@ namespace BizHawk.Client.Common
 
 		public SocketServer? Sockets => _networkingHelpers.Sockets;
 
-		public WebSocketServer WebSockets => _wsServer;
+		public WebSocketClient WebSockets => _wsClient;
+
+		public WebSocketServer? WebSocketServer => _networkingHelpers.WebSocketServer;
 
 		public CommApi(IMainFormForApi mainForm) => _networkingHelpers = mainForm.NetworkingHelpers;
 

--- a/src/BizHawk.Client.Common/Api/WebSocketClient.cs
+++ b/src/BizHawk.Client.Common/Api/WebSocketClient.cs
@@ -1,0 +1,9 @@
+﻿#nullable enable
+
+namespace BizHawk.Client.Common
+{
+	public sealed class WebSocketClient
+	{
+		public ClientWebSocketWrapper Open(Uri uri) => new(uri);
+	}
+}

--- a/src/BizHawk.Client.Common/Api/WebSocketServer.cs
+++ b/src/BizHawk.Client.Common/Api/WebSocketServer.cs
@@ -5,12 +5,22 @@ using System.Threading.Tasks;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Text;
+using System.Collections.Generic;
+using BizHawk.Client.Common.Websocket.Messages;
+using Newtonsoft.Json;
+using BizHawk.Common.CollectionExtensions;
+using Newtonsoft.Json.Serialization;
 
 namespace BizHawk.Client.Common
 {
 	public sealed class WebSocketServer
 	{
-		private readonly HttpListener httpListener;
+		private static readonly HashSet<Topic> forcedRegistrationTopics = [Topic.Error, Topic.Registration];
+		private readonly HttpListener clientRegistrationListener;
+		private CancellationToken _cancellationToken = default;
+		private bool _running = false;
+		private readonly Dictionary<string, WebSocket> clients = [];
+		private readonly Dictionary<Topic, HashSet<string>> topicRegistrations = [];
 
 		/// <param name="host">
 		/// 	host address to register for listening to connections, defaults to <see cref="IPAddress.Loopback"/>>
@@ -18,8 +28,20 @@ namespace BizHawk.Client.Common
 		/// <param name="port">port to register for listening to connections</param>
 		public WebSocketServer(IPAddress? host = null, int port = 3333)
 		{
-			httpListener = new();
-			httpListener.Prefixes.Add($"http://{host}:{port}/");
+			clientRegistrationListener = new();
+			clientRegistrationListener.Prefixes.Add($"http://{host}:{port}/");
+		}
+
+		/// <summary>
+		/// Stops the server. Alternatively, use the cancellation token passed into <see cref="Start"/>.
+		/// The server can be restarted by calling <see cref="Start"/> again.
+		/// </summary>
+		public void Stop()
+		{
+			var cancellationTokenSource = new CancellationTokenSource();
+			_cancellationToken = cancellationTokenSource.Token;
+			cancellationTokenSource.Cancel();
+			_running = false;
 		}
 
 		/// <summary>
@@ -29,71 +51,165 @@ namespace BizHawk.Client.Common
 		/// <returns>async task for the server loop</returns>
 		public async Task Start(CancellationToken cancellationToken = default)
 		{
-			Console.WriteLine("Starting the connection listener");
-			httpListener.Start();
-			Console.WriteLine("Started the connection listener");
-			while (!cancellationToken.IsCancellationRequested)
+			if (_running)
 			{
-				Console.WriteLine("Waiting for a request");
-				var context = await httpListener.GetContextAsync();
+				throw new InvalidOperationException("Server has already been started");
+			}
+			_cancellationToken = cancellationToken;
+			_running = true;
+
+			clientRegistrationListener.Start();
+			await ListenForAndRegisterClients();
+		}
+
+		private async Task ListenForAndRegisterClients()
+		{
+			while (_running && !_cancellationToken.IsCancellationRequested)
+			{
+				var context = await clientRegistrationListener.GetContextAsync();
 				if (context is null) return;
 
-				Console.WriteLine("Got a request");
 				if (!context.Request.IsWebSocketRequest)
 				{
-					Console.WriteLine("Request not for a websocket");
 					context.Response.Abort();
 					return;
 				}
 
-				Console.WriteLine("Got a websocket request, waiting for the handshake");
 				var webSocketContext = await context.AcceptWebSocketAsync(subProtocol: null);
 				if (webSocketContext is null) return;
-
-				string clientId = Guid.NewGuid().ToString();
-				Console.WriteLine($"Assigning client ID {clientId}");
-				var webSocket = webSocketContext.WebSocket;
-				_ = Task.Run(async () =>
-				{
-					Console.WriteLine($"Starting message send loop for {clientId}");
-					while ((webSocket.State == WebSocketState.Open) && !cancellationToken.IsCancellationRequested)
-					{
-						// TODO replace
-						await Task.Delay(1000, cancellationToken);
-						ArraySegment<byte> messageBuffer = new(Encoding.UTF8.GetBytes($"Hello {clientId}\r\n"));
-						await webSocket.SendAsync(
-							messageBuffer,
-							WebSocketMessageType.Text,
-							endOfMessage: true,
-							cancellationToken
-						);
-					}
-					Console.WriteLine($"Done with message send loop for {clientId}");
-				}, cancellationToken);
-
-				_ = Task.Run(async () =>
-				{
-					byte[] buffer = new byte[1024];
-					var stringBuilder = new StringBuilder(2048);
-					Console.WriteLine($"Starting message receive loop for {clientId}");
-					while (webSocket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
-					{
-						ArraySegment<byte> messageBuffer = new(buffer);
-						var receiveResult = await webSocket.ReceiveAsync(messageBuffer, cancellationToken);
-						if (receiveResult.Count == 0)
-							return;
-
-						// TODO replace
-						stringBuilder.Append(Encoding.UTF8.GetString(buffer, 0, receiveResult.Count));
-						if (receiveResult.EndOfMessage)
-						{
-							Console.WriteLine($"{clientId}: {stringBuilder}");
-							stringBuilder = new StringBuilder();
-						}
-					}
-					Console.WriteLine($"Done with message receive loop for {clientId}");
-				}, cancellationToken);
+				RegisterClient(webSocketContext.WebSocket);
 			}
+		}
+
+		private void RegisterClient(WebSocket newClient)
+		{
+			string clientId = Guid.NewGuid().ToString();
+			clients.Add(clientId, newClient);
+			_ = Task.Run(() => ClientMessageReceiveLoop(clientId), _cancellationToken);
+		}
+
+		private async Task ClientMessageReceiveLoop(string clientId)
+		{
+			byte[] buffer = new byte[1024];
+			var messageStringBuilder = new StringBuilder(2048);
+			var client = clients[clientId];
+			while (client.State == WebSocketState.Open && !_cancellationToken.IsCancellationRequested)
+			{
+				ArraySegment<byte> messageBuffer = new(buffer);
+				var receiveResult = await client.ReceiveAsync(messageBuffer, _cancellationToken);
+				if (receiveResult.Count == 0)
+					return;
+
+				messageStringBuilder.Append(Encoding.ASCII.GetString(buffer, 0, receiveResult.Count));
+				if (receiveResult.EndOfMessage)
+				{
+					string messageString = messageStringBuilder.ToString();
+					messageStringBuilder = new StringBuilder(2048);
+
+					try
+					{
+						var request = JsonSerde.Deserialize<RequestMessageWrapper>(messageString);
+						await HandleRequest(clientId, request);
+					}
+					catch (Exception e)
+					{
+						// TODO proper logging
+						Console.WriteLine("Error deserializing message {0}", e);
+						await SendClientGenericError(clientId);
+					}
+				}
+			}
+		}
+
+		private async Task HandleRequest(string clientId, RequestMessageWrapper request)
+		{
+			try
+			{
+				switch (request.Topic)
+				{
+					case Topic.Error:
+						// clients arent allowed to publish to this topic
+						await SendClientGenericError(clientId);
+						break;
+
+					case Topic.Registration:
+						await HandleRegistrationRequest(clientId, request.Registration!.Value);
+						break;
+
+					case Topic.Echo:
+						await HandleEchoRequest(clientId, request.Echo!.Value);
+						break;
+				}
+
+			}
+			catch (Exception e)
+			{
+				// this could happen if, for instance, the client sent a registration request to the echo topic, such
+				// that we tried to access the wrong field of the wrapper
+				// TODO proper logging
+				Console.WriteLine("Error handling message {0}", e);
+				await SendClientGenericError(clientId);
+			}
+		}
+
+		private async Task HandleRegistrationRequest(string clientId, RegistrationRequestMessage request)
+		{
+			foreach (Topic topic in Enum.GetValues(typeof(Topic)))
+			{
+				if (forcedRegistrationTopics.Contains(topic))
+				{
+					// we dont need to keep track of topics that clients must be registered for.
+					continue;
+				}
+				else if (request.Topics.Contains(topic))
+				{
+					_ = topicRegistrations.GetValueOrPut(topic, (_) => []).Add(clientId);
+				}
+				else
+				{
+					_ = topicRegistrations.GetValueOrDefault(topic, [])?.Remove(clientId);
+				}
+			}
+
+			var registeredTopics = request.Topics;
+			registeredTopics.AddRange(forcedRegistrationTopics);
+			var responseMessage = new ResponseMessageWrapper(new RegistrationResponseMessage(registeredTopics));
+			await SendClientMessage(clientId, responseMessage);
+		}
+
+		private async Task HandleEchoRequest(string clientId, EchoRequestMessage request)
+		{
+			if (topicRegistrations.GetValueOrDefault(Topic.Echo, [])?.Contains(clientId) ?? false)
+			{
+				await SendClientMessage(clientId, new ResponseMessageWrapper(new EchoResponseMessage(request.Message)));
+			}
+		}
+
+		// clients always get error topics
+		private async Task SendClientGenericError(string clientId) => await SendClientMessage(clientId, new ResponseMessageWrapper(new ErrorMessage(ErrorType.UnknownRequest)));
+
+		private async Task SendClientMessage(string clientId, object message)
+		{
+			await clients[clientId].SendAsync(
+				JsonSerde.Serialize(message),
+				WebSocketMessageType.Text,
+				endOfMessage: true,
+				_cancellationToken
+			);
+		}
+
+		private static class JsonSerde
+		{
+
+			private static readonly JsonSerializerSettings serializerSettings = new()
+			{
+				NullValueHandling = NullValueHandling.Ignore,
+				ContractResolver = new CamelCasePropertyNamesContractResolver(),
+			};
+
+			public static ArraySegment<byte> Serialize(object message) => new(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message, serializerSettings)));
+
+			public static T? Deserialize<T>(string message) => JsonConvert.DeserializeObject<T>(message, serializerSettings);
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/Api/WebSocketServer.cs
+++ b/src/BizHawk.Client.Common/Api/WebSocketServer.cs
@@ -1,14 +1,99 @@
 ﻿#nullable enable
 
+using System.Net;
+using System.Threading.Tasks;
+using System.Net.WebSockets;
 using System.Threading;
+using System.Text;
 
 namespace BizHawk.Client.Common
 {
 	public sealed class WebSocketServer
 	{
-		public ClientWebSocketWrapper Open(
-			Uri uri,
-			CancellationToken cancellationToken = default/* == CancellationToken.None */)
-				=> new(uri, cancellationToken);
+		private readonly HttpListener httpListener;
+
+		/// <param name="host">
+		/// 	host address to register for listening to connections, defaults to <see cref="IPAddress.Loopback"/>>
+		/// </param>
+		/// <param name="port">port to register for listening to connections</param>
+		public WebSocketServer(IPAddress? host = null, int port = 3333)
+		{
+			httpListener = new();
+			httpListener.Prefixes.Add($"http://{host}:{port}/");
+		}
+
+		/// <summary>
+		/// Starts the websocket server at the configured address and registers clients.
+		/// </summary>
+		/// <param name="cancellationToken">optional cancellation token to stop the server</param>
+		/// <returns>async task for the server loop</returns>
+		public async Task Start(CancellationToken cancellationToken = default)
+		{
+			Console.WriteLine("Starting the connection listener");
+			httpListener.Start();
+			Console.WriteLine("Started the connection listener");
+			while (!cancellationToken.IsCancellationRequested)
+			{
+				Console.WriteLine("Waiting for a request");
+				var context = await httpListener.GetContextAsync();
+				if (context is null) return;
+
+				Console.WriteLine("Got a request");
+				if (!context.Request.IsWebSocketRequest)
+				{
+					Console.WriteLine("Request not for a websocket");
+					context.Response.Abort();
+					return;
+				}
+
+				Console.WriteLine("Got a websocket request, waiting for the handshake");
+				var webSocketContext = await context.AcceptWebSocketAsync(subProtocol: null);
+				if (webSocketContext is null) return;
+
+				string clientId = Guid.NewGuid().ToString();
+				Console.WriteLine($"Assigning client ID {clientId}");
+				var webSocket = webSocketContext.WebSocket;
+				_ = Task.Run(async () =>
+				{
+					Console.WriteLine($"Starting message send loop for {clientId}");
+					while ((webSocket.State == WebSocketState.Open) && !cancellationToken.IsCancellationRequested)
+					{
+						// TODO replace
+						await Task.Delay(1000, cancellationToken);
+						ArraySegment<byte> messageBuffer = new(Encoding.UTF8.GetBytes($"Hello {clientId}\r\n"));
+						await webSocket.SendAsync(
+							messageBuffer,
+							WebSocketMessageType.Text,
+							endOfMessage: true,
+							cancellationToken
+						);
+					}
+					Console.WriteLine($"Done with message send loop for {clientId}");
+				}, cancellationToken);
+
+				_ = Task.Run(async () =>
+				{
+					byte[] buffer = new byte[1024];
+					var stringBuilder = new StringBuilder(2048);
+					Console.WriteLine($"Starting message receive loop for {clientId}");
+					while (webSocket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
+					{
+						ArraySegment<byte> messageBuffer = new(buffer);
+						var receiveResult = await webSocket.ReceiveAsync(messageBuffer, cancellationToken);
+						if (receiveResult.Count == 0)
+							return;
+
+						// TODO replace
+						stringBuilder.Append(Encoding.UTF8.GetString(buffer, 0, receiveResult.Count));
+						if (receiveResult.EndOfMessage)
+						{
+							Console.WriteLine($"{clientId}: {stringBuilder}");
+							stringBuilder = new StringBuilder();
+						}
+					}
+					Console.WriteLine($"Done with message receive loop for {clientId}");
+				}, cancellationToken);
+			}
+		}
 	}
 }

--- a/src/BizHawk.Client.Common/ArgParser.cs
+++ b/src/BizHawk.Client.Common/ArgParser.cs
@@ -17,16 +17,16 @@ namespace BizHawk.Client.Common
 		private sealed class BespokeOption<T> : Option<T>
 		{
 			public BespokeOption(string name)
-				: base(name) {}
+				: base(name) { }
 
 			public BespokeOption(string name, string description)
-				: base(name: name, description: description) {}
+				: base(name: name, description: description) { }
 
 			public BespokeOption(string[] aliases)
-				: base(aliases) {}
+				: base(aliases) { }
 
 			public BespokeOption(string[] aliases, string description)
-				: base(aliases, description) {}
+				: base(aliases, description) { }
 		}
 
 		private static readonly Argument<string?> ArgumentRomFilePath = new(name: "rom", () => null, description: "path; if specified, the file will be loaded the same way as it would be from `File` > `Open...`");
@@ -47,9 +47,9 @@ namespace BizHawk.Client.Common
 
 		private static readonly BespokeOption<string?> OptionConfigFilePath = new(name: "--config", description: "path of config file to use");
 
-		private static readonly BespokeOption<string?> OptionHTTPClientURIGET = new(aliases: [ "--url-get", "--url_get" ], description: "string; URI to use for HTTP 'GET' IPC (Lua `comm.http*Get*`)");
+		private static readonly BespokeOption<string?> OptionHTTPClientURIGET = new(aliases: ["--url-get", "--url_get"], description: "string; URI to use for HTTP 'GET' IPC (Lua `comm.http*Get*`)");
 
-		private static readonly BespokeOption<string?> OptionHTTPClientURIPOST = new(aliases: [ "--url-post", "--url_post" ], description: "string; URI to use for HTTP 'POST' IPC (Lua `comm.http*Post*`)");
+		private static readonly BespokeOption<string?> OptionHTTPClientURIPOST = new(aliases: ["--url-post", "--url_post"], description: "string; URI to use for HTTP 'POST' IPC (Lua `comm.http*Post*`)");
 
 		private static readonly BespokeOption<bool> OptionLaunchChromeless = new(name: "--chromeless", description: "pass and the 'chrome' (a.k.a. GUI) will never be shown, not even in windowed mode");
 
@@ -71,11 +71,15 @@ namespace BizHawk.Client.Common
 
 		private static readonly BespokeOption<bool> OptionQueryAppVersion = new(name: "--version", description: "pass to print version information and immediately quit");
 
-		private static readonly BespokeOption<string?> OptionSocketServerIP = new(aliases: [ "--socket-ip", "--socket_ip" ]); // desc added in static ctor
+		private static readonly BespokeOption<string?> OptionSocketServerIP = new(aliases: ["--socket-ip", "--socket_ip"]); // desc added in static ctor
 
-		private static readonly BespokeOption<ushort?> OptionSocketServerPort = new(aliases: [ "--socket-port", "--socket_port" ]); // desc added in static ctor
+		private static readonly BespokeOption<ushort?> OptionSocketServerPort = new(aliases: ["--socket-port", "--socket_port"]); // desc added in static ctor
 
-		private static readonly BespokeOption<bool> OptionSocketServerUseUDP = new(aliases: [ "--socket-udp", "--socket_udp" ]); // desc added in static ctor
+		private static readonly BespokeOption<bool> OptionSocketServerUseUDP = new(aliases: ["--socket-udp", "--socket_udp"]); // desc added in static ctor
+
+		private static readonly BespokeOption<string?> OptionWebSocketServerIP = new(aliases: ["--websocket-server-ip", "--ws_ip"]); // desc added in static ctor
+
+		private static readonly BespokeOption<ushort?> OptionWebSocketServerPort = new(aliases: ["--websocket-server-port", "--ws_port"]); // desc added in static ctor
 
 		private static readonly BespokeOption<string?> OptionUserdataUnparsedPairs = new(name: "--userdata", description: "pairs in the format `k1:v1;k2:v2` (mind your shell escape sequences); if the value is `true`/`false` it's interpreted as a boolean, if it's a valid 32-bit signed integer e.g. `-1234` it's interpreted as such, if it's a valid 32-bit float e.g. `12.34` it's interpreted as such, else it's interpreted as a string");
 
@@ -91,6 +95,8 @@ namespace BizHawk.Client.Common
 			OptionSocketServerIP.Description = $"string; IP address for Unix socket IPC (Lua `comm.socket*`); must be paired with `--{OptionSocketServerPort.Name}`";
 			OptionSocketServerPort.Description = $"int; port for Unix socket IPC (Lua `comm.socket*`); must be paired with `--{OptionSocketServerIP.Name}`";
 			OptionSocketServerUseUDP.Description = $"pass to use UDP instead of TCP for Unix socket IPC (Lua `comm.socket*`); ignored unless `--{OptionSocketServerIP.Name} --{OptionSocketServerPort.Name}` also passed";
+			OptionWebSocketServerIP.Description = $"string; IP address for websocket server; must be paired with `--{OptionWebSocketServerPort.Name}`";
+			OptionWebSocketServerPort.Description = $"int; port for websocket server; must be paired with `--{OptionWebSocketServerIP.Name}`";
 
 			RootCommand root = new();
 			root.Add(ArgumentRomFilePath);
@@ -114,22 +120,24 @@ namespace BizHawk.Client.Common
 			root.Add(/* --socket-ip */ OptionSocketServerIP);
 			root.Add(/* --socket-port */ OptionSocketServerPort);
 			root.Add(/* --socket-udp */ OptionSocketServerUseUDP);
+			root.Add(/* --websocket-server-ip */ OptionWebSocketServerIP);
+			root.Add(/* --websocket-server-port */ OptionWebSocketServerPort);
 			root.Add(/* --url-get */ OptionHTTPClientURIGET);
 			root.Add(/* --url-post */ OptionHTTPClientURIPOST);
 			root.Add(/* --userdata */ OptionUserdataUnparsedPairs);
 			root.Add(/* --version */ OptionQueryAppVersion);
 
 			Parser = new CommandLineBuilder(root)
-//				.UseVersionOption() // "cannot be combined with other arguments" which is fair enough but `--config` is crucial on NixOS
+				//				.UseVersionOption() // "cannot be combined with other arguments" which is fair enough but `--config` is crucial on NixOS
 				.UseHelp()
-//				.UseEnvironmentVariableDirective() // useless
+				//				.UseEnvironmentVariableDirective() // useless
 				.UseParseDirective()
 				.UseSuggestDirective()
-//				.RegisterWithDotnetSuggest() // intended for dotnet tools
-//				.UseTypoCorrections() // we're only using the parser, and I guess this only works with the full buy-in
-//				.UseParseErrorReporting() // we're only using the parser, and I guess this only works with the full buy-in
-//				.UseExceptionHandler() // we're only using the parser, so nothing should be throwing
-//				.CancelOnProcessTermination() // we're only using the parser, so there's not really anything to cancel
+				//				.RegisterWithDotnetSuggest() // intended for dotnet tools
+				//				.UseTypoCorrections() // we're only using the parser, and I guess this only works with the full buy-in
+				//				.UseParseErrorReporting() // we're only using the parser, and I guess this only works with the full buy-in
+				//				.UseExceptionHandler() // we're only using the parser, so nothing should be throwing
+				//				.CancelOnProcessTermination() // we're only using the parser, so there's not really anything to cancel
 				.Build();
 			GeneratedOptions = root.Options.Where(static o =>
 			{
@@ -185,6 +193,14 @@ namespace BizHawk.Client.Common
 					? (socketIP, socketPort.Value)
 					: throw new ArgParserException("Socket server needs both --socket_ip and --socket_port. Socket server was not started");
 
+			var websocketIP = result.GetValueForOption(OptionWebSocketServerIP);
+			var websocketPort = result.GetValueForOption(OptionWebSocketServerPort);
+			var webSocketServerAddress = websocketIP is null && websocketPort is null
+				? ((string, ushort)?) null // don't bother
+				: websocketIP is not null && websocketPort is not null
+					? (websocketIP, websocketPort.Value)
+					: throw new ArgParserException("Websocket server needs both --ws_ip and --ws_port. Websocket server was not started");
+
 			var httpClientURIGET = result.GetValueForOption(OptionHTTPClientURIGET);
 			var httpClientURIPOST = result.GetValueForOption(OptionHTTPClientURIPOST);
 			var httpAddresses = httpClientURIGET is null && httpClientURIPOST is null
@@ -221,6 +237,7 @@ namespace BizHawk.Client.Common
 				luaScript: luaScript,
 				luaConsole: luaConsole,
 				socketAddress: socketAddress,
+				webSocketServerAddress: webSocketServerAddress,
 				mmfFilename: result.GetValueForOption(OptionMMFPath),
 				httpAddresses: httpAddresses,
 				audiosync: audiosync,
@@ -234,7 +251,7 @@ namespace BizHawk.Client.Common
 
 		public sealed class ArgParserException : Exception
 		{
-			public ArgParserException(string message) : base(message) {}
+			public ArgParserException(string message) : base(message) { }
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/IMainFormForApi.cs
+++ b/src/BizHawk.Client.Common/IMainFormForApi.cs
@@ -27,7 +27,13 @@ namespace BizHawk.Client.Common
 		bool IsTurboing { get; }
 
 		/// <remarks>only referenced from <see cref="CommApi"/></remarks>
-		(HttpCommunication HTTP, MemoryMappedFiles MMF, SocketServer Sockets) NetworkingHelpers { get; }
+		(
+			HttpCommunication HTTP,
+			MemoryMappedFiles MMF,
+			SocketServer Sockets,
+			WebSocketServer WebSocketServer
+		) NetworkingHelpers
+		{ get; }
 
 		/// <remarks>only referenced from <c>EmuClientApi</c></remarks>
 		bool PauseAvi { get; set; }

--- a/src/BizHawk.Client.Common/ParsedCLIFlags.cs
+++ b/src/BizHawk.Client.Common/ParsedCLIFlags.cs
@@ -35,6 +35,8 @@ namespace BizHawk.Client.Common
 
 		public readonly bool luaConsole;
 
+		public readonly (string IP, ushort Port)? WebSocketServerAddress;
+
 		public readonly (string IP, ushort Port)? SocketAddress;
 
 		public readonly ProtocolType SocketProtocol;
@@ -67,6 +69,7 @@ namespace BizHawk.Client.Common
 			string? luaScript,
 			bool luaConsole,
 			(string IP, ushort Port)? socketAddress,
+			(string IP, ushort Port)? webSocketServerAddress,
 			string? mmfFilename,
 			(string? UrlGet, string? UrlPost)? httpAddresses,
 			bool? audiosync,
@@ -90,6 +93,7 @@ namespace BizHawk.Client.Common
 			this.luaScript = luaScript;
 			this.luaConsole = luaConsole;
 			SocketAddress = socketAddress;
+			WebSocketServerAddress = webSocketServerAddress;
 			MMFFilename = mmfFilename;
 			HTTPAddresses = httpAddresses;
 			this.audiosync = audiosync;

--- a/src/BizHawk.Client.Common/websocket/messages/Echo.cs
+++ b/src/BizHawk.Client.Common/websocket/messages/Echo.cs
@@ -1,0 +1,44 @@
+namespace BizHawk.Client.Common.Websocket.Messages
+{
+	/// <summary>
+	/// Test message for clients to use to confirm messages are passed back and forth.
+	/// 
+	/// Register for <see cref="Topic.Echo"/>
+	/// </summary>
+	/// <seealso cref="EchoResponseMessage"/>
+	public struct EchoRequestMessage
+	{
+		/// <summary>
+		/// Message body. Will be the same in the response.
+		/// </summary>
+		public string Message { get; set; }
+
+		public EchoRequestMessage() { }
+
+		public EchoRequestMessage(string message)
+		{
+			Message = message;
+		}
+	}
+
+	/// <summary>
+	/// Test message for clients to use to confirm messages are passed back and forth.
+	/// 
+	/// Register for <see cref="Topic.Echo"/>
+	/// </summary>
+	/// <seealso cref="EchoRequestMessage"/>
+	public struct EchoResponseMessage
+	{
+		/// <summary>
+		/// Message body. Same as was in the request.
+		/// </summary>
+		public string Message { get; set; }
+
+		public EchoResponseMessage() { }
+
+		public EchoResponseMessage(string message)
+		{
+			Message = message;
+		}
+	}
+}

--- a/src/BizHawk.Client.Common/websocket/messages/Error.cs
+++ b/src/BizHawk.Client.Common/websocket/messages/Error.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace BizHawk.Client.Common.Websocket.Messages
 {
 

--- a/src/BizHawk.Client.Common/websocket/messages/Error.cs
+++ b/src/BizHawk.Client.Common/websocket/messages/Error.cs
@@ -1,0 +1,31 @@
+namespace BizHawk.Client.Common.Websocket.Messages
+{
+
+	/// <summary>
+	/// Error message sent from the server for <see cref="Topic.Error"/>
+	/// </summary>
+	public struct ErrorMessage
+	{
+		public ErrorType Type { get; set; }
+
+		public string? Message { get; set; }
+
+		public ErrorMessage() { }
+
+		public ErrorMessage(ErrorType type)
+		{
+			Type = type;
+		}
+
+		public ErrorMessage(ErrorType type, string message)
+		{
+			Type = type;
+			Message = message;
+		}
+	}
+
+	public enum ErrorType : ushort
+	{
+		UnknownRequest = 0
+	}
+}

--- a/src/BizHawk.Client.Common/websocket/messages/MessageWrapper.cs
+++ b/src/BizHawk.Client.Common/websocket/messages/MessageWrapper.cs
@@ -1,0 +1,84 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace BizHawk.Client.Common.Websocket.Messages
+{
+	public struct RequestMessageWrapper
+	{
+		public Topic Topic { get; set; }
+
+		public RegistrationRequestMessage? Registration { get; set; }
+
+		public EchoRequestMessage? Echo { get; set; }
+
+		public RequestMessageWrapper() { }
+
+		public RequestMessageWrapper(RegistrationRequestMessage message)
+		{
+			Topic = Topic.Registration;
+			Registration = message;
+		}
+
+		public RequestMessageWrapper(EchoRequestMessage message)
+		{
+			Topic = Topic.Echo;
+			Echo = message;
+		}
+	}
+
+	public struct ResponseMessageWrapper
+	{
+		public Topic Topic { get; set; }
+
+		public ErrorMessage? Error { get; set; }
+
+		public RegistrationResponseMessage? Registration { get; set; }
+
+		public EchoResponseMessage? Echo { get; set; }
+
+		public ResponseMessageWrapper() { }
+
+		public ResponseMessageWrapper(ErrorMessage message)
+		{
+			Topic = Topic.Error;
+			Error = message;
+		}
+
+		public ResponseMessageWrapper(RegistrationResponseMessage message)
+		{
+			Topic = Topic.Registration;
+			Registration = message;
+		}
+
+		public ResponseMessageWrapper(EchoResponseMessage message)
+		{
+			Topic = Topic.Echo;
+			Echo = message;
+		}
+	}
+
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum Topic : ushort
+	{
+		/// <summary>
+		/// Topic for general errors. Some errors may be client-specific, such as when
+		/// a request was made that could not be assigned to a topic.
+		/// </summary>
+		Error = 0,
+
+		/// <summary>
+		/// Topic for registration requests.
+		/// </summary>
+		/// <see cref="RegistrationRequestMessage"/>
+		/// <see cref="RegistrationResponseMessage"/>
+		Registration = 1,
+
+		/// <summary>
+		/// This is a client-specific topic, i.e. only the client who sent the message
+		/// will receive the echoed response.
+		/// </summary>
+		/// <see cref="EchoRequestMessage"/>
+		/// <see cref="EchoResponseMessage"/>
+		Echo = 2,
+	}
+}

--- a/src/BizHawk.Client.Common/websocket/messages/MessageWrapper.cs
+++ b/src/BizHawk.Client.Common/websocket/messages/MessageWrapper.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/BizHawk.Client.Common/websocket/messages/Registration.cs
+++ b/src/BizHawk.Client.Common/websocket/messages/Registration.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace BizHawk.Client.Common.Websocket.Messages
+{
+
+	/// <summary>
+	/// Defines the set of topics a client wishes to register to listen to.
+	/// 
+	/// Register for <see cref="Topic.Registration"/>
+	/// </summary>
+	public struct RegistrationRequestMessage
+	{
+		/// <summary>
+		/// The set of topics to register for. Previous topics will be unregistered. Providing
+		/// an empty set of topics is the same as unregistering for all topics.
+		/// </summary>
+		public HashSet<Topic> Topics { get; set; }
+
+		public RegistrationRequestMessage() { }
+
+		public RegistrationRequestMessage(HashSet<Topic> topics)
+		{
+			Topics = topics;
+		}
+	}
+
+	/// <summary>
+	/// Response message after client has sent a <see cref="RegistrationRequestMessage"/>
+	/// 
+	/// Register for <see cref="Topic.Registration"/>
+	/// </summary>
+	public struct RegistrationResponseMessage
+	{
+		/// <summary>
+		/// The set of topics the client is registered for. Generally should match what was
+		/// in the request, plus some topics the client will always receive.
+		/// </summary>
+		public HashSet<Topic> Topics { get; set; }
+
+		public RegistrationResponseMessage() { }
+
+		public RegistrationResponseMessage(HashSet<Topic> topics)
+		{
+			Topics = topics;
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a base websocket server implementation, to be used for two-way JSON-based communication with clients in both event broadcasting and request/response messaging, such as to send commands to the emulator. The implementation is meant to stand alongside the existing `SocketServer` (more performant, lower-level, less dev friendly) and the websocket "server" (renamed to `WebSocketClient`)  which is actually a client implementation for connecting to and sending messages to external websocket servers.

Some notes on the implementation:
- It uses a single channel for all communications and differentiates messages by a topic ID enum in request/response message wrappers. The primary advantage with this implementation is clients get the send/receive to/from a single URL.
- The message wrappers use composition for topic-specific messages (i.e. the `registration`-specific message lives under the `registration` field of the wrapper). The primary advantage here is that clients can use a single implementation to serialize/deserialize all messages in a single pass over the JSON.
- Clients may be registered for topics by registration requests or by force (for e.g. the error and registration topics). 
- Being registered for a topic does not preclude a request message being handled, e.g. a client can send an echo request without getting it echoed back.
- Topics can be broadcast - goes to all clients registered for that topic - or client-specific - goes to a specific client based on some other message filtering or request/response. The implementation here does not use any broadcast topics. Those can be added in future topics.

# Main Changes
- renamed the prior `WebSocketServer` to `WebSocketClient` to match its usage, and make room for the new websocket server added here (`WebSocketClient`, `CommApi`)
- added a websocket server implementation as described above including client registration and generic methods for messaging clients (`WebSocketServer`)
- added messages for three topics - topic registration (`Registration.cs`), echo for debugging (`Echo.cs`), and generic errors (`Error.cs`) - which are wrapped in wrappers described above (`MessageWrapper.cs`) and described by their topic enum (`MessageWrapper`).
- added CLI args for creating the websocket server (`ArgParser`, `IMainFormForApi`, `ParsedCLIFlags`, `MainForm`) and use these to initialize the server (`MainForm`)

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
