### PR TITLE
Refactor equality check in `MDS_Format.MountBlobs`

### DIFF
--- a/src/BizHawk.Emulation.DiscSystem/DiscFormats/MDS_Format.cs
+++ b/src/BizHawk.Emulation.DiscSystem/DiscFormats/MDS_Format.cs
@@ -657,6 +657,7 @@ namespace BizHawk.Emulation.DiscSystem
 		/// <exception cref="MDSParseException">path reference no longer points to file</exception>
 		private static Dictionary<int, IBlob> MountBlobs(AFile mdsf, Disc disc)
 		{
+			Debug.Assert(disc.DisposableResources.Count is 0, "no other method should be adding to DisposableResources");
 			var BlobIndex = new Dictionary<int, IBlob>();
 
 			var count = 0;
@@ -667,18 +668,11 @@ namespace BizHawk.Emulation.DiscSystem
 					if (!File.Exists(file))
 						throw new MDSParseException($"Malformed MDS format: nonexistent image file: {file}");
 
-					//mount the file			
-					var mdfBlob = new Blob_RawFile { PhysicalPath = file };
-
-					var dupe = false;
-					foreach (var re in disc.DisposableResources)
+					//mount the file
+					if (!disc.DisposableResources.Cast<Blob_RawFile>()
+						.Select(static re => re.PhysicalPath).Contains(file))
 					{
-						if (re.ToString() == mdfBlob.ToString())
-							dupe = true;
-					}
-
-					if (!dupe)
-					{
+						Blob_RawFile mdfBlob = new() { PhysicalPath = file };
 						// wrap in zeropadadapter
 						disc.DisposableResources.Add(mdfBlob);
 						BlobIndex[count++] = mdfBlob;


### PR DESCRIPTION
This goes back to the initial implementation https://github.com/TASEmulators/BizHawk/commit/6d87be1396eb6b9ba41370bce76a7019774d826e. @Asnivor Can you say whether this matches the original intent? Or just whether it still functions correctly? That's probably more important.

(Throwback to my comment 6 years ago in https://github.com/TASEmulators/BizHawk/commit/1d5a097a75f93ad8898717835a2b6a419967441e.)