### PR TITLE
[C64] Fix filter stage passing sound when no filters are enabled

### DIFF
--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Sid.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Sid.cs
@@ -259,16 +259,28 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 				}
 			}
 
-			_fft = new RealFFT(nsamp_2);
+			if (_fft == null)
+				_fft = new RealFFT(nsamp_2);
+			else
+				_fft.Resize(nsamp_2);
 
 			// eventually this will settle on a single buffer size and stop reallocating
 			if (_fftBuffer.Length < nsamp_2)
 				Array.Resize(ref _fftBuffer, nsamp_2);
 
-			// linearly interpolate the original sample set into the new denser sample set
-			for (double i = 0; i < nsamp_2; i++)
+			// If no filters are enabled, filtered output will be silent.
+			if (!_filterSelectLoPass && !_filterSelectHiPass && !_filterSelectBandPass)
 			{
-				_fftBuffer[(int)i] = _outputBufferFiltered[(int)Math.Floor((i / (nsamp_2-1) * (nsamp - 1))) + _filterIndex];
+				for (var i = 0; i < nsamp_2; i++)
+					_fftBuffer[i] = 0;
+			}
+			else
+			{
+				// linearly interpolate the original sample set into the new denser sample set
+				for (double i = 0; i < nsamp_2; i++)
+				{
+					_fftBuffer[(int)i] = _outputBufferFiltered[(int)Math.Floor((i / (nsamp_2-1) * (nsamp - 1))) + _filterIndex];
+				}
 			}
 
 			// now we have everything we need to perform the FFT


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

This change fixes the following issue:
https://github.com/TASEmulators/BizHawk/issues/4153

It also changes the FFT code path to reuse the FFT instance.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
