### PR TITLE
implement emu.setrenderplanes in EmulationApi for snes9x

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/EmulationApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/EmulationApi.cs
@@ -15,6 +15,7 @@ using BizHawk.Emulation.Cores.Nintendo.SNES;
 using BizHawk.Emulation.Cores.PCEngine;
 using BizHawk.Emulation.Cores.Sega.MasterSystem;
 using BizHawk.Emulation.Cores.WonderSwan;
+using BizHawk.Emulation.Cores.Nintendo.SNES9X;
 
 namespace BizHawk.Client.Common
 {
@@ -234,6 +235,19 @@ namespace BizHawk.Client.Common
 				s.ShowOBJ_3 = GetSetting(args, 7);
 				core.PutSettings(s);
 			}
+			void SetSnes9x(Snes9x core)
+			{
+				var s = core.GetSettings();
+				s.ShowBg0 = GetSetting(args, 0);
+				s.ShowBg1 = GetSetting(args, 1);
+				s.ShowBg2 = GetSetting(args, 2);
+				s.ShowBg3 = GetSetting(args, 3);
+				s.ShowSprites0 = GetSetting(args, 4);
+				s.ShowSprites1 = GetSetting(args, 5);
+				s.ShowSprites2 = GetSetting(args, 6);
+				s.ShowSprites3 = GetSetting(args, 7);
+				core.PutSettings(s);
+			}
 			void SetBsnes(ISettable<BsnesCore.SnesSettings, BsnesCore.SnesSyncSettings> settingsProvider)
 			{
 				var s = settingsProvider.GetSettings();
@@ -305,6 +319,9 @@ namespace BizHawk.Client.Common
 			{
 				case GPGX gpgx:
 					SetGPGX(gpgx);
+					break;
+				case Snes9x snes9x:
+					SetSnes9x(snes9x);
 					break;
 				case LibsnesCore snes:
 					SetLibsnes(snes);


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

Implement emu.setrenderplanes for snes9x

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [ ] I have run any relevant test suites
- [x] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
