### PR TITLE
Tastudio Lua Branch Undo Callbacks

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -618,5 +618,18 @@ namespace BizHawk.Client.EmuHawk
 				};
 			}
 		}
+
+		[LuaMethodExample("function RemoveUndone(index)\r\nconsole.log(\"You did a branch remove undo for branch \"..index)\r\nend\r\ntastudio.onbranchundoremove(RemoveUndone)")]
+		[LuaMethod("onbranchundoremove", "called whenever a branch removal is undone. luaf must be a function that takes the integer branch index as a parameter")]
+		public void OnBranchUndoREmove(LuaFunction luaf)
+		{
+			if (Engaged())
+			{
+				Tastudio.BranchRemoveUndoneCallback = index =>
+				{
+					luaf.Call(index);
+				};
+			}
+		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -592,5 +592,18 @@ namespace BizHawk.Client.EmuHawk
 				};
 			}
 		}
+
+		[LuaMethodExample("function LoadUndone()\r\nconsole.log(\"You did a branch load undo\")\r\nend\r\ntastudio.onbranchundoload(LoadUndone)")]
+		[LuaMethod("onbranchundoload", "called whenever a branch load is undone. luaf must be a function without parameters")]
+		public void OnBranchUndoLoad(LuaFunction luaf)
+		{
+			if (Engaged())
+			{
+				Tastudio.BranchLoadUndoneCallback = () =>
+				{
+					luaf.Call(); 
+				};
+			}
+		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -593,7 +593,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		[LuaMethodExample("function LoadUndone()\r\nconsole.log(\"You did a branch load undo\")\r\nend\r\ntastudio.onbranchundoload(LoadUndone)")]
+		[LuaMethodExample("function LoadUndone()\r\n\tconsole.log(\"You did a branch load undo\")\r\nend\r\ntastudio.onbranchundoload(LoadUndone)")]
 		[LuaMethod("onbranchundoload", "called whenever a branch load is undone. luaf must be a function without parameters")]
 		public void OnBranchUndoLoad(LuaFunction luaf)
 		{
@@ -606,7 +606,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		[LuaMethodExample("function SaveUndone(index)\r\nconsole.log(\"You did a branch save undo for branch \"..index)\r\nend\r\ntastudio.onbranchundosave(SaveUndone)")]
+		[LuaMethodExample("function SaveUndone(index)\r\n\tconsole.log(\"You did a branch save undo for branch \"..index)\r\nend\r\ntastudio.onbranchundosave(SaveUndone)")]
 		[LuaMethod("onbranchundosave", "called whenever a branch save is undone. luaf must be a function that takes the integer branch index as a parameter")]
 		public void OnBranchUndoSave(LuaFunction luaf)
 		{
@@ -619,7 +619,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		[LuaMethodExample("function RemoveUndone(index)\r\nconsole.log(\"You did a branch remove undo for branch \"..index)\r\nend\r\ntastudio.onbranchundoremove(RemoveUndone)")]
+		[LuaMethodExample("function RemoveUndone(index)\r\n\tconsole.log(\"You did a branch remove undo for branch \"..index)\r\nend\r\ntastudio.onbranchundoremove(RemoveUndone)")]
 		[LuaMethod("onbranchundoremove", "called whenever a branch removal is undone. luaf must be a function that takes the integer branch index as a parameter")]
 		public void OnBranchUndoREmove(LuaFunction luaf)
 		{

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -606,13 +606,13 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		[LuaMethodExample("function SaveUndone(index)\r\n\tconsole.log(\"You did a branch save undo for branch \"..index)\r\nend\r\ntastudio.onbranchundosave(SaveUndone)")]
-		[LuaMethod("onbranchundosave", "called whenever a branch save is undone. luaf must be a function that takes the integer branch index as a parameter")]
-		public void OnBranchUndoSave(LuaFunction luaf)
+		[LuaMethodExample("function UpdateUndone(index)\r\n\tconsole.log(\"You did a branch updaate undo for branch \"..index)\r\nend\r\ntastudio.onbranchundoupdate(UpdateUndone)")]
+		[LuaMethod("onbranchundoupdate", "called whenever a branch update is undone. luaf must be a function that takes the integer branch index as a parameter")]
+		public void OnBranchUndoUpdate(LuaFunction luaf)
 		{
 			if (Engaged())
 			{
-				Tastudio.BranchSaveUndoneCallback = index =>
+				Tastudio.BranchUpdateUndoneCallback = index =>
 				{
 					luaf.Call(index); 
 				};

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -605,5 +605,18 @@ namespace BizHawk.Client.EmuHawk
 				};
 			}
 		}
+
+		[LuaMethodExample("function SaveUndone(index)\r\nconsole.log(\"You did a branch save undo for branch \"..index)\r\nend\r\ntastudio.onbranchundosave(SaveUndone)")]
+		[LuaMethod("onbranchundosave", "called whenever a branch save is undone. luaf must be a function that takes the integer branch index as a parameter")]
+		public void OnBranchUndoSave(LuaFunction luaf)
+		{
+			if (Engaged())
+			{
+				Tastudio.BranchSaveUndoneCallback = index =>
+				{
+					luaf.Call(index); 
+				};
+			}
+		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -41,6 +41,8 @@ namespace BizHawk.Client.EmuHawk
 
 		public Action<int> SaveUndoneCallback { get; set; }
 
+		public Action<int> RemoveUndoneCallback { get; set; }
+
 		public TAStudio Tastudio { get; set; }
 
 		public IDialogController DialogController => Tastudio.MainForm;
@@ -389,7 +391,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				Branches.Add(_backupBranch);
 				BranchView.RowCount = Branches.Count;
-				SavedCallback?.Invoke(Branches.IndexOf(_backupBranch));
+				RemoveUndoneCallback?.Invoke(Branches.IndexOf(_backupBranch));
 				Tastudio.MainForm.AddOnScreenMessage("Branch Removal canceled");
 			}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -37,6 +37,8 @@ namespace BizHawk.Client.EmuHawk
 
 		public Action<int> RemovedCallback { get; set; }
 
+		public Action LoadUndoneCallback { get; set; }
+
 		public TAStudio Tastudio { get; set; }
 
 		public IDialogController DialogController => Tastudio.MainForm;
@@ -358,7 +360,7 @@ namespace BizHawk.Client.EmuHawk
 			if (_branchUndo == BranchUndo.Load)
 			{
 				LoadBranch(_backupBranch);
-				LoadedCallback?.Invoke(Branches.IndexOf(_backupBranch));
+				LoadUndoneCallback?.Invoke();
 				Tastudio.MainForm.AddOnScreenMessage("Branch Load canceled");
 			}
 			else if (_branchUndo == BranchUndo.Update)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -39,6 +39,8 @@ namespace BizHawk.Client.EmuHawk
 
 		public Action LoadUndoneCallback { get; set; }
 
+		public Action<int> SaveUndoneCallback { get; set; }
+
 		public TAStudio Tastudio { get; set; }
 
 		public IDialogController DialogController => Tastudio.MainForm;
@@ -369,7 +371,7 @@ namespace BizHawk.Client.EmuHawk
 				if (branch != null)
 				{
 					Branches.Replace(branch, _backupBranch);
-					SavedCallback?.Invoke(Branches.IndexOf(_backupBranch));
+					SaveUndoneCallback?.Invoke(Branches.IndexOf(_backupBranch));
 					Tastudio.MainForm.AddOnScreenMessage("Branch Update canceled");
 				}
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -39,7 +39,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public Action LoadUndoneCallback { get; set; }
 
-		public Action<int> SaveUndoneCallback { get; set; }
+		public Action<int> UpdateUndoneCallback { get; set; }
 
 		public Action<int> RemoveUndoneCallback { get; set; }
 
@@ -373,7 +373,7 @@ namespace BizHawk.Client.EmuHawk
 				if (branch != null)
 				{
 					Branches.Replace(branch, _backupBranch);
-					SaveUndoneCallback?.Invoke(Branches.IndexOf(_backupBranch));
+					UpdateUndoneCallback?.Invoke(Branches.IndexOf(_backupBranch));
 					Tastudio.MainForm.AddOnScreenMessage("Branch Update canceled");
 				}
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Callbacks.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Callbacks.cs
@@ -13,6 +13,7 @@ namespace BizHawk.Client.EmuHawk
 		public Action<int> BranchLoadedCallback { get; set; }
 		public Action<int> BranchSavedCallback { get; set; }
 		public Action<int> BranchRemovedCallback { get; set; }
+		public Action BranchLoadUndoneCallback { get; set; }
 
 		private void GreenzoneInvalidated(int index)
 		{
@@ -32,6 +33,11 @@ namespace BizHawk.Client.EmuHawk
 		private void BranchRemoved(int index)
 		{
 			BranchRemovedCallback?.Invoke(index);
+		}
+
+		private void BranchLoadUndone()
+		{
+			BranchLoadUndoneCallback?.Invoke();
 		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Callbacks.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Callbacks.cs
@@ -14,7 +14,7 @@ namespace BizHawk.Client.EmuHawk
 		public Action<int> BranchSavedCallback { get; set; }
 		public Action<int> BranchRemovedCallback { get; set; }
 		public Action BranchLoadUndoneCallback { get; set; }
-		public Action<int> BranchSaveUndoneCallback { get; set; }
+		public Action<int> BranchUpdateUndoneCallback { get; set; }
 		public Action<int> BranchRemoveUndoneCallback { get; set; }
 
 		private void GreenzoneInvalidated(int index)
@@ -42,9 +42,9 @@ namespace BizHawk.Client.EmuHawk
 			BranchLoadUndoneCallback?.Invoke();
 		}
 
-		private void BranchSaveUndone(int index)
+		private void BranchUpdateUndone(int index)
 		{
-			BranchSaveUndoneCallback?.Invoke(index);
+			BranchUpdateUndoneCallback?.Invoke(index);
 		}
 
 		private void BranchRemoveUndone(int index)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Callbacks.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Callbacks.cs
@@ -14,6 +14,7 @@ namespace BizHawk.Client.EmuHawk
 		public Action<int> BranchSavedCallback { get; set; }
 		public Action<int> BranchRemovedCallback { get; set; }
 		public Action BranchLoadUndoneCallback { get; set; }
+		public Action<int> BranchSaveUndoneCallback { get; set; }
 
 		private void GreenzoneInvalidated(int index)
 		{
@@ -38,6 +39,11 @@ namespace BizHawk.Client.EmuHawk
 		private void BranchLoadUndone()
 		{
 			BranchLoadUndoneCallback?.Invoke();
+		}
+
+		private void BranchSaveUndone(int index)
+		{
+			BranchSaveUndoneCallback?.Invoke(index);
 		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Callbacks.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Callbacks.cs
@@ -15,6 +15,7 @@ namespace BizHawk.Client.EmuHawk
 		public Action<int> BranchRemovedCallback { get; set; }
 		public Action BranchLoadUndoneCallback { get; set; }
 		public Action<int> BranchSaveUndoneCallback { get; set; }
+		public Action<int> BranchRemoveUndoneCallback { get; set; }
 
 		private void GreenzoneInvalidated(int index)
 		{
@@ -44,6 +45,11 @@ namespace BizHawk.Client.EmuHawk
 		private void BranchSaveUndone(int index)
 		{
 			BranchSaveUndoneCallback?.Invoke(index);
+		}
+
+		private void BranchRemoveUndone(int index)
+		{
+			BranchRemoveUndoneCallback?.Invoke(index);
 		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -149,7 +149,7 @@ namespace BizHawk.Client.EmuHawk
 			BookMarkControl.SavedCallback = BranchSaved;
 			BookMarkControl.RemovedCallback = BranchRemoved;
 			BookMarkControl.LoadUndoneCallback = BranchLoadUndone;
-			BookMarkControl.SaveUndoneCallback = BranchSaveUndone;
+			BookMarkControl.UpdateUndoneCallback = BranchUpdateUndone;
 			BookMarkControl.RemoveUndoneCallback = BranchRemoveUndone;
 			TasView.MouseLeave += TAStudio_MouseLeave;
 			TasView.CellHovered += (_, e) =>

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -148,6 +148,7 @@ namespace BizHawk.Client.EmuHawk
 			BookMarkControl.LoadedCallback = BranchLoaded;
 			BookMarkControl.SavedCallback = BranchSaved;
 			BookMarkControl.RemovedCallback = BranchRemoved;
+			BookMarkControl.LoadUndoneCallback = BranchLoadUndone;
 			TasView.MouseLeave += TAStudio_MouseLeave;
 			TasView.CellHovered += (_, e) =>
 			{

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -149,6 +149,7 @@ namespace BizHawk.Client.EmuHawk
 			BookMarkControl.SavedCallback = BranchSaved;
 			BookMarkControl.RemovedCallback = BranchRemoved;
 			BookMarkControl.LoadUndoneCallback = BranchLoadUndone;
+			BookMarkControl.SaveUndoneCallback = BranchSaveUndone;
 			TasView.MouseLeave += TAStudio_MouseLeave;
 			TasView.CellHovered += (_, e) =>
 			{

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -150,6 +150,7 @@ namespace BizHawk.Client.EmuHawk
 			BookMarkControl.RemovedCallback = BranchRemoved;
 			BookMarkControl.LoadUndoneCallback = BranchLoadUndone;
 			BookMarkControl.SaveUndoneCallback = BranchSaveUndone;
+			BookMarkControl.RemoveUndoneCallback = BranchRemoveUndone;
 			TasView.MouseLeave += TAStudio_MouseLeave;
 			TasView.CellHovered += (_, e) =>
 			{


### PR DESCRIPTION
Implements proper callbacks for branch load/update/remove undos.
Previously it didn't work, since it wasn't possible to receive in Lua whether the callback came from a regular action or an undo.