### PR TITLE
Add a method to the `comm` Lua library to allow setting `ExpectContinue`

### DIFF
--- a/src/BizHawk.Client.Common/Api/HttpCommunication.cs
+++ b/src/BizHawk.Client.Common/Api/HttpCommunication.cs
@@ -20,6 +20,8 @@ namespace BizHawk.Client.Common
 
 		public int Timeout { get; set; }
 
+		public bool ExpectContinue { get; set; } = true;
+
 		public HttpCommunication(Func<byte[]> takeScreenshotCallback, string getURL, string postURL)
 		{
 			_takeScreenshotCallback = takeScreenshotCallback;
@@ -49,6 +51,7 @@ namespace BizHawk.Client.Common
 		public async Task<string> Post(string url, FormUrlEncodedContent content)
 		{
 			_client.DefaultRequestHeaders.ConnectionClose = true;
+			_client.DefaultRequestHeaders.ExpectContinue = ExpectContinue;
 			HttpResponseMessage response;
 			try
 			{

--- a/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
@@ -231,13 +231,6 @@ namespace BizHawk.Client.Common
 			APIs.Comm.HTTP.GetUrl = url;
 		}
 
-		[LuaMethod("httpSetExpectContinue", "Set ExpectContinue boolean to an explicit value")]
-		public void HttpSetExpectContinue(bool value)
-		{
-			CheckHttp();
-			APIs.Comm.HTTP.ExpectContinue = value;
-		}
-
 		[LuaMethod("httpGetPostUrl", "Gets HTTP POST URL")]
 		public string HttpGetPostUrl()
 		{
@@ -250,13 +243,6 @@ namespace BizHawk.Client.Common
 		{
 			CheckHttp();
 			return APIs.Comm.HTTP?.GetUrl;
-		}
-
-		[LuaMethod("httpGetExpectContinue", "Get ExpectContinue value")]
-		public bool HttpGetExpectContinue()
-		{
-			CheckHttp();
-			return APIs.Comm.HTTP.ExpectContinue;
 		}
 
 		private void CheckHttp()

--- a/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
@@ -231,6 +231,13 @@ namespace BizHawk.Client.Common
 			APIs.Comm.HTTP.GetUrl = url;
 		}
 
+		[LuaMethod("httpSetExpectContinue", "Set ExpectContinue boolean to an explicit value")]
+		public void HttpSetExpectContinue(bool value)
+		{
+			CheckHttp();
+			APIs.Comm.HTTP.ExpectContinue = value;
+		}
+
 		[LuaMethod("httpGetPostUrl", "Gets HTTP POST URL")]
 		public string HttpGetPostUrl()
 		{
@@ -243,6 +250,13 @@ namespace BizHawk.Client.Common
 		{
 			CheckHttp();
 			return APIs.Comm.HTTP?.GetUrl;
+		}
+
+		[LuaMethod("httpGetExpectContinue", "Get ExpectContinue value")]
+		public bool HttpGetExpectContinue()
+		{
+			CheckHttp();
+			return APIs.Comm.HTTP.ExpectContinue;
 		}
 
 		private void CheckHttp()


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

Fixes #4187 

Add a method to allow setting the ExpectContinue functionality in the C#.NET to off or on explicitly, allowing compatibility with servers that don't support the default "Expect: 100-Continue" header that C#.NET defaults to sending for POST requests.

I have done a test build but not directly tested the functionality as of yet.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [ ] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
