### PR TITLE
Bump AnalysisLevel to 8

### DIFF
--- a/.global.editorconfig.ini
+++ b/.global.editorconfig.ini
@@ -80,6 +80,8 @@ dotnet_code_quality.CA1826.exclude_ordefault_methods = true
 dotnet_diagnostic.CA1838.severity = suggestion
 # Use concrete types when possible for improved performance
 dotnet_diagnostic.CA1859.severity = suggestion
+# Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = none
 
 ## Usage rules
 

--- a/.global.editorconfig.ini
+++ b/.global.editorconfig.ini
@@ -63,6 +63,11 @@ dotnet_code_quality.CA1305.excluded_symbol_names = T:System.Byte|T:System.SByte|
 # Specify marshalling for P/Invoke string arguments
 dotnet_diagnostic.CA2101.severity = suggestion
 
+## Reliability rules
+
+# ThreadStatic fields should not use inline initialization
+dotnet_diagnostic.CA2019.severity = error
+
 ## Performance rules
 
 # Do not initialize unnecessarily

--- a/.global.editorconfig.ini
+++ b/.global.editorconfig.ini
@@ -78,6 +78,8 @@ dotnet_diagnostic.CA1822.severity = silent
 dotnet_code_quality.CA1826.exclude_ordefault_methods = true
 # Avoid StringBuilder parameters for P/Invokes
 dotnet_diagnostic.CA1838.severity = suggestion
+# Use concrete types when possible for improved performance
+dotnet_diagnostic.CA1859.severity = suggestion
 
 ## Usage rules
 

--- a/Common.props
+++ b/Common.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<AnalysisLevel>7</AnalysisLevel>
+		<AnalysisLevel>8</AnalysisLevel>
 		<AnalysisModeGlobalization>Recommended</AnalysisModeGlobalization>
 		<AnalysisModeMaintainability>Recommended</AnalysisModeMaintainability>
 		<AnalysisModeReliability>Recommended</AnalysisModeReliability>

--- a/Common.props
+++ b/Common.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<AnalysisLevel>6</AnalysisLevel>
+		<AnalysisLevel>7</AnalysisLevel>
 		<AnalysisModeGlobalization>Recommended</AnalysisModeGlobalization>
 		<AnalysisModeMaintainability>Recommended</AnalysisModeMaintainability>
 		<AnalysisModeReliability>Recommended</AnalysisModeReliability>

--- a/src/BizHawk.BizInvoke/BizInvoker.cs
+++ b/src/BizHawk.BizInvoke/BizInvoker.cs
@@ -26,7 +26,7 @@ namespace BizHawk.BizInvoke
 		/// <summary>
 		/// holds information about a proxy implementation, including type and setup hooks
 		/// </summary>
-		private class InvokerImpl
+		private sealed class InvokerImpl
 		{
 			private readonly Action<object, ICallingConventionAdapter> _connectCallingConventionAdapter;
 

--- a/src/BizHawk.BizInvoke/BizInvokerUtilities.cs
+++ b/src/BizHawk.BizInvoke/BizInvokerUtilities.cs
@@ -15,7 +15,7 @@ namespace BizHawk.BizInvoke
 	public static unsafe class BizInvokerUtilities
 	{
 		[StructLayout(LayoutKind.Explicit)]
-		private class U
+		private sealed class U
 		{
 			[FieldOffset(0)]
 			public readonly U1? First;
@@ -32,14 +32,14 @@ namespace BizHawk.BizInvoke
 		}
 
 		[StructLayout(LayoutKind.Explicit)]
-		private class U1
+		private sealed class U1
 		{
 			[FieldOffset(0)]
 			public UIntPtr P;
 		}
 
 		[StructLayout(LayoutKind.Explicit)]
-		private class U2
+		private sealed class U2
 		{
 			[FieldOffset(0)]
 			public object Target;
@@ -47,7 +47,7 @@ namespace BizHawk.BizInvoke
 			public U2(object target) => Target = target;
 		}
 
-		private class CF
+		private sealed class CF
 		{
 			public int FirstField = 0;
 		}

--- a/src/BizHawk.BizInvoke/CallingConventionAdapter.cs
+++ b/src/BizHawk.BizInvoke/CallingConventionAdapter.cs
@@ -225,12 +225,7 @@ namespace BizHawk.BizInvoke
 			// TODO: Another dll might be required for ARM64? Investigate
 
 			private const int BlockSize = 32;
-			private static readonly IImportResolver ThunkDll;
-
-			static MsHostSysVGuest()
-			{
-				ThunkDll = new DynamicLibraryImportResolver("libbizabiadapter_msabi_sysv.dll", hasLimitedLifetime: false);
-			}
+			private static readonly DynamicLibraryImportResolver ThunkDll = new("libbizabiadapter_msabi_sysv.dll", hasLimitedLifetime: false);
 
 			private readonly MemoryBlock _memory;
 			private readonly object _sync = new();

--- a/src/BizHawk.BizInvoke/CallingConventionAdapter.cs
+++ b/src/BizHawk.BizInvoke/CallingConventionAdapter.cs
@@ -92,7 +92,7 @@ namespace BizHawk.BizInvoke
 
 	public static class CallingConventionAdapters
 	{
-		private class NativeConvention : ICallingConventionAdapter
+		private sealed class NativeConvention : ICallingConventionAdapter
 		{
 			public IntPtr GetArrivalFunctionPointer(IntPtr p, InvokerParameterInfo pp, object lifetime)
 				=> p;
@@ -132,9 +132,9 @@ namespace BizHawk.BizInvoke
 		public static ICallingConventionAdapter GetWaterboxUnsafeUnwrapped()
 			=> WaterboxAdapter.WaterboxWrapper;
 
-		private class WaterboxAdapter : ICallingConventionAdapter
+		private sealed class WaterboxAdapter : ICallingConventionAdapter
 		{
-			private class ReferenceEqualityComparer : IEqualityComparer<Delegate>
+			private sealed class ReferenceEqualityComparer : IEqualityComparer<Delegate>
 			{
 				public bool Equals(Delegate x, Delegate y)
 					=> x == y;
@@ -218,7 +218,7 @@ namespace BizHawk.BizInvoke
 		/// Calling Convention Adapter for where host code expects msabi and guest code is sysv.
 		/// Does not handle anything Waterbox specific.
 		/// </summary>
-		private class MsHostSysVGuest : ICallingConventionAdapter
+		private sealed class MsHostSysVGuest : ICallingConventionAdapter
 		{
 			// This is implemented by using thunks defined in a small dll, and putting stubs on top of them that close over the
 			// function pointer parameter. A dll is used here to easily set unwind information (allowing SEH exceptions to work).

--- a/src/BizHawk.Bizware.Audio/OpenALSoundOutput.cs
+++ b/src/BizHawk.Bizware.Audio/OpenALSoundOutput.cs
@@ -255,7 +255,7 @@ namespace BizHawk.Bizware.Audio
 			}
 		}
 
-		private class BufferPool : IDisposable
+		private sealed class BufferPool : IDisposable
 		{
 			private readonly Stack<BufferPoolItem> _availableItems = new();
 			private readonly Queue<BufferPoolItem> _obtainedItems = new();
@@ -285,7 +285,7 @@ namespace BizHawk.Bizware.Audio
 				return item;
 			}
 
-			public class BufferPoolItem
+			public sealed class BufferPoolItem
 			{
 				public uint BufferID { get; } = _al.GenBuffer();
 				public int Length { get; set; }

--- a/src/BizHawk.Bizware.Audio/SDL2WavStream.cs
+++ b/src/BizHawk.Bizware.Audio/SDL2WavStream.cs
@@ -135,7 +135,7 @@ namespace BizHawk.Bizware.Audio
 		public override void Write(byte[] buffer, int offset, int count)
 			=> throw new NotSupportedException();
 
-		private unsafe class SDLRwOpsStreamWrapper : IDisposable
+		private sealed unsafe class SDLRwOpsStreamWrapper : IDisposable
 		{
 			public IntPtr Rw { get; private set; }
 			private readonly Stream _s;

--- a/src/BizHawk.Bizware.Audio/XAudio2SoundOutput.cs
+++ b/src/BizHawk.Bizware.Audio/XAudio2SoundOutput.cs
@@ -192,7 +192,7 @@ namespace BizHawk.Bizware.Audio
 			_wavVoice.Start();
 		}
 
-		private class BufferPool : IDisposable
+		private sealed class BufferPool : IDisposable
 		{
 			private readonly List<BufferPoolItem> _availableItems = new();
 			private readonly Queue<BufferPoolItem> _obtainedItems = new();
@@ -235,7 +235,7 @@ namespace BizHawk.Bizware.Audio
 					_availableItems.Add(_obtainedItems.Dequeue());
 			}
 
-			public class BufferPoolItem
+			public sealed class BufferPoolItem
 			{
 				public int MaxLength { get; }
 				public AudioBuffer AudioBuffer { get; }

--- a/src/BizHawk.Bizware.Graphics/D3D11/D3D11Pipeline.cs
+++ b/src/BizHawk.Bizware.Graphics/D3D11/D3D11Pipeline.cs
@@ -15,7 +15,7 @@ using Vortice.DXGI;
 
 namespace BizHawk.Bizware.Graphics
 {
-	internal class D3D11Pipeline : IPipeline
+	internal sealed class D3D11Pipeline : IPipeline
 	{
 		private readonly D3D11Resources _resources;
 		private ID3D11Device Device => _resources.Device;
@@ -43,7 +43,7 @@ namespace BizHawk.Bizware.Graphics
 		private readonly Dictionary<string, int> _vsSamplers = new();
 		private readonly Dictionary<string, int> _psSamplers = new();
 
-		public class D3D11PendingBuffer
+		public sealed class D3D11PendingBuffer
 		{
 			public IntPtr VSPendingBuffer, PSPendingBuffer;
 			public int VSBufferSize, PSBufferSize;

--- a/src/BizHawk.Bizware.Graphics/D3D11/D3D11SwapChain.cs
+++ b/src/BizHawk.Bizware.Graphics/D3D11/D3D11SwapChain.cs
@@ -25,7 +25,7 @@ namespace BizHawk.Bizware.Graphics
 			}
 		}
 
-		internal class SwapChainResources : IDisposable
+		internal sealed class SwapChainResources : IDisposable
 		{
 			public ID3D11Device Device;
 			public ID3D11DeviceContext Context;

--- a/src/BizHawk.Bizware.Graphics/OpenGL/OpenGLPipeline.cs
+++ b/src/BizHawk.Bizware.Graphics/OpenGL/OpenGLPipeline.cs
@@ -9,7 +9,7 @@ using BizHawk.Common.CollectionExtensions;
 
 namespace BizHawk.Bizware.Graphics
 {
-	internal class OpenGLPipeline : IPipeline
+	internal sealed class OpenGLPipeline : IPipeline
 	{
 		private readonly GL GL;
 

--- a/src/BizHawk.Bizware.Graphics/Renderers/ImGui2DRenderer.cs
+++ b/src/BizHawk.Bizware.Graphics/Renderers/ImGui2DRenderer.cs
@@ -146,13 +146,13 @@ namespace BizHawk.Bizware.Graphics
 			EnableBlending = _pendingBlendEnable;
 		}
 
-		protected class ImGuiUserTexture
+		protected sealed class ImGuiUserTexture
 		{
 			public Bitmap Bitmap;
 			public bool WantCache;
 		}
 
-		protected class DrawStringArgs
+		protected sealed class DrawStringArgs
 		{
 			public string Str;
 			public Font Font;

--- a/src/BizHawk.Bizware.Graphics/Renderers/SDLImGui2DRenderer.cs
+++ b/src/BizHawk.Bizware.Graphics/Renderers/SDLImGui2DRenderer.cs
@@ -13,7 +13,7 @@ namespace BizHawk.Bizware.Graphics
 	/// Wraps SDL2's software rendering with an ImGui 2D renderer
 	/// Used for the GDI+ IGL, which doesn't understand vertexes and such
 	/// </summary>
-	internal class SDLImGui2DRenderer : ImGui2DRenderer
+	internal sealed class SDLImGui2DRenderer : ImGui2DRenderer
 	{
 		// SDL's software renderer sometimes doesn't fill in shapes all the way with a thickness of 1
 		// a thickness of 2 seems to suffice however

--- a/src/BizHawk.Bizware.Input/SDL2/SDL2Gamepad.cs
+++ b/src/BizHawk.Bizware.Input/SDL2/SDL2Gamepad.cs
@@ -7,7 +7,7 @@ namespace BizHawk.Bizware.Input
 	/// <summary>
 	/// SDL2 Gamepad Handler
 	/// </summary>
-	internal class SDL2Gamepad : IDisposable
+	internal sealed class SDL2Gamepad : IDisposable
 	{
 		// indexed by instance id
 		private static readonly Dictionary<int, SDL2Gamepad> Gamepads = new();

--- a/src/BizHawk.Client.Common/Api/ExternalToolAttributes.cs
+++ b/src/BizHawk.Client.Common/Api/ExternalToolAttributes.cs
@@ -36,7 +36,7 @@ namespace BizHawk.Client.Common
 		[AttributeUsage(AttributeTargets.Class)]
 		public sealed class RomList : ExternalToolApplicabilityAttributeBase
 		{
-			private readonly IList<string> _romHashes;
+			private readonly List<string> _romHashes;
 
 			private readonly string _sysID;
 

--- a/src/BizHawk.Client.Common/DisplayManager/Filters/Retro.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/Filters/Retro.cs
@@ -229,22 +229,22 @@ namespace BizHawk.Client.Common.Filters
 			public Vector2 Scale;
 		}
 
-		private static string FetchString(IDictionary<string, string> dict, string key, string @default)
+		private static string FetchString(Dictionary<string, string> dict, string key, string @default)
 		{
 			return dict.TryGetValue(key, out var str) ? str : @default;
 		}
 
-		private static int FetchInt(IDictionary<string, string> dict, string key, int @default)
+		private static int FetchInt(Dictionary<string, string> dict, string key, int @default)
 		{
 			return dict.TryGetValue(key, out var str) ? int.Parse(str) : @default;
 		}
 
-		private static float FetchFloat(IDictionary<string, string> dict, string key, float @default)
+		private static float FetchFloat(Dictionary<string, string> dict, string key, float @default)
 		{
 			return dict.TryGetValue(key, out var str) ? float.Parse(str, NumberFormatInfo.InvariantInfo) : @default;
 		}
 
-		private static bool FetchBool(IDictionary<string, string> dict, string key, bool @default)
+		private static bool FetchBool(Dictionary<string, string> dict, string key, bool @default)
 		{
 			return dict.TryGetValue(key, out var str) ? ParseBool(str) : @default;
 		}

--- a/src/BizHawk.Client.Common/DisplayManager/OSDManager.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/OSDManager.cs
@@ -137,7 +137,7 @@ namespace BizHawk.Client.Common
 
 			_messages.RemoveAll(m => DateTime.Now > m.ExpireAt);
 
-			if (_messages.Any())
+			if (_messages.Count != 0)
 			{
 				if (_config.StackOSDMessages)
 				{

--- a/src/BizHawk.Client.Common/RecentFiles.cs
+++ b/src/BizHawk.Client.Common/RecentFiles.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace BizHawk.Client.Common
@@ -29,15 +28,15 @@ namespace BizHawk.Client.Common
 		public bool Frozen { get; set; }
 
 		[JsonIgnore]
-		public bool Empty => !recentlist.Any();
+		public bool Empty => recentlist.Count == 0;
 
 		[JsonIgnore]
 		public int Count => recentlist.Count;
 
 		[JsonIgnore]
-		public string MostRecent => recentlist.Any() ? recentlist[0] : "";
+		public string MostRecent => recentlist.Count != 0 ? recentlist[0] : "";
 
-		public string this[int index] => recentlist.Any() ? recentlist[index] : "";
+		public string this[int index] => recentlist.Count != 0 ? recentlist[index] : "";
 
 		public IEnumerator<string> GetEnumerator() => recentlist.GetEnumerator();
 

--- a/src/BizHawk.Client.Common/RomGame.cs
+++ b/src/BizHawk.Client.Common/RomGame.cs
@@ -63,7 +63,9 @@ namespace BizHawk.Client.Common
 					NotInDatabase = true
 				};
 
+#pragma warning disable CA1862 // incorrect detection, see https://github.com/dotnet/roslyn-analyzers/issues/7074
 				if (!string.IsNullOrWhiteSpace(GameInfo.Name) && GameInfo.Name == GameInfo.Name.ToUpperInvariant())
+#pragma warning restore CA1862
 				{
 					GameInfo.Name = Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(GameInfo.Name.ToLowerInvariant());
 				}

--- a/src/BizHawk.Client.Common/RomLoader.cs
+++ b/src/BizHawk.Client.Common/RomLoader.cs
@@ -386,7 +386,7 @@ namespace BizHawk.Client.Common
 							return (int)CorePriority.UserPreference;
 						}
 
-						if (string.Equals(c.Name, dbForcedCoreName, StringComparison.OrdinalIgnoreCase))
+						if (c.Name.Equals(dbForcedCoreName, StringComparison.OrdinalIgnoreCase))
 						{
 							return (int)CorePriority.GameDbPreference;
 						}
@@ -532,7 +532,7 @@ namespace BizHawk.Client.Common
 		private static bool IsDiscForXML(string system, string path)
 		{
 			var ext = Path.GetExtension(path);
-			if (system == VSystemID.Raw.Arcade && ext.ToLowerInvariant() == ".chd")
+			if (system == VSystemID.Raw.Arcade && ext.Equals(".chd", StringComparison.OrdinalIgnoreCase))
 			{
 				return false;
 			}

--- a/src/BizHawk.Client.Common/controllers/StickyControllers.cs
+++ b/src/BizHawk.Client.Common/controllers/StickyControllers.cs
@@ -74,13 +74,9 @@ namespace BizHawk.Client.Common
 		{
 			foreach (var button in buttons.Where(button => !_justPressed.Contains(button)))
 			{
-				if (_buttonHolds.Contains(button))
+				if (!_buttonHolds.Add(button))
 				{
 					_buttonHolds.Remove(button);
-				}
-				else
-				{
-					_buttonHolds.Add(button);
 				}
 			}
 

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -89,9 +89,9 @@ namespace BizHawk.Client.Common
 
 		private static Controller BindToDefinition(
 			ControllerDefinition def,
-			IDictionary<string, Dictionary<string, string>> allBinds,
-			IDictionary<string, Dictionary<string, AnalogBind>> analogBinds,
-			IDictionary<string, Dictionary<string, FeedbackBind>> feedbackBinds)
+			Dictionary<string, Dictionary<string, string>> allBinds,
+			Dictionary<string, Dictionary<string, AnalogBind>> analogBinds,
+			Dictionary<string, Dictionary<string, FeedbackBind>> feedbackBinds)
 		{
 			var ret = new Controller(def);
 			if (allBinds.TryGetValue(def.Name, out var binds))
@@ -129,7 +129,7 @@ namespace BizHawk.Client.Common
 
 		private static AutofireController BindToDefinitionAF(
 			IEmulator emulator,
-			IDictionary<string, Dictionary<string, string>> allBinds,
+			Dictionary<string, Dictionary<string, string>> allBinds,
 			int on,
 			int off)
 		{

--- a/src/BizHawk.Client.Common/lua/LuaDocumentation.cs
+++ b/src/BizHawk.Client.Common/lua/LuaDocumentation.cs
@@ -146,7 +146,7 @@ namespace BizHawk.Client.Common
 
 				var sb = new StringBuilder();
 
-				if (f.ParameterList.Any())
+				if (f.ParameterList.Length != 0)
 				{
 					sb
 						.Append($"{f.Library}.{f.Name}(");

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.ModeApi.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.ModeApi.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace BizHawk.Client.Common
+﻿namespace BizHawk.Client.Common
 {
 	public partial class Bk2Movie
 	{
@@ -9,7 +7,7 @@ namespace BizHawk.Client.Common
 		public virtual void StartNewRecording()
 		{
 			Mode = MovieMode.Record;
-			if (Session.Settings.EnableBackupMovies && MakeBackup && Log.Any())
+			if (Session.Settings.EnableBackupMovies && MakeBackup && Log.Count != 0)
 			{
 				SaveBackup();
 				MakeBackup = false;

--- a/src/BizHawk.Client.Common/movie/bk2/StringLogs.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/StringLogs.cs
@@ -87,7 +87,7 @@ namespace BizHawk.Client.Common
 	/// </summary>
 	internal class StreamStringLog : IStringLog
 	{
-		private readonly Stream _stream;
+		private readonly FileStream _stream;
 		private readonly List<long> _offsets = new List<long>();
 		private readonly BinaryWriter _bw;
 		private readonly BinaryReader _br;

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
@@ -107,7 +107,7 @@ namespace BizHawk.Client.Common
 
 		public void RemoveFrames(ICollection<int> frames)
 		{
-			if (frames.Any())
+			if (frames.Count != 0)
 			{
 				// Separate the given frames into contiguous blocks
 				// and process each block independently

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.IO.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.IO.cs
@@ -33,7 +33,7 @@ namespace BizHawk.Client.Common
 				bs.PutLump(BinaryStateLump.ClientSettings, (TextWriter tw) => tw.Write(inputRollSettingsJson));
 			}
 
-			if (VerificationLog.Any())
+			if (VerificationLog.Count != 0)
 			{
 				bs.PutLump(BinaryStateLump.VerificationLog, tw => tw.WriteLine(VerificationLog.ToInputLog()));
 			}

--- a/src/BizHawk.Client.Common/savestates/ZipStateSaver.cs
+++ b/src/BizHawk.Client.Common/savestates/ZipStateSaver.cs
@@ -6,7 +6,7 @@ namespace BizHawk.Client.Common
 {
 	public class ZipStateSaver : IDisposable
 	{
-		private readonly IZipWriter _zip;
+		private readonly FrameworkZipWriter _zip;
 		private bool _isDisposed;
 
 		private static void WriteZipVersion(Stream s)
@@ -51,9 +51,9 @@ namespace BizHawk.Client.Common
 			// don't zstd compress text, as it's annoying for users
 			PutLump(lump, s =>
 			{
-				TextWriter tw = new StreamWriter(s);
-				callback(tw);
-				tw.Flush();
+				StreamWriter writer = new StreamWriter(s);
+				callback(writer);
+				writer.Flush();
 			}, false);
 		}
 

--- a/src/BizHawk.Client.Common/tools/CheatList.cs
+++ b/src/BizHawk.Client.Common/tools/CheatList.cs
@@ -92,7 +92,7 @@ namespace BizHawk.Client.Common
 		{
 			_defaultFileName = defaultFileName;
 
-			if (_cheatList.Any() && _changes && autosave)
+			if (_cheatList.Count != 0 && _changes && autosave)
 			{
 				if (string.IsNullOrEmpty(CurrentFileName))
 				{
@@ -224,7 +224,7 @@ namespace BizHawk.Client.Common
 		{
 			if (_config.AutoSaveOnClose)
 			{
-				if (Changes && _cheatList.Any())
+				if (Changes && _cheatList.Count != 0)
 				{
 					if (string.IsNullOrWhiteSpace(CurrentFileName))
 					{
@@ -233,7 +233,7 @@ namespace BizHawk.Client.Common
 
 					SaveFile(CurrentFileName);
 				}
-				else if (!_cheatList.Any() && !string.IsNullOrWhiteSpace(CurrentFileName))
+				else if (_cheatList.Count == 0 && !string.IsNullOrWhiteSpace(CurrentFileName))
 				{
 					File.Delete(CurrentFileName);
 					_config.Recent.Remove(CurrentFileName);

--- a/src/BizHawk.Client.EmuHawk/AVOut/AviWriter.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/AviWriter.cs
@@ -18,7 +18,7 @@ namespace BizHawk.Client.EmuHawk
 {
 	[VideoWriter("vfwavi", "AVI writer",
 		"Uses the Microsoft AVIFIL32 system to write .avi files.  Audio is uncompressed; Video can be compressed with any installed VCM codec.  Splits on 2G and resolution change.")]
-	internal class AviWriter : IVideoWriter
+	internal sealed class AviWriter : IVideoWriter
 	{
 		private CodecToken _currVideoCodecToken;
 		private AviWriterSegment _currSegment;
@@ -111,7 +111,7 @@ namespace BizHawk.Client.EmuHawk
 		// we can't pass the IVideoProvider we get to another thread, because it doesn't actually keep a local copy of its data,
 		// instead grabbing it from the emu as needed.  this causes frame loss/dupping as a race condition
 		// instead we pass this
-		private class VideoCopy : IVideoProvider
+		private sealed class VideoCopy : IVideoProvider
 		{
 			private readonly int[] _vb;
 			public int VirtualWidth { get; }
@@ -287,7 +287,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class Parameters
+		private sealed class Parameters
 		{
 			public int width, height;
 			public int pitch; //in bytes
@@ -398,7 +398,7 @@ namespace BizHawk.Client.EmuHawk
 			Segment();
 		}
 
-		public class CodecToken : IDisposable
+		public sealed class CodecToken : IDisposable
 		{
 			public void Dispose()
 			{
@@ -570,7 +570,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 		}
 
-		private class AviWriterSegment : IDisposable
+		private sealed class AviWriterSegment : IDisposable
 		{
 			static AviWriterSegment()
 			{
@@ -608,7 +608,7 @@ namespace BizHawk.Client.EmuHawk
 				return _pGlobalBuf;
 			}
 
-			private class OutputStatus
+			private sealed class OutputStatus
 			{
 				public int video_frames;
 				public int video_bytes;

--- a/src/BizHawk.Client.EmuHawk/AVOut/AviWriter.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/AviWriter.cs
@@ -275,8 +275,7 @@ namespace BizHawk.Client.EmuHawk
 
 			try
 			{
-				var ret = tempSegment.AcquireVideoCodecToken(_dialogParent.AsWinFormsHandle().Handle, _currVideoCodecToken);
-				var token = (CodecToken)ret;
+				var token = tempSegment.AcquireVideoCodecToken(_dialogParent.AsWinFormsHandle().Handle, _currVideoCodecToken);
 				config.AviCodecToken = token?.Serialize();
 				return token;
 			}
@@ -709,7 +708,7 @@ namespace BizHawk.Client.EmuHawk
 
 			/// <summary>acquires a video codec configuration from the user</summary>
 			/// <exception cref="InvalidOperationException">no file open (need to call <see cref="OpenFile"/>)</exception>
-			public IDisposable AcquireVideoCodecToken(IntPtr hwnd, CodecToken lastCodecToken)
+			public CodecToken AcquireVideoCodecToken(IntPtr hwnd, CodecToken lastCodecToken)
 			{
 				if (!_isOpen)
 				{

--- a/src/BizHawk.Client.EmuHawk/AVOut/GifWriter.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/GifWriter.cs
@@ -115,7 +115,7 @@ namespace BizHawk.Client.EmuHawk
 		/// <summary>
 		/// the underlying stream we're writing to
 		/// </summary>
-		private Stream _f;
+		private FileStream _f;
 
 		/// <summary>
 		/// a final byte we must write before closing the stream

--- a/src/BizHawk.Client.EmuHawk/AVOut/ImageSequenceWriter.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/ImageSequenceWriter.cs
@@ -49,11 +49,11 @@ namespace BizHawk.Client.EmuHawk
 			var name = Path.Combine(dir!, $"{fileNoExt}_{_frame}{ext}");
 			BitmapBuffer bb = new BitmapBuffer(source.BufferWidth, source.BufferHeight, source.GetVideoBuffer());
 			using var bmp = bb.ToSysdrawingBitmap();
-			if (ext.ToUpperInvariant() == ".PNG")
+			if (ext.Equals(".PNG", StringComparison.OrdinalIgnoreCase))
 			{
 				bmp.Save(name, ImageFormat.Png);
 			}
-			else if (ext.ToUpperInvariant() == ".JPG")
+			else if (ext.Equals(".JPG", StringComparison.OrdinalIgnoreCase))
 			{
 				bmp.Save(name, ImageFormat.Jpeg);
 			}

--- a/src/BizHawk.Client.EmuHawk/AVOut/ImageSequenceWriter.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/ImageSequenceWriter.cs
@@ -65,7 +65,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 		}
 
-		private class CodecToken : IDisposable
+		private sealed class CodecToken : IDisposable
 		{
 			public void Dispose()
 			{

--- a/src/BizHawk.Client.EmuHawk/AVOut/JMDWriter.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/JMDWriter.cs
@@ -600,7 +600,7 @@ namespace BizHawk.Client.EmuHawk
 		public void OpenFile(string baseName)
 		{
 			string ext = Path.GetExtension(baseName);
-			if (ext == null || ext.ToLowerInvariant() != ".jmd")
+			if (ext == null || !ext.Equals(".jmd", StringComparison.OrdinalIgnoreCase))
 			{
 				baseName += ".jmd";
 			}

--- a/src/BizHawk.Client.EmuHawk/AVOut/JMDWriter.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/JMDWriter.cs
@@ -42,7 +42,7 @@ namespace BizHawk.Client.EmuHawk
 		/// <summary>
 		/// carries private compression information data
 		/// </summary>
-		private class CodecToken : IDisposable
+		private sealed class CodecToken : IDisposable
 		{
 			public void Dispose()
 			{
@@ -94,7 +94,7 @@ namespace BizHawk.Client.EmuHawk
 		/// metadata for a movie
 		/// not needed if we aren't dumping something that's not a movie
 		/// </summary>
-		private class MovieMetaData
+		private sealed class MovieMetaData
 		{
 			/// <summary>
 			/// name of the game (rom)
@@ -123,7 +123,7 @@ namespace BizHawk.Client.EmuHawk
 		/// <summary>
 		/// represents a JMD file packet ready to be written except for sorting and timestamp offset
 		/// </summary>
-		private class JmdPacket
+		private sealed class JmdPacket
 		{
 			public ushort Stream { get; set; }
 			public ulong Timestamp { get; set; } // final muxed timestamp will be relative to previous
@@ -135,7 +135,7 @@ namespace BizHawk.Client.EmuHawk
 		/// writes JMD file packets to an underlying bytestream
 		/// handles one video, one pcm audio, and one metadata track
 		/// </summary>
-		private class JmdFile
+		private sealed class JmdFile
 		{
 			// current timestamp position
 			private ulong _timestampOff;

--- a/src/BizHawk.Client.EmuHawk/AVOut/NutMuxer.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/NutMuxer.cs
@@ -199,7 +199,7 @@ namespace BizHawk.Client.EmuHawk
 		/// <summary>
 		/// writes a single packet out, including CheckSums
 		/// </summary>
-		private class NutPacket : Stream
+		private sealed class NutPacket : Stream
 		{
 			public enum StartCode : ulong
 			{
@@ -290,7 +290,7 @@ namespace BizHawk.Client.EmuHawk
 		/// <summary>
 		/// stores basic AV parameters
 		/// </summary>
-		private class AVParams
+		private sealed class AVParams
 		{
 			public int Width { get; set; }
 			public int Height { get; set; }
@@ -424,7 +424,7 @@ namespace BizHawk.Client.EmuHawk
 		/// stores a single frame with syncpoint, in mux-ready form
 		/// used because reordering of audio and video can be needed for proper interleave
 		/// </summary>
-		private class NutFrame
+		private sealed class NutFrame
 		{
 			/// <summary>
 			/// data ready to be written to stream/disk

--- a/src/BizHawk.Client.EmuHawk/AVOut/NutWriter.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/NutWriter.cs
@@ -16,7 +16,7 @@ namespace BizHawk.Client.EmuHawk
 		/// <summary>
 		/// dummy codec token class
 		/// </summary>
-		private class NutWriterToken : IDisposable
+		private sealed class NutWriterToken : IDisposable
 		{
 			public void Dispose()
 			{

--- a/src/BizHawk.Client.EmuHawk/AVOut/SynclessRecorder.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/SynclessRecorder.cs
@@ -75,7 +75,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public bool UsesVideo => true;
 
-		private class DummyDisposable : IDisposable
+		private sealed class DummyDisposable : IDisposable
 		{
 			public void Dispose()
 			{

--- a/src/BizHawk.Client.EmuHawk/AVOut/SynclessRecordingTools.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/SynclessRecordingTools.cs
@@ -88,7 +88,7 @@ namespace BizHawk.Client.EmuHawk
 			wav = $"{path}.wav";
 		}
 
-		private class FrameInfo
+		private sealed class FrameInfo
 		{
 			public string WavPath { get; set; }
 			public string PngPath { get; set; }

--- a/src/BizHawk.Client.EmuHawk/AVOut/WavWriter.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/WavWriter.cs
@@ -223,7 +223,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public bool UsesVideo => false;
 
-		private class WavWriterVToken : IDisposable
+		private sealed class WavWriterVToken : IDisposable
 		{
 			public void Dispose() { }
 		}

--- a/src/BizHawk.Client.EmuHawk/ArchiveChooser.cs
+++ b/src/BizHawk.Client.EmuHawk/ArchiveChooser.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Client.EmuHawk
 {
 	public partial class ArchiveChooser : Form
 	{
-		private readonly IList<ListViewItem> _archiveItems = new List<ListViewItem>();
+		private readonly List<ListViewItem> _archiveItems = new List<ListViewItem>();
 		private readonly ToolTip _errorBalloon = new ToolTip();
 
 		private static bool _useRegEx;

--- a/src/BizHawk.Client.EmuHawk/ArchiveChooser.cs
+++ b/src/BizHawk.Client.EmuHawk/ArchiveChooser.cs
@@ -34,7 +34,7 @@ namespace BizHawk.Client.EmuHawk
 				lvi.Text = item.Name;
 				long size = item.Size;
 				var extension = Path.GetExtension(item.Name);
-				if (extension != null && size % 1024 == 16 && extension.ToUpperInvariant() == ".NES")
+				if (extension != null && size % 1024 == 16 && extension.Equals(".NES", StringComparison.OrdinalIgnoreCase))
 					size -= 16;
 				lvi.SubItems[1].Text = Util.FormatFileSize(size);
 				_archiveItems.Add(lvi);

--- a/src/BizHawk.Client.EmuHawk/ArchiveChooser.cs
+++ b/src/BizHawk.Client.EmuHawk/ArchiveChooser.cs
@@ -200,7 +200,7 @@ namespace BizHawk.Client.EmuHawk
 			bool Matches(ListViewItem value);
 		}
 
-		private class SimpleMatcher : IMatcher
+		private sealed class SimpleMatcher : IMatcher
 		{
 			public string[] Keys { get; set; }
 			public bool Matches(ListViewItem value)
@@ -218,7 +218,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class RegExMatcher : IMatcher
+		private sealed class RegExMatcher : IMatcher
 		{
 			public Regex Matcher { get; set; }
 			public bool Matches(ListViewItem value)

--- a/src/BizHawk.Client.EmuHawk/CoreFeatureAnalysis.cs
+++ b/src/BizHawk.Client.EmuHawk/CoreFeatureAnalysis.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Client.EmuHawk
 {
 	public partial class CoreFeatureAnalysis : ToolFormBase, IToolFormAutoConfig
 	{
-		private class CoreInfo
+		private sealed class CoreInfo
 		{
 			public string CoreName { get; set; }
 			public bool Released { get; set; }
@@ -48,7 +48,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class ServiceInfo
+		private sealed class ServiceInfo
 		{
 			public string TypeName { get; set; }
 			public bool Complete { get; set; }
@@ -81,7 +81,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class FunctionInfo
+		private sealed class FunctionInfo
 		{
 			public string TypeName { get; set; }
 			public bool Complete { get; set; }

--- a/src/BizHawk.Client.EmuHawk/CustomControls/ControlRenderer/GdiPlusRenderer.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/ControlRenderer/GdiPlusRenderer.cs
@@ -20,7 +20,7 @@ namespace BizHawk.Client.EmuHawk.CustomControls
 			_currentFont = font;
 		}
 
-		private class GdiPlusGraphicsLock : IDisposable
+		private sealed class GdiPlusGraphicsLock : IDisposable
 		{
 			public void Dispose()
 			{

--- a/src/BizHawk.Client.EmuHawk/CustomControls/ExceptionBox.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/ExceptionBox.cs
@@ -66,7 +66,7 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		//http://stackoverflow.com/questions/2636065/alpha-in-forecolor
-		private class MyLabel : Label
+		private sealed class MyLabel : Label
 		{
 			protected override void OnPaint(PaintEventArgs e)
 			{

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.Drawing.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.Drawing.cs
@@ -44,7 +44,7 @@ namespace BizHawk.Client.EmuHawk
 				var lastVisibleRow = firstVisibleRow + visibleRows;
 
 				var needsColumnRedraw = HorizontalOrientation || e.ClipRectangle.Y < ColumnHeight;
-				if (visibleColumns.Any() && needsColumnRedraw)
+				if (visibleColumns.Count != 0 && needsColumnRedraw)
 				{
 					DrawColumnBg(visibleColumns, e.ClipRectangle);
 					DrawColumnText(visibleColumns);
@@ -215,7 +215,7 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 
-			if (!visibleColumns.Any())
+			if (visibleColumns.Count == 0)
 			{
 				return;
 			}
@@ -342,7 +342,7 @@ namespace BizHawk.Client.EmuHawk
 					y += GetHColHeight(j);
 				}
 
-				if (visibleColumns.Any())
+				if (visibleColumns.Count != 0)
 				{
 					_renderer.Line(1, y, MaxColumnWidth, y);
 				}
@@ -367,7 +367,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 
 				// Draw right most line
-				if (visibleColumns.Any())
+				if (visibleColumns.Count != 0)
 				{
 					int right = TotalColWidth - _hBar.Value;
 					if (right <= rect.Left + rect.Width)
@@ -482,7 +482,7 @@ namespace BizHawk.Client.EmuHawk
 						_renderer.Line(x, y, x, rect.Height - 1);
 					}
 
-					if (visibleColumns.Any())
+					if (visibleColumns.Count != 0)
 					{
 						int x = TotalColWidth - _hBar.Value;
 						_renderer.Line(x, y, x, rect.Height - 1);
@@ -586,7 +586,7 @@ namespace BizHawk.Client.EmuHawk
 		// Calls QueryItemBkColor callback for all visible cells and fills in the background of those cells.
 		private void DoBackGroundCallback(List<RollColumn> visibleColumns, Rectangle rect, int firstVisibleRow, int lastVisibleRow)
 		{
-			if (!visibleColumns.Any())
+			if (visibleColumns.Count == 0)
 			{
 				return;
 			}

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -20,7 +20,7 @@ namespace BizHawk.Client.EmuHawk
 	// Row width is specified for horizontal orientation
 	public partial class InputRoll : Control
 	{
-		private readonly IControlRenderer _renderer;
+		private readonly GdiPlusRenderer _renderer;
 
 		private readonly CellList _selectedItems = new();
 

--- a/src/BizHawk.Client.EmuHawk/CustomControls/MsgBox.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/MsgBox.cs
@@ -7,7 +7,7 @@ namespace BizHawk.Client.EmuHawk.CustomControls
 	/// <summary>
 	/// A customizable Dialog box with 3 buttons, custom icon, and checkbox.
 	/// </summary>
-	internal partial class MsgBox : Form
+	internal sealed partial class MsgBox : Form
 	{
 		private readonly Icon _msgIcon;
 		private static readonly int FormYMargin = UIHelper.ScaleY(10);

--- a/src/BizHawk.Client.EmuHawk/LogWindow.cs
+++ b/src/BizHawk.Client.EmuHawk/LogWindow.cs
@@ -205,7 +205,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class LogWriter : TextWriter
+		private sealed class LogWriter : TextWriter
 		{
 			public override void Write(char[] buffer, int offset, int count)
 			{

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2026,7 +2026,7 @@ namespace BizHawk.Client.EmuHawk
 				&& t.GetCustomAttribute<SpecializedToolAttribute>() is not null)
 			.ToList();
 
-		private ISet<char> _availableAccelerators;
+		private HashSet<char> _availableAccelerators;
 
 		private ISet<char> AvailableAccelerators
 		{

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2055,9 +2055,8 @@ namespace BizHawk.Client.EmuHawk
 			for (var i = 0; i < sysID.Length; i++)
 			{
 				var upper = char.ToUpperInvariant(sysID[i]);
-				if (AvailableAccelerators.Contains(upper))
+				if (AvailableAccelerators.Remove(upper))
 				{
-					AvailableAccelerators.Remove(upper);
 					sysID = sysID.Insert(i, "&");
 					break;
 				}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1377,7 +1377,7 @@ namespace BizHawk.Client.EmuHawk
 			using (var bb = Config.ScreenshotCaptureOsd ? CaptureOSD() : MakeScreenshotImage())
 			{
 				using var img = bb.ToSysdrawingBitmap();
-				if (Path.GetExtension(path).ToUpperInvariant() == ".JPG")
+				if (Path.GetExtension(path).Equals(".JPG", StringComparison.OrdinalIgnoreCase))
 				{
 					img.Save(fi.FullName, ImageFormat.Jpeg);
 				}
@@ -3713,7 +3713,7 @@ namespace BizHawk.Client.EmuHawk
 					InputManager.SyncControls(Emulator, MovieSession, Config);
 					_multiDiskMode = false;
 
-					if (oaOpenrom != null && Path.GetExtension(oaOpenrom.Path.Replace("|", "")).ToLowerInvariant() == ".xml" && Emulator is not LibsnesCore)
+					if (oaOpenrom != null && Path.GetExtension(oaOpenrom.Path.Replace("|", "")).Equals(".xml", StringComparison.OrdinalIgnoreCase) && Emulator is not LibsnesCore)
 					{
 						// this is a multi-disk bundler file
 						// determine the xml assets and create RomStatusDetails for all of them

--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RAIntegration.Update.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RAIntegration.Update.cs
@@ -19,7 +19,7 @@ namespace BizHawk.Client.EmuHawk
 		public static bool IsAvailable => _RA != null;
 
 		// can't have both a proxy with a monitor and without one, so...
-		private class DummyMonitor : IMonitor
+		private sealed class DummyMonitor : IMonitor
 		{
 			public void Enter() {}
 			public void Exit() {}

--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RCheevos.Debug.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RCheevos.Debug.cs
@@ -98,7 +98,7 @@ namespace BizHawk.Client.EmuHawk
 			handle.Free();
 		}
 
-		private class RCTrack : IDisposable
+		private sealed class RCTrack : IDisposable
 		{
 			private readonly Disc _disc;
 			private readonly DiscSectorReader _dsr;

--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Hardcore.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Hardcore.cs
@@ -123,7 +123,7 @@ namespace BizHawk.Client.EmuHawk
 					HandleHardcoreModeDisable("Using MAME in hardcore mode is not allowed.");
 					break;
 				case NymaCore nyma:
-					if (nyma.GetSettings().DisabledLayers.Any())
+					if (nyma.GetSettings().DisabledLayers.Count != 0)
 					{
 						HandleHardcoreModeDisable($"Disabling {Emu.GetType().Name}'s graphics layers in hardcore mode is not allowed.");
 					}

--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Memory.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Memory.cs
@@ -190,7 +190,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class NullMemFunctions : MemFunctions
+		private sealed class NullMemFunctions : MemFunctions
 		{
 			public NullMemFunctions(long bankSize)
 				: base(null, 0, bankSize)
@@ -202,7 +202,7 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		// this is a complete hack because the libretro Intelli core sucks and so achievements are made expecting this format
-		private class IntelliMemFunctions : MemFunctions
+		private sealed class IntelliMemFunctions : MemFunctions
 		{
 			protected override uint FixAddr(uint addr)
 				=> (addr >> 1) + (~addr & 1);
@@ -265,7 +265,7 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		// our vram is unpacked, but RA expects it packed
-		private class ChanFMemFunctions(MemoryDomain vram)
+		private sealed class ChanFMemFunctions(MemoryDomain vram)
 			: MemFunctions(null, 0, 0x800)
 		{
 			private byte ReadVRAMPacked(uint addr)

--- a/src/BizHawk.Client.EmuHawk/ScreenSaver.cs
+++ b/src/BizHawk.Client.EmuHawk/ScreenSaver.cs
@@ -13,7 +13,7 @@ namespace BizHawk.Client.EmuHawk
 			int Duration { get; set; }
 		}
 
-		private class Win32ScreenBlankTimer : IScreenBlankTimer
+		private sealed class Win32ScreenBlankTimer : IScreenBlankTimer
 		{
 			public int Duration
 			{
@@ -34,7 +34,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class UnixScreenBlankTimer : IScreenBlankTimer
+		private sealed class UnixScreenBlankTimer : IScreenBlankTimer
 		{
 			public int Duration { get; set; } = 0; //TODO implementation
 		}

--- a/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
@@ -143,14 +143,15 @@ namespace BizHawk.Client.EmuHawk
 						: "Console"; // anything that wants not console can set it in the categorylabels
 				}
 
-				if (!buckets.ContainsKey(categoryLabel))
+				if (!buckets.TryGetValue(categoryLabel, out var bucket))
 				{
 					var l = new List<string>();
-					buckets.Add(categoryLabel, l);
+					bucket = l;
+					buckets.Add(categoryLabel, bucket);
 					orderedBuckets.Add(new KeyValuePair<string, List<string>>(categoryLabel, l));
 				}
 
-				buckets[categoryLabel].Add(button);
+				bucket.Add(button);
 			}
 
 			if (orderedBuckets.Count == 1)

--- a/src/BizHawk.Client.EmuHawk/config/FirmwareConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/FirmwareConfig.cs
@@ -100,7 +100,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private Font _fixedFont, _boldFont, _boldFixedFont;
 
-		private class ListViewSorter : IComparer
+		private sealed class ListViewSorter : IComparer
 		{
 			public int Column { get; set; }
 			public int Sign { get; set; }

--- a/src/BizHawk.Client.EmuHawk/movie/PlayMovie.cs
+++ b/src/BizHawk.Client.EmuHawk/movie/PlayMovie.cs
@@ -153,9 +153,9 @@ namespace BizHawk.Client.EmuHawk
 			return null;
 		}
 
-		private IBasicMovieInfo LoadMovieInfo(HawkFile hf, bool force)
+		private BasicMovieInfo LoadMovieInfo(HawkFile hf, bool force)
 		{
-			IBasicMovieInfo movie = new BasicMovieInfo(hf.CanonicalFullPath);
+			var movie = new BasicMovieInfo(hf.CanonicalFullPath);
 
 			try
 			{

--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
@@ -472,7 +472,7 @@ namespace BizHawk.Client.EmuHawk
 			Frames = 0;
 		}
 
-		private class BotAttempt
+		private sealed class BotAttempt
 		{
 			public long Attempt { get; set; }
 			public int Maximize { get; set; }
@@ -524,7 +524,7 @@ namespace BizHawk.Client.EmuHawk
 			_bestBotAttempt.is_Reset = false;
 		}
 
-		private class BotData
+		private sealed class BotData
 		{
 			public BotAttempt Best { get; set; }
 			public Dictionary<string, double> ControlProbabilities { get; set; }

--- a/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.cs
@@ -400,7 +400,7 @@ namespace BizHawk.Client.EmuHawk
 		private void RemoveCheatMenuItem_Click(object sender, EventArgs e)
 		{
 			var items = SelectedItems.ToList();
-			if (items.Any())
+			if (items.Count != 0)
 			{
 				foreach (var item in items)
 				{
@@ -600,7 +600,7 @@ namespace BizHawk.Client.EmuHawk
 		private void ViewInHexEditorContextMenuItem_Click(object sender, EventArgs e)
 		{
 			var selected = SelectedCheats.ToList();
-			if (selected.Any())
+			if (selected.Count != 0)
 			{
 				Tools.Load<HexEditor>();
 

--- a/src/BizHawk.Client.EmuHawk/tools/Debugger/BreakpointControl.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Debugger/BreakpointControl.cs
@@ -185,7 +185,7 @@ namespace BizHawk.Client.EmuHawk
 			if (EditableItems.Any())
 			{
 				var items = EditableItems.ToList();
-				if (items.Any())
+				if (items.Count != 0)
 				{
 					foreach (var item in items)
 					{
@@ -216,7 +216,7 @@ namespace BizHawk.Client.EmuHawk
 			if (EditableItems.Any())
 			{
 				var items = EditableItems.ToList();
-				if (items.Any())
+				if (items.Count != 0)
 				{
 					foreach (var item in items) item.Active = !item.Active;
 					BreakpointView.VirtualListSize = _breakpoints.Count;

--- a/src/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.Disassembler.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.Disassembler.cs
@@ -90,7 +90,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void DisassemblerView_QueryItemBkColor(int index, RollColumn column, ref Color color)
 		{
-			if (_disassemblyLines.Any() && index < _disassemblyLines.Count)
+			if (_disassemblyLines.Count != 0 && index < _disassemblyLines.Count)
 			{
 				if (_disassemblyLines[index].Address == _currentDisassemblerAddress)
 				{

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -2176,11 +2176,7 @@ namespace BizHawk.Client.EmuHawk
 						{
 							ClearHighlighted();
 						}
-						else if (_secondaryHighlightedAddresses.Contains(pointedAddress))
-						{
-							_secondaryHighlightedAddresses.Remove(pointedAddress);
-						}
-						else
+						else if (!_secondaryHighlightedAddresses.Remove(pointedAddress))
 						{
 							_secondaryHighlightedAddresses.Add(pointedAddress);
 						}

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -45,7 +45,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class NullMemoryDomain : MemoryDomain
+		private sealed class NullMemoryDomain : MemoryDomain
 		{
 			public override byte PeekByte(long addr) => 0;
 
@@ -125,7 +125,7 @@ namespace BizHawk.Client.EmuHawk
 		[ConfigPersist]
 		private RecentFiles RecentTables { get; set; }
 
-		internal class ColorConfig
+		internal sealed class ColorConfig
 		{
 			public Color Background { get; set; } = SystemColors.Control;
 			public Color Foreground { get; set; } = SystemColors.ControlText;

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -273,7 +273,7 @@ namespace BizHawk.Client.EmuHawk
 			DataSize = (int)size;
 			SetDataSize(DataSize);
 			var addrList = addresses.ToList();
-			if (addrList.Any())
+			if (addrList.Count != 0)
 			{
 				SetMemoryDomain(domain.Name);
 				SetHighlighted(addrList[0]);
@@ -287,7 +287,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public byte[] ConvertTextToBytes(string str)
 		{
-			if (_textTable.Any())
+			if (_textTable.Count != 0)
 			{
 				var byteArr = new byte[str.Length];
 				for (var i = 0; i < str.Length; i++)
@@ -699,7 +699,7 @@ namespace BizHawk.Client.EmuHawk
 				: SystemColors.ControlDarkDark;
 
 			if (_highlightedAddress >= _domain.Size
-				|| (_secondaryHighlightedAddresses.Any() && _secondaryHighlightedAddresses.Max() >= _domain.Size))
+				|| (_secondaryHighlightedAddresses.Count != 0 && _secondaryHighlightedAddresses.Max() >= _domain.Size))
 			{
 				_highlightedAddress = null;
 				_secondaryHighlightedAddresses.Clear();
@@ -715,7 +715,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			var addressesString = "0x" + $"{_domain.Size / DataSize:X8}".TrimStart('0');
 			var viewerText = $"{Emulator.SystemId} {_domain}{(_domain.Writable ? string.Empty : " (READ-ONLY)")}  -  {addressesString} addresses";
-			if (_nibbles.Any())
+			if (_nibbles.Count != 0)
 			{
 				viewerText += $"  Typing: ({MakeNibbles()})";
 			}
@@ -786,7 +786,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				var newTitle = "Hex Editor";
 				newTitle += " - Editing Address 0x" + string.Format(_numDigitsStr, _highlightedAddress);
-				if (_secondaryHighlightedAddresses.Any())
+				if (_secondaryHighlightedAddresses.Count != 0)
 				{
 					newTitle += $" (Selected 0x{_secondaryHighlightedAddresses.Count + (_secondaryHighlightedAddresses.Contains(_highlightedAddress.Value) ? 0 : 1):X})";
 				}
@@ -850,7 +850,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void FreezeHighlighted()
 		{
-			if (!_highlightedAddress.HasValue && !_secondaryHighlightedAddresses.Any())
+			if (!_highlightedAddress.HasValue && _secondaryHighlightedAddresses.Count == 0)
 			{
 				return;
 			}
@@ -870,7 +870,7 @@ namespace BizHawk.Client.EmuHawk
 					watch.Value));
 			}
 
-			if (_secondaryHighlightedAddresses.Any())
+			if (_secondaryHighlightedAddresses.Count != 0)
 			{
 				foreach (var address in _secondaryHighlightedAddresses)
 				{
@@ -894,7 +894,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void UnfreezeHighlighted()
 		{
-			if (!_highlightedAddress.HasValue && !_secondaryHighlightedAddresses.Any())
+			if (!_highlightedAddress.HasValue && _secondaryHighlightedAddresses.Count == 0)
 			{
 				return;
 			}
@@ -904,7 +904,7 @@ namespace BizHawk.Client.EmuHawk
 				MainForm.CheatList.RemoveRange(MainForm.CheatList.Where(x => x.Contains(_highlightedAddress.Value)));
 			}
 
-			if (_secondaryHighlightedAddresses.Any())
+			if (_secondaryHighlightedAddresses.Count != 0)
 			{
 				MainForm.CheatList.RemoveRange(
 					MainForm.CheatList.Where(cheat => !cheat.IsSeparator && cheat.Domain == _domain
@@ -1265,7 +1265,7 @@ namespace BizHawk.Client.EmuHawk
 				SaveAsBinaryMenuItem.Text = "Save as binary...";
 			}
 
-			CloseTableFileMenuItem.Enabled = _textTable.Any();
+			CloseTableFileMenuItem.Enabled = _textTable.Count != 0;
 		}
 		
 		private void SaveMenuItem_Click(object sender, EventArgs e)
@@ -1371,7 +1371,7 @@ namespace BizHawk.Client.EmuHawk
 			var data = Clipboard.GetDataObject();
 			PasteMenuItem.Enabled =
 				_domain.Writable
-				&& (_highlightedAddress.HasValue || _secondaryHighlightedAddresses.Any())
+				&& (_highlightedAddress.HasValue || _secondaryHighlightedAddresses.Count != 0)
 				&& data != null
 				&& data.GetDataPresent(DataFormats.Text);
 
@@ -1599,7 +1599,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void AddToRamWatchMenuItem_Click(object sender, EventArgs e)
 		{
-			if (_highlightedAddress.HasValue || _secondaryHighlightedAddresses.Any())
+			if (_highlightedAddress.HasValue || _secondaryHighlightedAddresses.Count != 0)
 			{
 				Tools.LoadRamWatch(true);
 			}
@@ -1655,12 +1655,12 @@ namespace BizHawk.Client.EmuHawk
 				addresses.Add(_highlightedAddress.Value);
 			}
 
-			if (_secondaryHighlightedAddresses.Any())
+			if (_secondaryHighlightedAddresses.Count != 0)
 			{
 				addresses.AddRange(_secondaryHighlightedAddresses);
 			}
 
-			if (addresses.Any())
+			if (addresses.Count != 0)
 			{
 				var watches = addresses.Select(
 					address => Watch.GenerateWatch(
@@ -1961,7 +1961,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			var data = Clipboard.GetDataObject();
 
-			var selectionNotEmpty = _highlightedAddress is not null || _secondaryHighlightedAddresses.Any();
+			var selectionNotEmpty = _highlightedAddress is not null || _secondaryHighlightedAddresses.Count != 0;
 			CopyContextItem.Visible = AddToRamWatchContextItem.Visible = selectionNotEmpty;
 
 			FreezeContextItem.Visible = PokeContextItem.Visible

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -16,7 +16,7 @@ namespace BizHawk.Client.EmuHawk
 	[LuaLibrary(released: true)]
 	public sealed class TAStudioLuaLibrary : LuaLibraryBase
 	{
-		private static readonly IDictionary<string, Icon> _iconCache = new Dictionary<string, Icon>();
+		private static readonly Dictionary<string, Icon> _iconCache = new Dictionary<string, Icon>();
 
 		public ToolManager Tools { get; set; }
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaButton.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaButton.cs
@@ -2,7 +2,7 @@ using System.Windows.Forms;
 
 namespace BizHawk.Client.EmuHawk
 {
-	internal class LuaButton : Button
+	internal sealed class LuaButton : Button
 	{
 		protected override void OnClick(EventArgs e)
 		{

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -940,7 +940,7 @@ namespace BizHawk.Client.EmuHawk
 		private void RemoveScriptMenuItem_Click(object sender, EventArgs e)
 		{
 			var items = SelectedItems.ToList();
-			if (items.Any())
+			if (items.Count != 0)
 			{
 				foreach (var item in items)
 				{
@@ -1202,10 +1202,10 @@ namespace BizHawk.Client.EmuHawk
 		private void ConsoleContextMenu_Opening(object sender, CancelEventArgs e)
 		{
 			RegisteredFunctionsContextItem.Enabled = LuaImp.RegisteredFunctions.Any();
-			CopyContextItem.Enabled = OutputBox.SelectedText.Any();
+			CopyContextItem.Enabled = OutputBox.SelectedText.Length != 0;
 			ClearConsoleContextItem.Enabled =
 				SelectAllContextItem.Enabled =
-				OutputBox.Text.Any();
+				OutputBox.Text.Length != 0;
 
 			ClearRegisteredFunctionsLogContextItem.Enabled =
 				LuaImp.RegisteredFunctions.Any();

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaFunctionsForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaFunctionsForm.cs
@@ -92,7 +92,7 @@ namespace BizHawk.Client.EmuHawk
 			OrderColumn(e.Column);
 		}
 
-		private class Sorting
+		private sealed class Sorting
 		{
 			private int _column = 1;
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaLibraries.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaLibraries.cs
@@ -166,7 +166,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public bool IsInInputOrMemoryCallback { get; set; }
 
-		private readonly IDictionary<Type, LuaLibraryBase> Libraries = new Dictionary<Type, LuaLibraryBase>();
+		private readonly Dictionary<Type, LuaLibraryBase> Libraries = new Dictionary<Type, LuaLibraryBase>();
 
 		private EventWaitHandle LuaWait;
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaTextBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaTextBox.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Client.EmuHawk
 		All, Signed, Unsigned, Hex
 	}
 
-	internal class LuaTextBox : TextBox
+	internal sealed class LuaTextBox : TextBox
 	{
 		private BoxType _boxType = BoxType.All;
 

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.cs
@@ -94,7 +94,7 @@ namespace BizHawk.Client.EmuHawk
 			public int Note;
 		}
 
-		private class ApuState
+		private sealed class ApuState
 		{
 			public PulseState Pulse0;
 			public PulseState Pulse1;

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCESoundDebugger.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCESoundDebugger.cs
@@ -152,7 +152,7 @@ namespace BizHawk.Client.EmuHawk
 			lvChannels.EndUpdate();
 		}
 
-		private class PsgEntry
+		private sealed class PsgEntry
 		{
 			public int Index { get; set; }
 			public bool Active { get; set; }

--- a/src/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.cs
@@ -505,7 +505,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class DisplayTypeItem
+		private sealed class DisplayTypeItem
 		{
 			public eDisplayType Type { get; }
 			public string Descr { get; }
@@ -516,7 +516,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class PaletteTypeItem
+		private sealed class PaletteTypeItem
 		{
 			public SnesColors.ColorType Type { get; }
 			public string Descr { get; }
@@ -930,7 +930,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private class MapEntryState
+		private sealed class MapEntryState
 		{
 			public SNESGraphicsDecoder.TileEntry entry;
 			public int bgnum;
@@ -938,7 +938,7 @@ namespace BizHawk.Client.EmuHawk
 		}
 		private MapEntryState currMapEntryState;
 
-		private class TileDataState
+		private sealed class TileDataState
 		{
 			public eDisplayType Type;
 			public int Bpp;
@@ -948,7 +948,7 @@ namespace BizHawk.Client.EmuHawk
 		}
 		private TileDataState currTileDataState;
 
-		private class ObjDataState
+		private sealed class ObjDataState
 		{
 			public int Number;
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -124,7 +124,7 @@ namespace BizHawk.Client.EmuHawk
 
 		// used to capture a reserved state immediately on branch creation
 		// while also not doing a double state
-		private class BufferedStatable : IStatable
+		private sealed class BufferedStatable : IStatable
 		{
 			private readonly byte[] _bufferedState;
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -1387,7 +1387,7 @@ namespace BizHawk.Client.EmuHawk
 					}
 				}
 
-				if (_extraAxisRows.Any())
+				if (_extraAxisRows.Count != 0)
 				{
 					foreach (int row in _extraAxisRows)
 					{

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -938,7 +938,7 @@ namespace BizHawk.Client.EmuHawk
 			// TODO: columns selected?
 			var selectedRowCount = TasView.SelectedRows.Count();
 			var temp = $"Selected: {selectedRowCount} {(selectedRowCount == 1 ? "frame" : "frames")}, States: {CurrentTasMovie.TasStateManager.Count}";
-			if (_tasClipboard.Any()) temp += $", Clipboard: {_tasClipboard.Count} {(_tasClipboard.Count == 1 ? "frame" : "frames")}";
+			if (_tasClipboard.Count != 0) temp += $", Clipboard: {_tasClipboard.Count} {(_tasClipboard.Count == 1 ? "frame" : "frames")}";
 			SplicerStatusLabel.Text = temp;
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -793,7 +793,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private static readonly IList<string> PossibleToolTypeNames = EmuHawk.ReflectionCache.Types.Select(t => t.AssemblyQualifiedName).ToList();
+		private static readonly List<string> PossibleToolTypeNames = EmuHawk.ReflectionCache.Types.Select(t => t.AssemblyQualifiedName).ToList();
 
 		public bool IsAvailable(Type tool)
 		{

--- a/src/BizHawk.Client.EmuHawk/tools/TraceLogger.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TraceLogger.cs
@@ -241,7 +241,7 @@ namespace BizHawk.Client.EmuHawk
 				{
 					TracerBox.Text = "Trace log - logging to file...";
 				}
-				else if (_instructions.Any())
+				else if (_instructions.Count != 0)
 				{
 					TracerBox.Text = $"Trace log - logging - {_instructions.Count} instructions";
 				}
@@ -252,7 +252,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 			else
 			{
-				if (_instructions.Any())
+				if (_instructions.Count != 0)
 				{
 					TracerBox.Text = $"Trace log - {_instructions.Count} instructions";
 				}

--- a/src/BizHawk.Client.EmuHawk/tools/TraceLogger.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TraceLogger.cs
@@ -125,7 +125,7 @@ namespace BizHawk.Client.EmuHawk
 			SetTracerBoxTitle();
 		}
 
-		private class CallbackSink : ITraceSink
+		private sealed class CallbackSink : ITraceSink
 		{
 			public void Put(TraceInfo info)
 			{

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
@@ -812,7 +812,7 @@ namespace BizHawk.Client.EmuHawk
 		private void RemoveAddresses()
 		{
 			var indices = SelectedIndices.ToList();
-			if (indices.Any())
+			if (indices.Count != 0)
 			{
 				SetRemovedMessage(indices.Count);
 				_searches.RemoveRange(indices);
@@ -865,7 +865,7 @@ namespace BizHawk.Client.EmuHawk
 		private void AddToRamWatch()
 		{
 			var watches = SelectedWatches.ToList();
-			if (watches.Any())
+			if (watches.Count != 0)
 			{
 				Tools.LoadRamWatch(true);
 				watches.ForEach(Tools.RamWatch.AddWatch);

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -327,7 +327,7 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 
-			if (_watches.Any())
+			if (_watches.Count != 0)
 			{
 				_watches.UpdateValues(Config.RamWatchDefinePrevious);
 				DisplayOnScreenWatches();
@@ -342,7 +342,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			DisplayManager.OSD.ClearRamWatches();
-			if (_watches.Any())
+			if (_watches.Count != 0)
 			{
 				_watches.UpdateValues(Config.RamWatchDefinePrevious);
 				DisplayOnScreenWatches();
@@ -898,7 +898,7 @@ namespace BizHawk.Client.EmuHawk
 		private void MoveUpMenuItem_Click(object sender, EventArgs e)
 		{
 			var indexes = SelectedIndices.ToList();
-			if (!indexes.Any() || indexes[0] == 0)
+			if (indexes.Count == 0 || indexes[0] == 0)
 			{
 				return;
 			}
@@ -954,7 +954,7 @@ namespace BizHawk.Client.EmuHawk
 		private void MoveTopMenuItem_Click(object sender, EventArgs e)
 		{
 			var indexes = SelectedIndices.ToList();
-			if (!indexes.Any())
+			if (indexes.Count == 0)
 			{
 				return;
 			}
@@ -1177,7 +1177,7 @@ namespace BizHawk.Client.EmuHawk
 		private void ViewInHexEditorContextMenuItem_Click(object sender, EventArgs e)
 		{
 			var selected = SelectedWatches.ToList();
-			if (selected.Any())
+			if (selected.Count != 0)
 			{
 				Tools.Load<HexEditor>();
 				ViewInHexEditor(
@@ -1193,7 +1193,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			var selected = SelectedWatches.ToList();
 
-			if (selected.Any())
+			if (selected.Count != 0)
 			{
 				var debugger = Tools.Load<GenericDebugger>();
 
@@ -1208,7 +1208,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			var selected = SelectedWatches.ToList();
 
-			if (selected.Any())
+			if (selected.Count != 0)
 			{
 				var debugger = Tools.Load<GenericDebugger>();
 

--- a/src/BizHawk.Common/Log.cs
+++ b/src/BizHawk.Common/Log.cs
@@ -31,10 +31,7 @@ namespace BizHawk.Common
 
 		public static void DisableDomain(string domain)
 		{
-			if (EnabledLogDomains.Contains(domain))
-			{
-				EnabledLogDomains.Remove(domain);
-			}
+			EnabledLogDomains.Remove(domain);
 		}
 
 		// -------------- Logging Action Configuration --------------

--- a/src/BizHawk.Common/OSTailoredCode.cs
+++ b/src/BizHawk.Common/OSTailoredCode.cs
@@ -143,7 +143,7 @@ namespace BizHawk.Common
 			string GetErrorMessage();
 		}
 
-		private class LinuxLLManager : ILinkedLibManager
+		private sealed class LinuxLLManager : ILinkedLibManager
 		{
 			public int FreeByPtr(IntPtr hModule) => LinuxDlfcnImports.dlclose(hModule);
 
@@ -176,7 +176,7 @@ namespace BizHawk.Common
 
 		// this is just a copy paste of LinuxLLManager using PosixDlfcnImports instead of LinuxDlfcnImports
 		// TODO: probably could do some OOP magic so there isn't just a copy paste here
-		private class PosixLLManager : ILinkedLibManager
+		private sealed class PosixLLManager : ILinkedLibManager
 		{
 			public int FreeByPtr(IntPtr hModule) => PosixDlfcnImports.dlclose(hModule);
 
@@ -207,7 +207,7 @@ namespace BizHawk.Common
 			}
 		}
 
-		private class WindowsLLManager : ILinkedLibManager
+		private sealed class WindowsLLManager : ILinkedLibManager
 		{
 			public int FreeByPtr(IntPtr hModule) => FreeLibrary(hModule) ? 0 : 1;
 

--- a/src/BizHawk.Common/SpanStream.cs
+++ b/src/BizHawk.Common/SpanStream.cs
@@ -19,7 +19,7 @@ namespace BizHawk.Common
 			return s as ISpanStream
 				?? new SpanStreamAdapter(s);
 		}
-		private class SpanStreamAdapter : ISpanStream
+		private sealed class SpanStreamAdapter : ISpanStream
 		{
 			public SpanStreamAdapter(Stream stream)
 			{

--- a/src/BizHawk.Common/UndoHistory.cs
+++ b/src/BizHawk.Common/UndoHistory.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Common
 		/// </remarks>
 		private int _curPos;
 
-		private readonly IList<T> _history = new List<T>();
+		private readonly List<T> _history = new List<T>();
 
 		public bool CanRedo => Enabled && _curPos < _history.Count;
 

--- a/src/BizHawk.Emulation.Common/Base Implementations/CallbackBasedTraceBuffer.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/CallbackBasedTraceBuffer.cs
@@ -65,7 +65,7 @@ namespace BizHawk.Emulation.Common
 		public string Header { get; }
 
 #nullable disable
-		private class TracingMemoryCallback : IMemoryCallback
+		private sealed class TracingMemoryCallback : IMemoryCallback
 		{
 			public TracingMemoryCallback(MemoryCallbackDelegate callback, string scope)
 			{

--- a/src/BizHawk.Emulation.Common/Base Implementations/ControllerDefinition.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/ControllerDefinition.cs
@@ -166,7 +166,7 @@ namespace BizHawk.Emulation.Common
 
 		public bool Any()
 		{
-			return BoolButtons.Any() || Axes.Any();
+			return BoolButtons.Any() || Axes.Count != 0;
 		}
 	}
 }

--- a/src/BizHawk.Emulation.Common/Base Implementations/LinkedMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/LinkedMemoryDomains.cs
@@ -34,7 +34,7 @@ namespace BizHawk.Emulation.Common
 			return mm;
 		}
 
-		private class WrappedMemoryDomain : MemoryDomain
+		private sealed class WrappedMemoryDomain : MemoryDomain
 		{
 			private readonly MemoryDomain _m;
 
@@ -54,7 +54,7 @@ namespace BizHawk.Emulation.Common
 			public override void PokeByte(long addr, byte val) => _m.PokeByte(addr, val);
 		}
 
-		private class LinkedSystemBus : MemoryDomain
+		private sealed class LinkedSystemBus : MemoryDomain
 		{
 			private readonly MemoryDomain[] _linkedSystemBuses;
 			private readonly LinkedDisassemblable _linkedDisassemblable;

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryCallbackSystem.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryCallbackSystem.cs
@@ -250,7 +250,7 @@ namespace BizHawk.Emulation.Common
 	/// <remarks>
 	/// Reentrancy from ItemAdded and ItemRemoved events is not allowed.
 	/// </remarks>
-	internal class MemoryCallbackCollection : IReadOnlyCollection<IMemoryCallback>
+	internal sealed class MemoryCallbackCollection : IReadOnlyCollection<IMemoryCallback>
 	{
 		private List<IMemoryCallback> _items = new();
 		private int _copyOnWriteRequired = 0;

--- a/src/BizHawk.Emulation.Common/ControllerDefinitionMerger.cs
+++ b/src/BizHawk.Emulation.Common/ControllerDefinitionMerger.cs
@@ -63,7 +63,7 @@ namespace BizHawk.Emulation.Common
 
 	public class ControlDefUnMerger
 	{
-		private class DummyController : IController
+		private sealed class DummyController : IController
 		{
 			private readonly IReadOnlyDictionary<string, string> _buttonAxisRemaps;
 

--- a/src/BizHawk.Emulation.Common/Database/Database.cs
+++ b/src/BizHawk.Emulation.Common/Database/Database.cs
@@ -26,7 +26,7 @@ namespace BizHawk.Emulation.Common
 
 		private static string _bundledRoot = null;
 
-		private static IList<string> _expected = null;
+		private static List<string> _expected = null;
 
 		private static string _userRoot = null;
 

--- a/src/BizHawk.Emulation.Common/Database/Database.cs
+++ b/src/BizHawk.Emulation.Common/Database/Database.cs
@@ -482,7 +482,9 @@ namespace BizHawk.Emulation.Common
 			game.Name = Path.GetFileNameWithoutExtension(fileName)?.Replace('_', ' ');
 
 			// If filename is all-caps, then attempt to proper-case the title.
+#pragma warning disable CA1862 // incorrect detection, see https://github.com/dotnet/roslyn-analyzers/issues/7074
 			if (!string.IsNullOrWhiteSpace(game.Name) && game.Name == game.Name.ToUpperInvariant())
+#pragma warning restore CA1862
 			{
 				game.Name = Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(game.Name.ToLowerInvariant());
 			}

--- a/src/BizHawk.Emulation.Common/filetype_detectors/SatellaviewFileTypeDetector.cs
+++ b/src/BizHawk.Emulation.Common/filetype_detectors/SatellaviewFileTypeDetector.cs
@@ -99,7 +99,7 @@ namespace BizHawk.Emulation.Common
 
 		private const int THRESHOLD = 3;
 
-		private static bool CheckHeaderHeuristics(bool checkHiROM, ReadOnlySpan<byte> rom, IList<string> warnings)
+		private static bool CheckHeaderHeuristics(bool checkHiROM, ReadOnlySpan<byte> rom, List<string> warnings)
 		{
 			SatellaviewHeader header = new(rom.Slice(start: checkHiROM ? 0xFFB0 : 0x7FB0, length: HEADER_LENGTH));
 			var corruption = 0;

--- a/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.ISettable.ComponentModel.cs
+++ b/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.ISettable.ComponentModel.cs
@@ -134,7 +134,7 @@ namespace BizHawk.Emulation.Cores.Arcades.MAME
 			((MAMESyncSettings)component).DriverSettings[Setting.LookupKey] = s;
 		}
 
-		private class MyTypeConverter : TypeConverter
+		private sealed class MyTypeConverter : TypeConverter
 		{
 			public MyTypeConverter(DriverSetting setting)
 				=> Setting = setting;

--- a/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.ISettable.cs
+++ b/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.ISettable.cs
@@ -101,7 +101,7 @@ namespace BizHawk.Emulation.Cores.Arcades.MAME
 						setting.Options.Add(opt[0], opt[1]);
 					}
 
-					if (options.Any())
+					if (options.Length != 0)
 					{
 						CurrentDriverSettings.Add(setting);
 					}

--- a/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.cs
+++ b/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.cs
@@ -263,7 +263,7 @@ namespace BizHawk.Emulation.Cores.Arcades.MAME
 			foreach (var rom in roms)
 			{
 				// only close non-chd files
-				if (rom.Extension.ToLowerInvariant() != ".chd")
+				if (!rom.Extension.Equals(".chd", StringComparison.OrdinalIgnoreCase))
 				{
 					_exe.RemoveReadonlyFile(MakeFileName(rom));
 				}

--- a/src/BizHawk.Emulation.Cores/CPUs/W65816/Disassembler.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/W65816/Disassembler.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Components.W65816
 {
-	internal class W65816_DisassemblerService : IDisassemblable
+	internal sealed class W65816_DisassemblerService : IDisassemblable
 	{
 		public string Cpu { get; set; }
 
@@ -27,7 +27,7 @@ namespace BizHawk.Emulation.Cores.Components.W65816
 	/// The DisPel software is unlicensed, and is thus assumed to be copyrighted without any transfer of rights.
 	/// This reproduction is made with the assumption that it cannot be infringing because every part of its structure is necessary for its function (in the US, scènes à faire).
 	/// </remarks>
-	internal class W65816
+	internal sealed class W65816
 	{
 		//unsigned char *mem, unsigned long pos, unsigned char *flag, char *inst, unsigned char tsrc
 		//TODO - what ha ppens at the end of memory? make sure peek wraps around?

--- a/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/Hardware/Datacorder/DatacorderDevice.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/Hardware/Datacorder/DatacorderDevice.cs
@@ -80,7 +80,7 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 		{
 			get
 			{
-				if (DataBlocks.Any())
+				if (DataBlocks.Count != 0)
 				{
 					return _currentDataBlockIndex;
 				}

--- a/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/Hardware/Disk/NECUPD765.Definitions.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/Hardware/Disk/NECUPD765.Definitions.cs
@@ -677,7 +677,7 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 		/// <summary>
 		/// Class that holds information about a specific command
 		/// </summary>
-		private class Command
+		private sealed class Command
 		{
 			//          /// <summary>
 			//          /// Mask to remove potential parameter bits (5,6, and or 7) in order to identify the command

--- a/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/SoundProviderMixer.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/SoundProviderMixer.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 	/// </summary>
 	internal sealed class SoundProviderMixer : ISoundProvider
 	{
-		private class Provider
+		private sealed class Provider
 		{
 			public ISoundProvider SoundProvider { get; set; }
 			public string ProviderDescription { get; set; }

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper000A.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper000A.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 	// to pull down EXROM. Also, accesses to LOROM while it is active
 	// discharge the capacitor.
 	// Thanks to VICE team for the info: http://vice-emu.sourceforge.net/vice_15.html
-	internal class Mapper000A : CartridgeDevice
+	internal sealed class Mapper000A : CartridgeDevice
 	{
 		// This constant differs depending on whose research you reference. TODO: Verify.
 		private const int RESET_CAPACITOR_CYCLES = 512;

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0011.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0011.cs
@@ -7,7 +7,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 	// to the System 3 mapper (000F) except that bank switching is
 	// done by reads to the DExx region instead of writes.
 	// This is why mapper 0011 inherits directly from 000F.
-	internal class Mapper0011 : Mapper000F
+	internal sealed class Mapper0011 : Mapper000F
 	{
 		public Mapper0011(IList<int> newAddresses, IList<int> newBanks, IList<int[]> newData)
 			: base(newAddresses, newBanks, newData)

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper002B.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper002B.cs
@@ -9,7 +9,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 	// 32 banks of 8KB.
 	// DFxx = status register, xxABBBBB. A=enable cart, B=bank
 	// Thanks to VICE team for the info: http://vice-emu.sourceforge.net/vice_15.html
-	internal class Mapper002B : CartridgeDevice
+	internal sealed class Mapper002B : CartridgeDevice
 	{
 		private readonly int[] _rom;
 

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Hardware/Disk/NECUPD765.Definitions.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Hardware/Disk/NECUPD765.Definitions.cs
@@ -677,7 +677,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
         /// <summary>
         /// Class that holds information about a specific command
         /// </summary>
-        private class Command
+        private sealed class Command
         {
 //          /// <summary>
 //          /// Mask to remove potential parameter bits (5,6, and or 7) in order to identify the command

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/Pentagon128K/Pentagon128.Screen.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/Pentagon128K/Pentagon128.Screen.cs
@@ -4,7 +4,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 	/// <summary>
 	/// 128K/+2 ULA
 	/// </summary>
-	internal class ScreenPentagon128 : ULA
+	internal sealed class ScreenPentagon128 : ULA
 	{
 		public ScreenPentagon128(SpectrumBase machine)
 			: base(machine)

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/ZXSpectrum128K/ZX128.Screen.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/ZXSpectrum128K/ZX128.Screen.cs
@@ -4,7 +4,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 	/// <summary>
 	/// 128K/+2 ULA
 	/// </summary>
-	internal class Screen128 : ULA
+	internal sealed class Screen128 : ULA
 	{
 		public Screen128(SpectrumBase machine)
 			: base(machine)

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/ZXSpectrum128KPlus2a/ZX128Plus2a.Memory.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/ZXSpectrum128KPlus2a/ZX128Plus2a.Memory.cs
@@ -616,7 +616,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
                 ROM 2: +3DOS
                 ROM 3: 48 BASIC
             */
-            Stream stream = new MemoryStream(RomData.RomBytes);
+            MemoryStream stream = new MemoryStream(RomData.RomBytes);
             stream.Read(ROM0, 0, 16384);
             stream.Read(ROM1, 0, 16384);
             stream.Read(ROM2, 0, 16384);

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/ZXSpectrum128KPlus2a/ZX128Plus2a.Screen.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/ZXSpectrum128KPlus2a/ZX128Plus2a.Screen.cs
@@ -4,7 +4,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 	/// <summary>
 	/// +2A/+3 ULA
 	/// </summary>
-	internal class Screen128Plus2a : ULA
+	internal sealed class Screen128Plus2a : ULA
 	{
 		public Screen128Plus2a(SpectrumBase machine)
 			: base(machine)

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/ZXSpectrum128KPlus3/ZX128Plus3.Memory.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/ZXSpectrum128KPlus3/ZX128Plus3.Memory.cs
@@ -617,7 +617,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
                 ROM 2: +3DOS
                 ROM 3: 48 BASIC
             */
-            Stream stream = new MemoryStream(RomData.RomBytes);
+            MemoryStream stream = new MemoryStream(RomData.RomBytes);
             stream.Read(ROM0, 0, 16384);
             stream.Read(ROM1, 0, 16384);
             stream.Read(ROM2, 0, 16384);

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/ZXSpectrum48K/ZX48.Screen.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Machine/ZXSpectrum48K/ZX48.Screen.cs
@@ -4,7 +4,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 	/// <summary>
 	/// 48K ULA
 	/// </summary>
-	internal class Screen48 : ULA
+	internal sealed class Screen48 : ULA
 	{
 		public Screen48(SpectrumBase machine)
 			: base(machine)

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Media/Tape/CSW/CswConverter.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Media/Tape/CSW/CswConverter.cs
@@ -57,7 +57,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 			int majorVer = data[8];
 			int minorVer = data[9];
 
-			if (ident.ToUpperInvariant() != "COMPRESSED SQUARE WAVE")
+			if (!ident.Equals("COMPRESSED SQUARE WAVE", StringComparison.OrdinalIgnoreCase))
 			{
 				// this is not a valid CSW format file
 				return false;
@@ -80,7 +80,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 			// (first 22 bytes of the file)
 			string ident = Encoding.ASCII.GetString(data, 0, 22);
 
-			if (ident.ToUpperInvariant() != "COMPRESSED SQUARE WAVE")
+			if (!ident.Equals("COMPRESSED SQUARE WAVE", StringComparison.OrdinalIgnoreCase))
 			{
 				// this is not a valid CSW format file
 				throw new Exception($"{nameof(CswConverter)}: This is not a valid CSW format file");

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Media/Tape/PZX/PzxConverter.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Media/Tape/PZX/PzxConverter.cs
@@ -67,7 +67,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 			int majorVer = data[8];
 			int minorVer = data[9];
 
-			if (ident.ToUpperInvariant() != "PZXT")
+			if (!ident.Equals("PZXT", StringComparison.OrdinalIgnoreCase))
 			{
 				// this is not a valid PZX format file
 				return false;
@@ -96,7 +96,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 			// check whether this is a valid pzx format file by looking at the identifier in the header block
 			string ident = Encoding.ASCII.GetString(data, 0, 4);
 
-			if (ident.ToUpperInvariant() != "PZXT")
+			if (!ident.Equals("PZXT", StringComparison.OrdinalIgnoreCase))
 			{
 				// this is not a valid TZX format file
 				throw new Exception($"{nameof(PzxConverter)}: This is not a valid PZX format file");

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Media/Tape/WAV/WavConverter.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Media/Tape/WAV/WavConverter.cs
@@ -50,7 +50,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 			// check whether this is a valid wav format file by looking at the identifier in the header
 			string ident = Encoding.ASCII.GetString(data, 8, 4);
 
-			if (ident.ToUpperInvariant() != "WAVE")
+			if (!ident.Equals("WAVE", StringComparison.OrdinalIgnoreCase))
 			{
 				// this is not a valid WAV format file
 				return false;
@@ -72,7 +72,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 			// check whether this is a valid pzx format file by looking at the identifier in the header block
 			string ident = Encoding.ASCII.GetString(data, 8, 4);
 
-			if (ident.ToUpperInvariant() != "WAVE")
+			if (!ident.Equals("WAVE", StringComparison.OrdinalIgnoreCase))
 			{
 				// this is not a valid TZX format file
 				throw new Exception($"{nameof(WavConverter)}: This is not a valid WAV format file");

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.RomHeuristics.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.RomHeuristics.cs
@@ -232,12 +232,12 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 			return "UNKNOWN";
 		}
 
-		private static bool IsProbablySC(IList<byte> rom)
+		private static bool IsProbablySC(byte[] rom)
 		{
 			// We assume a Superchip cart contains the same bytes for its entire
 			// RAM area; obviously this test will fail if it doesn't
 			// The RAM area will be the first 256 bytes of each 4K bank
-			var numBanks = rom.Count / 4096;
+			var numBanks = rom.Length / 4096;
 			for (var i = 0; i < numBanks; i++)
 			{
 				var first = rom[i * 4096];
@@ -273,12 +273,12 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 			});
 		}
 
-		private static bool IsProbably4A50(IList<byte> rom)
+		private static bool IsProbably4A50(byte[] rom)
 		{
 			// 4A50 carts store address $4A50 at the NMI vector, which
 			// in this scheme is always in the last page of ROM at
 			// $1FFA - $1FFB (at least this is true in rev 1 of the format)
-			if (rom[rom.Count - 6] == 0x50 && rom[rom.Count - 5] == 0x4A)
+			if (rom[rom.Length - 6] == 0x50 && rom[rom.Length - 5] == 0x4A)
 			{
 				return true;
 			}

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.IStatable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.IStatable.cs
@@ -72,7 +72,7 @@ namespace BizHawk.Emulation.Cores.Atari.Lynx
 		private readonly JsonSerializer _ser = new JsonSerializer { Formatting = Formatting.Indented };
 		private readonly byte[] _saveBuff;
 
-		private class TextStateData
+		private sealed class TextStateData
 		{
 			public int Frame;
 			public int LagCount;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/3DS/Encore.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/3DS/Encore.cs
@@ -122,7 +122,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 			_serviceProvider.Register<IVideoProvider>(_encoreVideoProvider);
 
 			var romPath = lp.Roms[0].RomPath;
-			if (lp.Roms[0].Extension.ToLowerInvariant() == ".cia")
+			if (lp.Roms[0].Extension.Equals(".cia", StringComparison.OrdinalIgnoreCase))
 			{
 				var message = new byte[1024];
 				var res = _core.Encore_InstallCIA(_context, romPath, message, message.Length);
@@ -145,7 +145,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 			for (var i = 1; i < lp.Roms.Count; i++)
 			{
 				// doesn't make sense if not a CIA
-				if (lp.Roms[i].Extension.ToLowerInvariant() != ".cia")
+				if (!lp.Roms[i].Extension.Equals(".cia", StringComparison.OrdinalIgnoreCase))
 				{
 					Dispose();
 					throw new("ROMs after the index 0 should be CIAs");

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesControllers.cs
@@ -81,7 +81,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 		ControllerDefinition Definition { get; }
 	}
 
-	internal class BsnesUnpluggedController : IBsnesController
+	internal sealed class BsnesUnpluggedController : IBsnesController
 	{
 		private static readonly ControllerDefinition _definition = new("(SNES Controller fragment)");
 
@@ -90,7 +90,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 		public short GetState(IController controller, int index, int id) => 0;
 	}
 
-	internal class BsnesController : IBsnesController
+	internal sealed class BsnesController : IBsnesController
 	{
 		private static readonly string[] Buttons =
 		{
@@ -128,7 +128,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 			return (short) (controller.IsPressed(Buttons[id]) ? 1 : 0);
 		}
 	}
-	internal class BsnesExtendedController : IBsnesController
+	internal sealed class BsnesExtendedController : IBsnesController
 	{
 		private static readonly string[] Buttons =
 		{
@@ -171,7 +171,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 		}
 	}
 
-	internal class BsnesMouseController : IBsnesController
+	internal sealed class BsnesMouseController : IBsnesController
 	{
 		private static readonly ControllerDefinition _definition = new ControllerDefinition("(SNES Controller fragment)")
 				{ BoolButtons = { "0Mouse Left", "0Mouse Right" } }
@@ -208,7 +208,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 		}
 	}
 
-	internal class BsnesMultitapController : IBsnesController
+	internal sealed class BsnesMultitapController : IBsnesController
 	{
 		private static readonly string[] Buttons =
 		{
@@ -253,7 +253,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 	/// <summary>
 	/// "Virtual" controller that behaves like a multitap controller, but with 16 instead of 12 buttons per controller.
 	/// </summary>
-	internal class BsnesPayloadController : IBsnesController
+	internal sealed class BsnesPayloadController : IBsnesController
 	{
 		private static readonly string[] Buttons =
 		{
@@ -299,7 +299,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 		}
 	}
 
-	internal class BsnesSuperScopeController : IBsnesController
+	internal sealed class BsnesSuperScopeController : IBsnesController
 	{
 		private static readonly ControllerDefinition _definition = new ControllerDefinition("(SNES Controller fragment)")
 			{ BoolButtons = { "0Trigger", "0Cursor", "0Turbo", "0Pause", "0Offscreen" } }
@@ -322,7 +322,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 		}
 	}
 
-	internal class BsnesJustifierController : IBsnesController
+	internal sealed class BsnesJustifierController : IBsnesController
 	{
 		public BsnesJustifierController(bool chained)
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/SNESGraphicsDecoder.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/SNESGraphicsDecoder.cs
@@ -592,7 +592,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 		}
 	}
 
-	internal class OAMInfo : ISNESGraphicsDecoder.OAMInfo
+	internal sealed class OAMInfo : ISNESGraphicsDecoder.OAMInfo
 	{
 		public ushort X { get; }
 		public byte Y { get; }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAMemoryCallbackSystem.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAMemoryCallbackSystem.cs
@@ -207,7 +207,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 			_core = IntPtr.Zero;
 		}
 
-		private class CallbackContainer
+		private sealed class CallbackContainer
 		{
 			public CallbackContainer(IMemoryCallback callBack)
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.cs
@@ -282,7 +282,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 			);
 		}
 
-		private class GPUMemoryAreas : IGPUMemoryAreas
+		private sealed class GPUMemoryAreas : IGPUMemoryAreas
 		{
 			public IntPtr Vram { get; }
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_Sachen_MMC1.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_Sachen_MMC1.cs
@@ -9,7 +9,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 	// this occurs when the Boot Rom is loading the nintendo logo into VRAM
 	// instead of tracking that in the main memory map where it will just slow things down for no reason
 	// we'll clear the 'locked' flag when the last byte of the logo is read
-	internal class MapperSachen1 : MapperBase
+	internal sealed class MapperSachen1 : MapperBase
 	{
 		public int ROM_bank;
 		public bool locked;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_Sachen_MMC2.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_Sachen_MMC2.cs
@@ -9,7 +9,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 	// this occurs when the Boot Rom is loading the nintendo logo into VRAM
 	// instead of tracking that in the main memory map where it will just slow things down for no reason
 	// we'll clear the 'locked' flag when the last byte of the logo is read
-	internal class MapperSachen2 : MapperBase
+	internal sealed class MapperSachen2 : MapperBase
 	{
 		public int ROM_bank;
 		public bool locked, locked_GBC, finished;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.IDebuggable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.IDebuggable.cs
@@ -35,7 +35,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 
 		public void SetCpuRegister(string register, int value)
 		{
-			if (register.Length == 9 && register.Substring(4, 5).ToUpperInvariant() == " BANK")
+			if (register.Length == 9 && register.Substring(4, 5).Equals(" BANK", StringComparison.OrdinalIgnoreCase))
 			{
 				var type = (LibGambatte.BankType)Enum.Parse(typeof(LibGambatte.BankType), register.Substring(0, 4).ToUpperInvariant());
 				LibGambatte.gambatte_setbank(GambatteState, type, value);

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.IStatable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.IStatable.cs
@@ -97,7 +97,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 		private readonly JsonSerializer _ser = new() { Formatting = Formatting.Indented };
 
 		// other data in the text state besides core
-		internal class TextStateData
+		internal sealed class TextStateData
 		{
 			public int Frame;
 			public int LagCount;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
@@ -641,7 +641,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 			};
 		}
 
-		private class GPUMemoryAreas : IGPUMemoryAreas
+		private sealed class GPUMemoryAreas : IGPUMemoryAreas
 		{
 			public IntPtr Vram { get; init; }
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/GambatteLink.IStatable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/GambatteLink.IStatable.cs
@@ -99,7 +99,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 
 		private readonly JsonSerializer ser = new JsonSerializer { Formatting = Formatting.Indented };
 
-		private class GBLSerialized
+		private sealed class GBLSerialized
 		{
 			public int NumCores;
 			public TextState<Gameboy.TextStateData>[] LinkedStates;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IMemoryDomains.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 	{
 		private readonly List<MemoryDomain> _memoryDomains = new List<MemoryDomain>();
 
-		private IMemoryDomains MemoryDomains;
+		private MemoryDomainList MemoryDomains;
 
 		private void MakeMemoryDomain(string name, mupen64plusApi.N64_MEMORY id, MemoryDomain.Endian endian, bool swizzled = false)
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64Audio.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64Audio.cs
@@ -3,7 +3,7 @@ using BizHawk.Emulation.Cores.Nintendo.N64.NativeApi;
 
 namespace BizHawk.Emulation.Cores.Nintendo.N64
 {
-	internal class N64Audio : IDisposable
+	internal sealed class N64Audio : IDisposable
 	{
 		/// <summary>
 		/// mupen64 DLL Api

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64VideoProvider.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64VideoProvider.cs
@@ -3,7 +3,7 @@ using BizHawk.Emulation.Cores.Nintendo.N64.NativeApi;
 
 namespace BizHawk.Emulation.Cores.Nintendo.N64
 {
-	internal class N64VideoProvider : IVideoProvider, IDisposable
+	internal sealed class N64VideoProvider : IVideoProvider, IDisposable
 	{
 		private int[] frameBuffer;
 		private mupen64plusVideoApi api;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/NativeApi/mupen64plusAudioApi.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/NativeApi/mupen64plusAudioApi.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 namespace BizHawk.Emulation.Cores.Nintendo.N64.NativeApi
 {
-	internal class mupen64plusAudioApi
+	internal sealed class mupen64plusAudioApi
 	{
 		/// <summary>
 		/// Handle to native audio plugin

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/NativeApi/mupen64plusInputApi.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/NativeApi/mupen64plusInputApi.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 namespace BizHawk.Emulation.Cores.Nintendo.N64.NativeApi
 {
-	internal class mupen64plusInputApi
+	internal sealed class mupen64plusInputApi
 	{
 		private IntPtr InpDll;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/NativeApi/mupen64plusVideoApi.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/NativeApi/mupen64plusVideoApi.cs
@@ -4,7 +4,7 @@ using BizHawk.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.N64.NativeApi
 {
-	internal class mupen64plusVideoApi
+	internal sealed class mupen64plusVideoApi
 	{
 		private IntPtr GfxDll;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/AVE-NINA.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/AVE-NINA.cs
@@ -88,7 +88,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 	// according to the latest on nesdev:
 	// mapper 079: [.... PCCC] @ 4100
 	// mapper 113: [MCPP PCCC] @ 4100  (no games for this are in bootgod)
-	internal class AVE_NINA_006 : NesBoardBase
+	internal sealed class AVE_NINA_006 : NesBoardBase
 	{
 		//configuration
 		private int prg_bank_mask_32k, chr_bank_mask_8k;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Camerica.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Camerica.cs
@@ -87,7 +87,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 	}
 
 	//AKA mapper 232
-	internal class Camerica_Mapper232 : NesBoardBase
+	internal sealed class Camerica_Mapper232 : NesBoardBase
 	{
 		//configuration
 		private int prg_bank_mask_16k;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/MMC3_family/Mapper044.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/MMC3_family/Mapper044.cs
@@ -3,9 +3,9 @@
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
 	//http://wiki.nesdev.com/w/index.php/INES_Mapper_044
-	internal class Mapper044 : MMC3Board_Base
+	internal sealed class Mapper044 : MMC3Board_Base
 	{
-		public sealed override bool Configure(EDetectionOrigin origin)
+		public override bool Configure(EDetectionOrigin origin)
 		{
 			//analyze board type
 			switch (Cart.BoardType)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Mapper116.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Mapper116.cs
@@ -8,7 +8,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 	internal sealed class Mapper116 : NesBoardBase
 	{
 		[NesBoardImplCancel]
-		private class MMC3_CustomBoard : MMC3Board_Base
+		private sealed class MMC3_CustomBoard : MMC3Board_Base
 		{
 			public override void WritePrg(int addr, byte value)
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Mapper186.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Mapper186.cs
@@ -2,7 +2,7 @@
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
-	internal class Mapper186 : NesBoardBase
+	internal sealed class Mapper186 : NesBoardBase
 	{
 		private byte[] _SRAM = new byte[3072];
 		private byte[] regs = new byte[4];

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Namcot175_340.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Namcot175_340.cs
@@ -4,7 +4,7 @@ using BizHawk.Common.NumberExtensions;
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
 	[NesBoardImplPriority]
-	internal class Namcot175_340 : NesBoardBase
+	internal sealed class Namcot175_340 : NesBoardBase
 	{
 		/*
 		 * Namcot 175 and 340.  Simpler versions of the 129/163.  Differences:

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Namcot1xx/Namcot1xx.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Namcot1xx/Namcot1xx.cs
@@ -8,7 +8,7 @@
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
 	// also, Namcot109, Namcot118, Namcot119 chips are this exact same thing
-	internal class Namcot108Chip
+	internal sealed class Namcot108Chip
 	{
 		private int reg_addr;
 		private byte[] regs = new byte[8];
@@ -21,7 +21,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			Sync();
 		}
 
-		public virtual void SyncState(Serializer ser)
+		public void SyncState(Serializer ser)
 		{
 			ser.Sync(nameof(reg_addr), ref reg_addr);
 			ser.Sync(nameof(regs), ref regs, false);
@@ -30,7 +30,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			Sync();
 		}
 
-		public virtual void WritePRG(int addr, byte value)
+		public void WritePRG(int addr, byte value)
 		{
 			//($8001-$9FFF, odd)
 			switch (addr & 0x6001)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/SxROM.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/SxROM.cs
@@ -90,7 +90,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		private readonly int[] chr_banks_4k = new int[2];
 		private readonly int[] prg_banks_16k = new int[2];
 
-		public class MMC1_SerialController
+		public sealed class MMC1_SerialController
 		{
 			//state
 			private int shift_count, shift_val;
@@ -580,7 +580,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		}
 	}
 
-	internal class SXROM : SuROM
+	internal sealed class SXROM : SuROM
 	{
 		//SXROM's PRG behaves similar to SuROM (and so inherits from it)
 		//it also has some WRAM select bits like SoROM

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Taito_TC0190FMC.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Taito_TC0190FMC.cs
@@ -20,7 +20,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		private int prg_bank_mask, chr_bank_mask;
 		private bool pal16;
 
-		private class MMC3Variant : MMC3
+		private sealed class MMC3Variant : MMC3
 		{
 			public MMC3Variant(NesBoardBase board)
 			: base(board,0)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF-DREAMTECH01.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF-DREAMTECH01.cs
@@ -2,7 +2,7 @@
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
-	internal class UNIF_DREAMTECH01 : NesBoardBase
+	internal sealed class UNIF_DREAMTECH01 : NesBoardBase
 	{
 		// Korean Igo (Unl) [U][!]
 		private int reg;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_BMC-64in1-NR.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_BMC-64in1-NR.cs
@@ -3,7 +3,7 @@
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
 	// Adapted from FCEUX src
-	internal class UNIF_BMC_64in1_NR : NesBoardBase
+	internal sealed class UNIF_BMC_64in1_NR : NesBoardBase
 	{
 		private byte[] regs = new byte[4];
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_BMC-8157.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_BMC-8157.cs
@@ -3,7 +3,7 @@
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
 	// 4-in-1 1993 (CK-001) [U][!].unf
-	internal class UNIF_BMC_8157 : NesBoardBase
+	internal sealed class UNIF_BMC_8157 : NesBoardBase
 	{
 		[MapperProp]
 		public bool _4in1Mode;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_BMC-A65AS.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_BMC-A65AS.cs
@@ -3,7 +3,7 @@ using BizHawk.Common.NumberExtensions;
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
-	internal class UNIF_BMC_A65AS : NesBoardBase
+	internal sealed class UNIF_BMC_A65AS : NesBoardBase
 	{
 		private int _prgReg;
 		private bool _isPrg32kMode;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_BMC-T-262.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_BMC-T-262.cs
@@ -2,7 +2,7 @@
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
-	internal class UNIF_BMC_T_262 : NesBoardBase
+	internal sealed class UNIF_BMC_T_262 : NesBoardBase
 	{
 		private bool _mode;
 		private bool _locked;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_UNL-SHERO.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_UNL-SHERO.cs
@@ -2,7 +2,7 @@
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
-	internal class UNIF_UNL_SHERO : MMC3Board_Base
+	internal sealed class UNIF_UNL_SHERO : MMC3Board_Base
 	{
 		[MapperProp]
 		public bool RegionAsia = false;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_UNL-TF1201.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_UNL-TF1201.cs
@@ -3,7 +3,7 @@ using BizHawk.Common.NumberExtensions;
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
-	internal class UNIF_UNL_TF1201 : NesBoardBase
+	internal sealed class UNIF_UNL_TF1201 : NesBoardBase
 	{
 		private byte prg0;
 		private byte prg1;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_UNL_DripGame.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/UNIF/UNIF_UNL_DripGame.cs
@@ -253,7 +253,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				base.WriteWram(addr, value);
 		}
 
-		private class SoundChannel
+		private sealed class SoundChannel
 		{
 			public SoundChannel(Action<int> enqueuer)
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.cs
@@ -299,7 +299,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 		private void LoadWriteLine(object arg) { LoadWriteLine("{0}", arg); }
 
-		private class MyWriter : StringWriter
+		private sealed class MyWriter : StringWriter
 		{
 			public MyWriter(TextWriter _loadReport)
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NESControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NESControllers.cs
@@ -615,8 +615,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 	public class FamicomDeck : IControllerDeck
 	{
 		// two NES controllers are maintained internally
-		private readonly INesPort _player1 = new ControllerNES(false);
-		private readonly INesPort _player2 = new ControllerNES(true);
+		private readonly ControllerNES _player1 = new ControllerNES(false);
+		private readonly ControllerNES _player2 = new ControllerNES(true);
 		private readonly IFamicomExpansion _player3;
 
 		private readonly ControlDefUnMerger _player1U;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.cs
@@ -221,7 +221,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 
 		public bool IsSGB { get; }
 
-		private class SGBBoardInfo : IBoardInfo
+		private sealed class SGBBoardInfo : IBoardInfo
 		{
 			public string BoardName => "SGB";
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.cs
@@ -279,7 +279,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 			// every rom requests msu1.rom... why? who knows.
 			// also handle msu-1 pcm files here
 			bool isMsu1Rom = hint == "msu1.rom";
-			bool isMsu1Pcm = Path.GetExtension(hint).ToLowerInvariant() == ".pcm";
+			bool isMsu1Pcm = Path.GetExtension(hint).Equals(".pcm", StringComparison.OrdinalIgnoreCase);
 			if (isMsu1Rom || isMsu1Pcm)
 			{
 				// well, check if we have an msu-1 xml

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/ScanlineHookManager.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/ScanlineHookManager.cs
@@ -39,7 +39,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 			}
 		}
 
-		private class RegistrationRecord
+		private sealed class RegistrationRecord
 		{
 			public object Tag { get; set; }
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES9X/Snes9xControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES9X/Snes9xControllers.cs
@@ -81,7 +81,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES9X
 			void ApplyState(IController controller, short[] input, int offset);
 		}
 
-		private class Joypad : IControlDevice
+		private sealed class Joypad : IControlDevice
 		{
 			private static readonly string[] Buttons =
 			{
@@ -127,7 +127,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES9X
 			}
 		}
 
-		private class Mouse : Analog
+		private sealed class Mouse : Analog
 		{
 			private static readonly ControllerDefinition _definition
 				= new ControllerDefinition("(SNES Controller fragment)") { BoolButtons = { "0Mouse Left", "0Mouse Right" } }
@@ -136,7 +136,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES9X
 			public override ControllerDefinition Definition => _definition;
 		}
 
-		private class SuperScope : Analog
+		private sealed class SuperScope : Analog
 		{
 			private static readonly ControllerDefinition _definition
 				= new ControllerDefinition("(SNES Controller fragment)") { BoolButtons = { "0Trigger", "0Cursor", "0Turbo", "0Pause", "0Offscreen" } }
@@ -145,7 +145,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES9X
 			public override ControllerDefinition Definition => _definition;
 		}
 
-		private class Justifier : Analog
+		private sealed class Justifier : Analog
 		{
 			private static readonly ControllerDefinition _definition
 				= new ControllerDefinition("(SNES Controller fragment)") { BoolButtons = { "0Trigger", "0Start", "0Offscreen" } }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SameBoy/SameBoy.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SameBoy/SameBoy.cs
@@ -270,7 +270,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Sameboy
 			};
 		}
 
-		private class GPUMemoryAreas : IGPUMemoryAreas
+		private sealed class GPUMemoryAreas : IGPUMemoryAreas
 		{
 			public IntPtr Vram { get; init; }
 

--- a/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.ArcadeCard.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.ArcadeCard.cs
@@ -11,7 +11,7 @@ namespace BizHawk.Emulation.Cores.PCEngine
 
 		private readonly ArcadeCardPage[] ArcadePage = new ArcadeCardPage[4];
 
-		private class ArcadeCardPage
+		private sealed class ArcadeCardPage
 		{
 			public byte Control;
 			public int Base;

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/EEPROM.93c46.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/EEPROM.93c46.cs
@@ -2,7 +2,7 @@ using BizHawk.Common;
 
 namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 {
-	internal class EEPROM93c46
+	internal sealed class EEPROM93c46
 	{
 		private enum EEPROMWriteMode
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.ISettable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.ISettable.cs
@@ -31,7 +31,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 			return ret ? PutSettingsDirtyBits.RebootCore : PutSettingsDirtyBits.None;
 		}
 
-		private class UintToHexConverter : TypeConverter
+		private sealed class UintToHexConverter : TypeConverter
 		{
 			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 				=> sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
@@ -66,7 +66,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 			}
 		}
 
-		private class UshortToHexConverter : TypeConverter
+		private sealed class UshortToHexConverter : TypeConverter
 		{
 			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 				=> sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);

--- a/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
@@ -364,7 +364,7 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 		/// <summary>
 		/// Wraps the ShockDiscRef returned from the DLL and acts as a bridge between it and a DiscSystem disc
 		/// </summary>
-		private class DiscInterface : IDisposable
+		private sealed class DiscInterface : IDisposable
 		{
 			public DiscInterface(Disc disc, Action<DiscInterface> cbActivity)
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.IStatable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.IStatable.cs
@@ -15,7 +15,7 @@ namespace BizHawk.Emulation.Cores.WonderSwan
 		private readonly JsonSerializer ser = new() { Formatting = Formatting.Indented };
 
 		[StructLayout(LayoutKind.Sequential)]
-		private class TextStateData
+		private sealed class TextStateData
 		{
 			public bool IsLagFrame;
 			public int LagCount;

--- a/src/BizHawk.Emulation.Cores/CoreInventory.cs
+++ b/src/BizHawk.Emulation.Cores/CoreInventory.cs
@@ -22,15 +22,6 @@ namespace BizHawk.Emulation.Cores
 
 		public class Core
 		{
-			private class RomGameFake : IRomAsset
-			{
-				public byte[] RomData { get; set; }
-				public byte[] FileData { get; set; }
-				public string Extension { get; set; }
-				public string RomPath { get; set; }
-				public GameInfo Game { get; set; }
-			}
-
 			// map parameter names to locations in the constructor
 			private readonly Dictionary<string, int> _paramMap = new Dictionary<string, int>();
 			// If true, this is a new style constructor that takes a CoreLoadParameters object

--- a/src/BizHawk.Emulation.Cores/FileID.cs
+++ b/src/BizHawk.Emulation.Cores/FileID.cs
@@ -126,7 +126,7 @@ namespace BizHawk.Emulation.Cores
 			public DiscSystem.Disc Disc;
 		}
 
-		private class IdentifyJob
+		private sealed class IdentifyJob
 		{
 			public Stream Stream;
 			public string Extension;
@@ -239,7 +239,7 @@ namespace BizHawk.Emulation.Cores
 			}
 		}
 
-		private class SimpleMagicRecord
+		private sealed class SimpleMagicRecord
 		{
 			public int Offset;
 			public string Key;
@@ -296,7 +296,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private class ExtensionInfo
+		private sealed class ExtensionInfo
 		{
 			public ExtensionInfo(FileIDType defaultForExtension, FormatTester tester)
 			{

--- a/src/BizHawk.Emulation.Cores/Libretro/Libretro.cs
+++ b/src/BizHawk.Emulation.Cores/Libretro/Libretro.cs
@@ -28,7 +28,7 @@ namespace BizHawk.Emulation.Cores.Libretro
 		private readonly LibretroApi api;
 		private readonly IntPtr cbHandler;
 
-		private class BridgeGuard(IntPtr parentHandler) : IMonitor
+		private sealed class BridgeGuard(IntPtr parentHandler) : IMonitor
 		{
 			private static readonly object _sync = new();
 			private static IntPtr _activeHandler;
@@ -129,7 +129,7 @@ namespace BizHawk.Emulation.Cores.Libretro
 			}
 		}
 
-		private class RetroData(object o, long len = 0) : IDisposable
+		private sealed class RetroData(object o, long len = 0) : IDisposable
 		{
 			private GCHandle _handle = GCHandle.Alloc(o, GCHandleType.Pinned);
 

--- a/src/BizHawk.Emulation.Cores/Sound/HuC6280PSG.cs
+++ b/src/BizHawk.Emulation.Cores/Sound/HuC6280PSG.cs
@@ -275,7 +275,7 @@ namespace BizHawk.Emulation.Cores.Components
 			ser.EndSection();
 		}
 
-		private class QueuedCommand
+		private sealed class QueuedCommand
 		{
 			public byte Register;
 			public byte Value;

--- a/src/BizHawk.Emulation.Cores/Sound/MMC5Audio.cs
+++ b/src/BizHawk.Emulation.Cores/Sound/MMC5Audio.cs
@@ -5,7 +5,7 @@ namespace BizHawk.Emulation.Cores.Components
 {
 	public class MMC5Audio
 	{
-		private class Pulse
+		private sealed class Pulse
 		{
 			// regs
 			private int V;

--- a/src/BizHawk.Emulation.Cores/Sound/Sunsoft5BAudio.cs
+++ b/src/BizHawk.Emulation.Cores/Sound/Sunsoft5BAudio.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Emulation.Cores.Components
 	/// </summary>
 	public class Sunsoft5BAudio
 	{
-		private class Pulse
+		private sealed class Pulse
 		{
 			private readonly Action<int> SendDiff;
 			// regs

--- a/src/BizHawk.Emulation.Cores/Sound/SyncSoundMixer.cs
+++ b/src/BizHawk.Emulation.Cores/Sound/SyncSoundMixer.cs
@@ -226,7 +226,7 @@ namespace BizHawk.Emulation.Cores.Components
 		/// <summary>
 		/// Instantiated for every ISoundProvider source that is added to the mixer
 		/// </summary>
-		private class ChildProvider
+		private sealed class ChildProvider
 		{
 			/// <summary>
 			/// The Child ISoundProvider

--- a/src/BizHawk.Emulation.Cores/Sound/VRC6Alt.cs
+++ b/src/BizHawk.Emulation.Cores/Sound/VRC6Alt.cs
@@ -87,7 +87,7 @@ namespace BizHawk.Emulation.Cores.Components
 			}
 		}
 
-		private class Saw
+		private sealed class Saw
 		{
 			private readonly Action<int> SendDiff;
 			public Saw(Action<int> SendDiff) { this.SendDiff = SendDiff; }
@@ -186,7 +186,7 @@ namespace BizHawk.Emulation.Cores.Components
 			}
 		}
 
-		private class Pulse
+		private sealed class Pulse
 		{
 			private readonly Action<int> SendDiff;
 			public Pulse(Action<int> SendDiff) { this.SendDiff = SendDiff; }

--- a/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.Controller.ButtonNameOverrides.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.Controller.ButtonNameOverrides.cs
@@ -36,9 +36,9 @@ namespace BizHawk.Emulation.Cores.Waterbox
 		private string OverrideButtonName(string original)
 		{
 			// VB hack
-			if (ButtonNameOverrides.ContainsKey(original))
+			if (ButtonNameOverrides.TryGetValue(original, out string vbOverrideName))
 			{
-				original = ButtonNameOverrides[original];
+				original = vbOverrideName;
 			}
 
 			original = Regex.Replace(original, @"\s*(↑|↓|←|→)\s*", "");
@@ -48,9 +48,9 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				original = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(original.ToLowerInvariant());
 			}
 
-			if (ButtonNameOverrides.ContainsKey(original))
+			if (ButtonNameOverrides.TryGetValue(original, out string overrideName))
 			{
-				original = ButtonNameOverrides[original];
+				original = overrideName;
 			}
 
 			// TODO: Add dictionaries or whatever here as needed

--- a/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.Settings.ComponentModel.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.Settings.ComponentModel.cs
@@ -182,7 +182,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 		}
 		public override TypeConverter Converter => new MyTypeConverter { Setting = Setting };
 
-		private class MyTypeConverter : TypeConverter
+		private sealed class MyTypeConverter : TypeConverter
 		{
 			public SettingT Setting { get; set; }
 			// Mednafen includes extra fallback aliases of enums that are nameless, just one way value aliases.
@@ -354,7 +354,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 
 		public override TypeConverter Converter => new MyTypeConverter { Port = Port };
 
-		private class MyTypeConverter : TypeConverter
+		private sealed class MyTypeConverter : TypeConverter
 		{
 			public Port Port { get; set; }
 

--- a/src/BizHawk.Emulation.Cores/Waterbox/WaterboxHost.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/WaterboxHost.cs
@@ -82,7 +82,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 #endif
 		}
 
-		private class ReadWriteWrapper : IDisposable
+		private sealed class ReadWriteWrapper : IDisposable
 		{
 			private GCHandle _handle;
 			private readonly ISpanStream _backingSpanStream;
@@ -313,7 +313,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			return new WaterboxPagesDomain(this);
 		}
 
-		private class WaterboxPagesDomain : MemoryDomain
+		private sealed class WaterboxPagesDomain : MemoryDomain
 		{
 			private readonly WaterboxHost _host;
 

--- a/src/BizHawk.Emulation.Cores/Waterbox/WaterboxMemoryDomain.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/WaterboxMemoryDomain.cs
@@ -132,7 +132,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 		[BizImport(CallingConvention.Cdecl)]
 		public abstract void Access(IntPtr buffer, long address, long count, bool write);
 
-		private class StubResolver : IImportResolver
+		private sealed class StubResolver : IImportResolver
 		{
 			private readonly IntPtr _p;
 			public StubResolver(IntPtr p)

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/A26Schema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/A26Schema.cs
@@ -197,7 +197,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/A78Schema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/A78Schema.cs
@@ -105,7 +105,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/ChannelFSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/ChannelFSchema.cs
@@ -6,7 +6,7 @@ using System.Drawing;
 namespace BizHawk.Emulation.Cores
 {
 	[Schema(VSystemID.Raw.ChannelF)]
-	internal class ChannelFSchema : IVirtualPadSchema
+	internal sealed class ChannelFSchema : IVirtualPadSchema
 	{
 		public IEnumerable<PadSchema> GetPadSchemas(IEmulator core, Action<string> showMessageBox)
 		{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/ColecoSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/ColecoSchema.cs
@@ -82,7 +82,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static IEnumerable<ButtonSchema> StandardButtons(int controller) => new ButtonSchema[]
+		private static ButtonSchema[] StandardButtons(int controller) => new ButtonSchema[]
 		{
 			ButtonSchema.Up(50, 11, controller),
 			ButtonSchema.Down(50, 32, controller),

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/GBASchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/GBASchema.cs
@@ -69,7 +69,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/GBSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/GBSchema.cs
@@ -48,7 +48,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/GenSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/GenSchema.cs
@@ -90,7 +90,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static IEnumerable<ButtonSchema> ThreeButtons(int controller)
+		private static ButtonSchema[] ThreeButtons(int controller)
 		{
 			return new[]
 			{
@@ -141,7 +141,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/IntvSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/IntvSchema.cs
@@ -85,7 +85,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static IEnumerable<ButtonSchema> StandardButtons(int controller)
+		private static ButtonSchema[] StandardButtons(int controller)
 		{
 			return new[]
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/JaguarSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/JaguarSchema.cs
@@ -49,7 +49,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/N3DSSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/N3DSSchema.cs
@@ -62,7 +62,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema Console()
+		private static ConsoleSchema Console()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/NdsSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/NdsSchema.cs
@@ -43,7 +43,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema Console()
+		private static ConsoleSchema Console()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/NesSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/NesSchema.cs
@@ -160,7 +160,7 @@ namespace BizHawk.Emulation.Cores
 			}
 		}
 
-		private static PadSchema NesConsoleButtons()
+		private static ConsoleSchema NesConsoleButtons()
 		{
 			return new ConsoleSchema
 			{
@@ -173,7 +173,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema FdsConsoleButtons(int diskSize)
+		private static ConsoleSchema FdsConsoleButtons(int diskSize)
 		{
 			var buttons = new List<ButtonSchema>
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/NgpSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/NgpSchema.cs
@@ -32,7 +32,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/O2Schema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/O2Schema.cs
@@ -96,7 +96,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/PSXSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/PSXSchema.cs
@@ -414,7 +414,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons(Octoshock octo)
+		private static ConsoleSchema ConsoleButtons(Octoshock octo)
 		{
 			return new ConsoleSchema
 			{
@@ -427,7 +427,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema NymaConsoleButtons(AxisSpec diskRange)
+		private static ConsoleSchema NymaConsoleButtons(AxisSpec diskRange)
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/PceSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/PceSchema.cs
@@ -159,7 +159,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/PcfxSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/PcfxSchema.cs
@@ -93,7 +93,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/SaturnSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/SaturnSchema.cs
@@ -275,7 +275,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons(AxisSpec diskRange)
+		private static ConsoleSchema ConsoleButtons(AxisSpec diskRange)
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/SmsSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/SmsSchema.cs
@@ -191,7 +191,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/SnesSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/SnesSchema.cs
@@ -328,7 +328,7 @@ namespace BizHawk.Emulation.Cores
 			}
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/TIC80Schema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/TIC80Schema.cs
@@ -76,7 +76,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/VECSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/VECSchema.cs
@@ -83,7 +83,7 @@ namespace BizHawk.Emulation.Cores
 			return new ButtonSchema(x, y, controller, $"Button {button}", button.ToString());
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/VirtualBoySchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/VirtualBoySchema.cs
@@ -39,7 +39,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/WonderSwanSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/WonderSwanSchema.cs
@@ -61,7 +61,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private static PadSchema ConsoleButtons()
+		private static ConsoleSchema ConsoleButtons()
 		{
 			return new ConsoleSchema
 			{

--- a/src/BizHawk.Emulation.Cores/vpads_schemata/ZXSpectrumSchema.cs
+++ b/src/BizHawk.Emulation.Cores/vpads_schemata/ZXSpectrumSchema.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 namespace BizHawk.Emulation.Cores
 {
 	[Schema(VSystemID.Raw.ZXSpectrum)]
-	internal class ZxSpectrumSchema : IVirtualPadSchema
+	public class ZxSpectrumSchema : IVirtualPadSchema
 	{
 		public IEnumerable<PadSchema> GetPadSchemas(IEmulator core, Action<string> showMessageBox)
 		{
@@ -34,7 +34,7 @@ namespace BizHawk.Emulation.Cores
 			};
 		}
 
-		private class ButtonLayout
+		private sealed class ButtonLayout
 		{
 			public string Name { get; set; }
 			public string DisName { get; set; }

--- a/src/BizHawk.Emulation.DiscSystem/API_MednaDisc.cs
+++ b/src/BizHawk.Emulation.DiscSystem/API_MednaDisc.cs
@@ -35,8 +35,8 @@ namespace BizHawk.Emulation.DiscSystem
 		public MednadiscTOC TOC;
 		public MednadiscTOCTrack[] TOCTracks;
 
-		[ThreadStatic] private static byte[] buf2442 = new byte[2448];
-		[ThreadStatic] private static byte[] buf96 = new byte[96];
+		private static byte[] buf2442 = new byte[2448];
+		private static byte[] buf96 = new byte[96];
 
 
 		public void Read_2442(int LBA, byte[] buffer, int offset)

--- a/src/BizHawk.Emulation.DiscSystem/DiscDecoding.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscDecoding.cs
@@ -5,10 +5,10 @@ using BizHawk.Common.PathExtensions;
 
 namespace BizHawk.Emulation.DiscSystem
 {
-	internal class AudioDecoder
+	internal sealed class AudioDecoder
 	{
 		[Serializable]
-		public class AudioDecoder_Exception : Exception
+		public sealed class AudioDecoder_Exception : Exception
 		{
 			public AudioDecoder_Exception(string message)
 				: base(message)

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/Blob_CHD.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/Blob_CHD.cs
@@ -2,7 +2,7 @@ using System.IO;
 
 namespace BizHawk.Emulation.DiscSystem
 {
-	internal class Blob_CHD : IBlob
+	internal sealed class Blob_CHD : IBlob
 	{
 		private IntPtr _chdFile;
 

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/Blob_ECM.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/Blob_ECM.cs
@@ -12,7 +12,7 @@ using BizHawk.Common.NumberExtensions;
 
 namespace BizHawk.Emulation.DiscSystem
 {
-	internal class Blob_ECM : IBlob
+	internal sealed class Blob_ECM : IBlob
 	{
 		private FileStream stream;
 

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/Blob_RawFile.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/Blob_RawFile.cs
@@ -2,7 +2,7 @@
 
 namespace BizHawk.Emulation.DiscSystem
 {
-	internal class Blob_RawFile : IBlob
+	internal sealed class Blob_RawFile : IBlob
 	{
 		public string PhysicalPath
 		{

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/Blob_WaveFile.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/Blob_WaveFile.cs
@@ -7,10 +7,10 @@ namespace BizHawk.Emulation.DiscSystem
 	/// TODO - double-check that riffmaster is not filling memory at load-time but reading through to the disk
 	/// TODO - clarify stream disposing semantics
 	/// </summary>
-	internal class Blob_WaveFile : IBlob
+	internal sealed class Blob_WaveFile : IBlob
 	{
 		[Serializable]
-		public class Blob_WaveFile_Exception : Exception
+		public sealed class Blob_WaveFile_Exception : Exception
 		{
 			public Blob_WaveFile_Exception(string message)
 				: base(message)

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/RiffMaster.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/RiffMaster.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Emulation.DiscSystem
 	/// Please be sure to test round-tripping when you make any changes. This architecture is a bit tricky to use, but it works if you're careful.
 	/// TODO - clarify stream disposing semantics
 	/// </summary>
-	internal class RiffMaster : IDisposable
+	internal sealed class RiffMaster : IDisposable
 	{
 		public RiffMaster() { }
 
@@ -40,7 +40,7 @@ namespace BizHawk.Emulation.DiscSystem
 		private static string ReadTag(BinaryReader br) =>
 			string.Concat(br.ReadChar(), br.ReadChar(), br.ReadChar(), br.ReadChar());
 
-		protected static void WriteTag(BinaryWriter bw, string tag)
+		private static void WriteTag(BinaryWriter bw, string tag)
 		{
 			for (var i = 0; i < 4; i++)
 				bw.Write(tag[i]);
@@ -115,7 +115,7 @@ namespace BizHawk.Emulation.DiscSystem
 			}
 		}
 
-		public class RiffSubchunk_fmt : RiffSubchunk
+		public sealed class RiffSubchunk_fmt : RiffSubchunk
 		{
 			public enum FORMAT_TAG : ushort
 			{
@@ -231,7 +231,7 @@ namespace BizHawk.Emulation.DiscSystem
 			}
 		}
 
-		public class RiffContainer_INFO : RiffContainer
+		public sealed class RiffContainer_INFO : RiffContainer
 		{
 			public readonly IDictionary<string, string> dictionary = new Dictionary<string, string>();
 			public RiffContainer_INFO() { type = "INFO"; }

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CCD_format.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CCD_format.cs
@@ -204,7 +204,7 @@ namespace BizHawk.Emulation.DiscSystem
 					var parts = line.Split('=');
 					if (parts.Length != 2)
 						throw new CCDParseException("Malformed or unexpected CCD format: parsing item into two parts");
-					if (parts[0].ToUpperInvariant() == "FLAGS")
+					if (parts[0].Equals("FLAGS", StringComparison.OrdinalIgnoreCase))
 					{
 						// flags are a space-separated collection of symbolic constants:
 						// https://www.gnu.org/software/ccd2cue/manual/html_node/FLAGS-_0028Compact-Disc-fields_0029.html#FLAGS-_0028Compact-Disc-fields_0029

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CCD_format.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CCD_format.cs
@@ -159,7 +159,7 @@ namespace BizHawk.Emulation.DiscSystem
 			public CCDParseException(string message) : base(message) { }
 		}
 
-		private class CCDSection : Dictionary<string, int>
+		private sealed class CCDSection : Dictionary<string, int>
 		{
 			public string Name;
 
@@ -448,7 +448,7 @@ namespace BizHawk.Emulation.DiscSystem
 			}
 		}
 
-		private class SS_CCD : ISectorSynthJob2448
+		private sealed class SS_CCD : ISectorSynthJob2448
 		{
 			public void Synth(SectorSynthJob job)
 			{

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CHD_format.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CHD_format.cs
@@ -516,7 +516,7 @@ namespace BizHawk.Emulation.DiscSystem
 		/// <summary>
 		/// CHD is dumb and byteswaps audio samples for some reason
 		/// </summary>
-		private class SS_CHD_Audio : SS_Base
+		private sealed class SS_CHD_Audio : SS_Base
 		{
 			public override void Synth(SectorSynthJob job)
 			{
@@ -532,7 +532,7 @@ namespace BizHawk.Emulation.DiscSystem
 			}
 		}
 
-		private class SS_CHD_Sub : ISectorSynthJob2448
+		private sealed class SS_CHD_Sub : ISectorSynthJob2448
 		{
 			private readonly SS_Base _baseSynth;
 			private readonly uint _subOffset;
@@ -853,7 +853,7 @@ namespace BizHawk.Emulation.DiscSystem
 			return crc16;
 		}
 
-		private class ChdHunkMapEntry
+		private sealed class ChdHunkMapEntry
 		{
 			public uint CompressedLength;
 			public long HunkOffset;

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_Compile.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_Compile.cs
@@ -10,7 +10,7 @@ using BizHawk.Common.CollectionExtensions;
 
 namespace BizHawk.Emulation.DiscSystem.CUE
 {
-	internal class CompiledCDText
+	internal sealed class CompiledCDText
 	{
 		public string Songwriter;
 		public string Performer;
@@ -68,7 +68,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 		DecodeAudio,
 	}
 
-	internal class CompiledCueFile
+	internal sealed class CompiledCueFile
 	{
 		public string FullPath;
 		public CompiledCueFileType Type;
@@ -78,13 +78,13 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 		}
 	}
 
-	internal class CompiledSessionInfo
+	internal sealed class CompiledSessionInfo
 	{
 		public int FirstRecordedTrackNumber, LastRecordedTrackNumber;
 		public SessionFormat SessionFormat;
 	}
 
-	internal class CompiledCueTrack
+	internal sealed class CompiledCueTrack
 	{
 		public int BlobIndex;
 		public int Number;
@@ -117,7 +117,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 		}
 	}
 
-	internal class CompileCueJob : DiscJob
+	internal sealed class CompileCueJob : DiscJob
 	{
 		private readonly CUE_File IN_CueFile;
 

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_File.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_File.cs
@@ -5,7 +5,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// <summary>
 	/// Represents the contents of a cue file
 	/// </summary>
-	internal class CUE_File
+	internal sealed class CUE_File
 	{
 		/// <remarks>
 		/// (here are all the commands we can encounter)
@@ -172,7 +172,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 		/// <summary>
 		/// Stuff other than the commands, global for the whole disc
 		/// </summary>
-		public class DiscInfo
+		public sealed class DiscInfo
 		{
 			public Command.CATALOG? Catalog;
 			public Command.ISRC? ISRC;

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_Load.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_Load.cs
@@ -28,7 +28,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// For this job, virtually all nonsense input is treated as errors, but the process will try to recover as best it can.
 	/// The user should still reject any jobs which generated errors
 	/// </summary>
-	internal class LoadCueJob : DiscJob
+	internal sealed class LoadCueJob : DiscJob
 	{
 		private readonly CompileCueJob IN_CompileJob;
 
@@ -45,7 +45,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 			Normal, Pregap, Postgap
 		}
 
-		private class BlobInfo
+		private sealed class BlobInfo
 		{
 			public IBlob Blob;
 			public long Length;

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_Parse.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_Parse.cs
@@ -14,7 +14,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// <summary>
 	/// Performs minimum parse processing on a cue file
 	/// </summary>
-	internal class ParseCueJob : DiscJob
+	internal sealed class ParseCueJob : DiscJob
 	{
 		private readonly string IN_CueString;
 
@@ -33,7 +33,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 		/// </summary>
 		public CUE_File OUT_CueFile { get; private set; }
 
-		private class CueLineParser
+		private sealed class CueLineParser
 		{
 			private int index;
 			private readonly string str;

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_Parse.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_Parse.cs
@@ -133,12 +133,12 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 
 		private void LoadFromString()
 		{
-			TextReader tr = new StringReader(IN_CueString);
+			StringReader reader = new(IN_CueString);
 
 			while (true)
 			{
 				CurrentLine++;
-				var line = tr.ReadLine()?.Trim();
+				var line = reader.ReadLine()?.Trim();
 				if (line is null) break;
 				if (line == string.Empty) continue;
 				var clp = new CueLineParser(line);

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_SynthExtras.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_SynthExtras.cs
@@ -6,7 +6,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// Represents a Mode2 Form1 2048-byte sector
 	/// Only used by NRG, MDS, and CHD
 	/// </summary>
-	internal class SS_Mode2_Form1_2048 : SS_Base
+	internal sealed class SS_Mode2_Form1_2048 : SS_Base
 	{
 		public override void Synth(SectorSynthJob job)
 		{
@@ -36,7 +36,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// Represents a Mode2 Form1 2324-byte sector
 	/// Only used by MDS and CHD
 	/// </summary>
-	internal class SS_Mode2_Form2_2324 : SS_Base
+	internal sealed class SS_Mode2_Form2_2324 : SS_Base
 	{
 		public override void Synth(SectorSynthJob job)
 		{
@@ -59,7 +59,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// Represents a Mode2 Form1 2328-byte sector
 	/// Only used by MDS
 	/// </summary>
-	internal class SS_Mode2_Form2_2328 : SS_Base
+	internal sealed class SS_Mode2_Form2_2328 : SS_Base
 	{
 		public override void Synth(SectorSynthJob job)
 		{
@@ -82,7 +82,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// Represents a full 2448-byte sector with interleaved subcode
 	/// Only used by MDS, NRG, and CDI
 	/// </summary>
-	internal class SS_2448_Interleaved : SS_Base
+	internal sealed class SS_2448_Interleaved : SS_Base
 	{
 		public override void Synth(SectorSynthJob job)
 		{
@@ -99,7 +99,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// Represents a 2364-byte (2352 + 12) sector with deinterleaved Q subcode
 	/// Only used by CDI
 	/// </summary>
-	internal class SS_2364_DeinterleavedQ : SS_Base
+	internal sealed class SS_2364_DeinterleavedQ : SS_Base
 	{
 		public override void Synth(SectorSynthJob job)
 		{

--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_Synths.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/CUE/CUE_Synths.cs
@@ -47,7 +47,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// <summary>
 	/// Represents a Mode1 2048-byte sector
 	/// </summary>
-	internal class SS_Mode1_2048 : SS_Base
+	internal sealed class SS_Mode1_2048 : SS_Base
 	{
 		public override void Synth(SectorSynthJob job)
 		{
@@ -76,7 +76,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// <summary>
 	/// Represents a Mode2 2336-byte sector
 	/// </summary>
-	internal class SS_Mode2_2336 : SS_Base
+	internal sealed class SS_Mode2_2336 : SS_Base
 	{
 		public override void Synth(SectorSynthJob job)
 		{
@@ -95,7 +95,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// <summary>
 	/// Represents a 2352-byte sector of any sort
 	/// </summary>
-	internal class SS_2352 : SS_Base
+	internal sealed class SS_2352 : SS_Base
 	{
 		public override void Synth(SectorSynthJob job)
 		{
@@ -111,7 +111,7 @@ namespace BizHawk.Emulation.DiscSystem.CUE
 	/// <summary>
 	/// Encodes a pre-gap sector
 	/// </summary>
-	internal class SS_Gap : SS_Base
+	internal sealed class SS_Gap : SS_Base
 	{
 		public CueTrackType TrackType;
 

--- a/src/BizHawk.Emulation.DiscSystem/DiscMountJob.MednaDisc.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscMountJob.MednaDisc.cs
@@ -2,7 +2,7 @@
 {
 	public partial class DiscMountJob
 	{
-		private class SS_MednaDisc : ISectorSynthJob2448
+		private sealed class SS_MednaDisc : ISectorSynthJob2448
 		{
 			public void Synth(SectorSynthJob job)
 			{

--- a/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/ApplySBIJob.cs
+++ b/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/ApplySBIJob.cs
@@ -1,7 +1,7 @@
 // TODO - generate correct Q subchannel CRC
 namespace BizHawk.Emulation.DiscSystem
 {
-	internal class ApplySBIJob
+	internal sealed class ApplySBIJob
 	{
 		/// <summary>
 		/// applies an SBI file to the disc

--- a/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/LoadSBIJob.cs
+++ b/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/LoadSBIJob.cs
@@ -8,7 +8,7 @@ namespace BizHawk.Emulation.DiscSystem.SBI
 	/// <summary>
 	/// Loads SBI files into an internal representation.
 	/// </summary>
-	internal class LoadSBIJob : DiscJob
+	internal sealed class LoadSBIJob : DiscJob
 	{
 		private readonly string IN_Path;
 

--- a/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/Synthesize_A0A1A2_Job.cs
+++ b/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/Synthesize_A0A1A2_Job.cs
@@ -8,7 +8,7 @@ namespace BizHawk.Emulation.DiscSystem
 	/// Synthesizes RawTCOEntry A0 A1 A2 from the provided information.
 	/// This might be reused by formats other than CUE later, so it isn't directly associated with that
 	/// </summary>
-	internal class Synthesize_A0A1A2_Job
+	internal sealed class Synthesize_A0A1A2_Job
 	{
 		private readonly int IN_FirstRecordedTrackNumber;
 

--- a/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/Synthesize_DiscTOC_From_RawTOCEntries_Job.cs
+++ b/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/Synthesize_DiscTOC_From_RawTOCEntries_Job.cs
@@ -7,7 +7,7 @@ namespace BizHawk.Emulation.DiscSystem
 	/// When a disc drive firmware reads the lead-in area, it builds this TOC from finding q-mode 1 sectors in the Q subchannel of the lead-in area.
 	/// Question: I guess it must ignore q-mode != 1? what else would it do with it?
 	/// </summary>
-	internal class Synthesize_DiscTOC_From_RawTOCEntries_Job
+	internal sealed class Synthesize_DiscTOC_From_RawTOCEntries_Job
 	{
 		private readonly IReadOnlyList<RawTOCEntry> Entries;
 

--- a/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/Synthesize_DiscTracks_From_DiscTOC_Job.cs
+++ b/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/Synthesize_DiscTracks_From_DiscTOC_Job.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace BizHawk.Emulation.DiscSystem
 {
-	internal class Synthesize_DiscTracks_From_DiscTOC_Job
+	internal sealed class Synthesize_DiscTracks_From_DiscTOC_Job
 	{
 		private readonly Disc IN_Disc;
 

--- a/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/Synthesize_Leadout_Job.cs
+++ b/src/BizHawk.Emulation.DiscSystem/Internal/Jobs/Synthesize_Leadout_Job.cs
@@ -6,7 +6,7 @@ namespace BizHawk.Emulation.DiscSystem
 	/// generates lead-out sectors according to very crude approximations
 	/// TODO - this isn't being used right now
 	/// </summary>
-	internal class Synthesize_LeadoutJob
+	internal sealed class Synthesize_LeadoutJob
 	{
 		private readonly int Length;
 		private readonly Disc Disc;

--- a/src/BizHawk.Emulation.DiscSystem/Internal/SectorSynth.cs
+++ b/src/BizHawk.Emulation.DiscSystem/Internal/SectorSynth.cs
@@ -111,7 +111,7 @@ namespace BizHawk.Emulation.DiscSystem
 	/// <summary>
 	/// Not a proper job? maybe with additional flags, it could be
 	/// </summary>
-	internal class SectorSynthJob
+	internal sealed class SectorSynthJob
 	{
 		public int LBA;
 		public ESectorSynthPart Parts;
@@ -124,7 +124,7 @@ namespace BizHawk.Emulation.DiscSystem
 	/// <summary>
 	/// an ISectorSynthProvider that just returns a value from an array of pre-made sectors
 	/// </summary>
-	internal class ArraySectorSynthProvider : ISectorSynthProvider
+	internal sealed class ArraySectorSynthProvider : ISectorSynthProvider
 	{
 		public List<ISectorSynthJob2448> Sectors = new();
 		public int FirstLBA;
@@ -140,7 +140,7 @@ namespace BizHawk.Emulation.DiscSystem
 	/// <summary>
 	/// an ISectorSynthProvider that just returns a fixed synthesizer
 	/// </summary>
-	internal class SimpleSectorSynthProvider : ISectorSynthProvider
+	internal sealed class SimpleSectorSynthProvider : ISectorSynthProvider
 	{
 		public ISectorSynthJob2448 SS;
 
@@ -150,7 +150,7 @@ namespace BizHawk.Emulation.DiscSystem
 	/// <summary>
 	/// Returns 'Patch' synth if the provided condition is met
 	/// </summary>
-	internal class ConditionalSectorSynthProvider : ISectorSynthProvider
+	internal sealed class ConditionalSectorSynthProvider : ISectorSynthProvider
 	{
 		private Func<int,bool> Condition;
 		private ISectorSynthJob2448 Patch;
@@ -193,7 +193,7 @@ namespace BizHawk.Emulation.DiscSystem
 	}
 
 
-	internal class SS_PatchQ : ISectorSynthJob2448
+	internal sealed class SS_PatchQ : ISectorSynthJob2448
 	{
 		public ISectorSynthJob2448 Original;
 		public readonly byte[] Buffer_SubQ = new byte[12];
@@ -211,7 +211,7 @@ namespace BizHawk.Emulation.DiscSystem
 		}
 	}
 
-	internal class SS_Leadout : ISectorSynthJob2448
+	internal sealed class SS_Leadout : ISectorSynthJob2448
 	{
 		public int SessionNumber;
 		public DiscMountPolicy Policy;

--- a/src/BizHawk.Tests/Client.Common/Api/MemoryApiTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Api/MemoryApiTests.cs
@@ -20,7 +20,7 @@ namespace BizHawk.Tests.Client.Common.Api
 			Assert.Fail(message);
 		}
 
-		private IMemoryApi CreateDummyApi(byte[] memDomainContents)
+		private MemoryApi CreateDummyApi(byte[] memDomainContents)
 			=> new MemoryApi(Console.WriteLine) //TODO capture and check for error messages?
 			{
 				MemoryDomainCore = new MemoryDomainList(new MemoryDomain[]

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -595,7 +595,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 			}
 		}
 
-		private class StateSource : IStatable
+		private sealed class StateSource : IStatable
 		{
 			public int Frame { get; set; }
 			public byte[] PaddingData { get; set; } = Array.Empty<byte>();

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -54,7 +54,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 			return zw;
 		}
 
-		private IStatable CreateStateSource() => new StateSource {PaddingData = new byte[1000]};
+		private StateSource CreateStateSource() => new StateSource {PaddingData = new byte[1000]};
 
 		[TestMethod]
 		public void SaveCreateRoundTrip()

--- a/src/BizHawk.Tests/Client.Common/config/SerializationStabilityTests.cs
+++ b/src/BizHawk.Tests/Client.Common/config/SerializationStabilityTests.cs
@@ -22,7 +22,7 @@ namespace BizHawk.Tests.Client.Common.config
 #if NET5_0_OR_GREATER
 		private static readonly IReadOnlySet<Type> KnownGoodFromStdlib = new HashSet<Type>
 #else
-		private static readonly ICollection<Type> KnownGoodFromStdlib = new HashSet<Type>
+		private static readonly HashSet<Type> KnownGoodFromStdlib = new HashSet<Type>
 #endif
 		{
 			typeof(bool),

--- a/src/BizHawk.Tests/Common/CollectionExtensions/CollectionExtensionTests.cs
+++ b/src/BizHawk.Tests/Common/CollectionExtensions/CollectionExtensionTests.cs
@@ -14,7 +14,7 @@ namespace BizHawk.Tests.Common.CollectionExtensions
 		/// <summary>there isn't really an <see cref="IList{T}"/> implementor which isn't <see cref="List{T}"/> and isn't immutable... so I made one</summary>
 		private readonly struct ListImpl : IList<int>
 		{
-			private readonly IList<int> _wrapped;
+			private readonly List<int> _wrapped;
 
 			public int Count => _wrapped.Count;
 

--- a/src/BizHawk.Tests/Emulation.Common/Database/FirmwareDatabaseTests.cs
+++ b/src/BizHawk.Tests/Emulation.Common/Database/FirmwareDatabaseTests.cs
@@ -16,7 +16,9 @@ namespace BizHawk.Tests.Emulation.Common
 		public void CheckFormatOfHashes()
 		{
 			static void CustomAssert(string hash)
+#pragma warning disable CA1862 // incorrect detection, see https://github.com/dotnet/roslyn-analyzers/issues/7074
 				=> Assert.IsTrue(hash.Length == 40 && hash == hash.ToUpperInvariant() && hash.IsHex(), $"incorrectly formatted: {hash}");
+#pragma warning restore CA1862
 			foreach (var hash in FirmwareDatabase.FirmwareFilesByHash.Keys) CustomAssert(hash);
 			foreach (var fo in FirmwareDatabase.FirmwareOptions) CustomAssert(fo.Hash);
 		}


### PR DESCRIPTION
This bumps the `AnalysisLevel` for code analyzers from 6 to 8, enabling more analyzers by default. This is now safe as we require the .NET 8 SDK to build.

I've applied fixes and severity changes to all new inspections. Open to feedback on whether any of those are disagreed on.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
