### PR TITLE
TAStudio marker lua 

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -475,12 +475,14 @@ namespace BizHawk.Client.EmuHawk
 
 		[LuaMethodExample("local marker = tastudio.getbranchmarkerabove(tastudio.getbranches()[1].Id, 100)")]
 		[LuaMethod("getbranchmarkerabove", "returns a table of the marker at or above the given frame for the given branchId with fields Frame and Text")]
-		public LuaTable GetBranchMarkerAbove(string branchId, int frame)
+		public LuaTable GetBranchMarkerAbove(int index, int frame)
 		{
 			var table = _th.CreateTable();
 			if (!Engaged()) return table;
 
-			var branch = Tastudio.CurrentTasMovie.Branches.FirstOrDefault(b => b.Uuid.ToString() == branchId);
+			if (index >= Tastudio.CurrentTasMovie.Branches.Count) return table;
+
+			var branch = Tastudio.CurrentTasMovie.Branches[index];
 			var marker = branch.Markers.PreviousOrCurrent(frame);
 			table["Frame"] = marker.Frame;
 			table["Text"] = marker.Message;
@@ -507,11 +509,13 @@ namespace BizHawk.Client.EmuHawk
 
 		[LuaMethodExample("local markers = tastudio.getbranchmarkers(tastudio.getbranches()[1].Id)\r\nfor i = 0, #makers, 1 do\r\n\tconsole.log(v[i].Text)\r\nend")]
 		[LuaMethod("getbranchmarkers", "returns a table of all markers with fields Frame and Text")]
-		public LuaTable GetBranchMarkers(string branchId)
+		public LuaTable GetBranchMarkers(int index)
 		{
 			if (!Engaged()) return _th.CreateTable();
 
-			var branch = Tastudio.CurrentTasMovie.Branches.FirstOrDefault(b => b.Uuid.ToString() == branchId);
+			if (index >= Tastudio.CurrentTasMovie.Branches.Count) return _th.CreateTable();
+						
+			var branch = Tastudio.CurrentTasMovie.Branches[index];
 
 			return _th.EnumerateToLuaTable(
 				branch.Markers.Select(m =>

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -459,6 +459,23 @@ namespace BizHawk.Client.EmuHawk
 			return "";
 		}
 
+		[LuaMethodExample("local markers = tastudio.getmarkers()\r\nfor i = 0, #makers, 1 do\r\n\tconsole.log(v[i].Text)\r\nend")]
+		[LuaMethod("getmarkers", "returns a table of all markers with with fields Frame and Text")]
+		public LuaTable GetMarkers()
+		{
+			if (!Engaged()) return _th.CreateTable();
+
+			return _th.EnumerateToLuaTable(
+				Tastudio.CurrentTasMovie.Markers.Select(m =>
+				{
+					var table = _th.CreateTable();
+					table["Frame"] = m.Frame;
+					table["Text"] = m.Message;
+					return table;
+				}),
+				indexFrom: 0);
+		}
+
 		[LuaMethodExample("tastudio.removemarker( 500 );")]
 		[LuaMethod("removemarker", "if there is a marker for the given frame, it will be removed")]
 		public void RemoveMarker(int frame)

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -473,6 +473,21 @@ namespace BizHawk.Client.EmuHawk
 			return table;
 		}
 
+		[LuaMethodExample("local marker = tastudio.getbranchmarkerabove(tastudio.getbranches()[1].Id, 100)")]
+		[LuaMethod("getbranchmarkerabove", "returns a table of the marker at or above the given frame for the given branchId with fields Frame and Text")]
+		public LuaTable GetBranchMarkerAbove(string branchId, int frame)
+		{
+			var table = _th.CreateTable();
+			if (!Engaged()) return table;
+
+			var branch = Tastudio.CurrentTasMovie.Branches.FirstOrDefault(b => b.Uuid.ToString() == branchId);
+			var marker = branch.Markers.PreviousOrCurrent(frame);
+			table["Frame"] = marker.Frame;
+			table["Text"] = marker.Message;
+
+			return table;
+		}
+
 		[LuaMethodExample("local markers = tastudio.getmarkers()\r\nfor i = 0, #makers, 1 do\r\n\tconsole.log(v[i].Text)\r\nend")]
 		[LuaMethod("getmarkers", "returns a table of all markers with with fields Frame and Text")]
 		public LuaTable GetMarkers()

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -459,7 +459,7 @@ namespace BizHawk.Client.EmuHawk
 			return "";
 		}
 
-		[LuaMethodExample("local marker = tastudio.getmarkerabove(100)")]
+		[LuaMethodExample("local markerframe = tastudio.getmarkerabove(100).Frame")]
 		[LuaMethod("getmarkerabove", "returns a table of the marker at or above the given frame with fields Frame and Text")]
 		public LuaTable GetMarkerAbove(int frame)
 		{
@@ -473,8 +473,8 @@ namespace BizHawk.Client.EmuHawk
 			return table;
 		}
 
-		[LuaMethodExample("local marker = tastudio.getbranchmarkerabove(tastudio.getbranches()[1].Id, 100)")]
-		[LuaMethod("getbranchmarkerabove", "returns a table of the marker at or above the given frame for the given branchId with fields Frame and Text")]
+		[LuaMethodExample("local branchmarkertext = tastudio.getbranchmarkerabove(0, 100).Text")]
+		[LuaMethod("getbranchmarkerabove", "returns a table of the marker at or above the given frame for the given branch index, starting at 0, with fields Frame and Text")]
 		public LuaTable GetBranchMarkerAbove(int index, int frame)
 		{
 			var table = _th.CreateTable();
@@ -490,8 +490,8 @@ namespace BizHawk.Client.EmuHawk
 			return table;
 		}
 
-		[LuaMethodExample("local markers = tastudio.getmarkers()\r\nfor i = 0, #makers, 1 do\r\n\tconsole.log(v[i].Text)\r\nend")]
-		[LuaMethod("getmarkers", "returns a table of all markers with with fields Frame and Text")]
+		[LuaMethodExample("local markertext = tastudio.getmarkers()[0].Text")]
+		[LuaMethod("getmarkers", "returns a table of all markers with fields Frame and Text")]
 		public LuaTable GetMarkers()
 		{
 			if (!Engaged()) return _th.CreateTable();
@@ -507,8 +507,8 @@ namespace BizHawk.Client.EmuHawk
 				indexFrom: 0);
 		}
 
-		[LuaMethodExample("local markers = tastudio.getbranchmarkers(tastudio.getbranches()[1].Id)\r\nfor i = 0, #makers, 1 do\r\n\tconsole.log(v[i].Text)\r\nend")]
-		[LuaMethod("getbranchmarkers", "returns a table of all markers with fields Frame and Text")]
+		[LuaMethodExample("local branchmarkerframe = tastudio.getmarkers(0)[0].Frame")]
+		[LuaMethod("getbranchmarkers", "returns a table of all markers for the given branch index, starting at 0, with fields Frame and Text")]
 		public LuaTable GetBranchMarkers(int index)
 		{
 			if (!Engaged()) return _th.CreateTable();

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -505,7 +505,7 @@ namespace BizHawk.Client.EmuHawk
 				indexFrom: 0);
 		}
 
-		[LuaMethodExample("local markers = tastudio.getbranchmarkers(tastudio.getbranches()[1]\r\nfor i = 0, #makers, 1 do\r\n\tconsole.log(v[i].Text)\r\nend")]
+		[LuaMethodExample("local markers = tastudio.getbranchmarkers(tastudio.getbranches()[1].Id)\r\nfor i = 0, #makers, 1 do\r\n\tconsole.log(v[i].Text)\r\nend")]
 		[LuaMethod("getbranchmarkers", "returns a table of all markers with fields Frame and Text")]
 		public LuaTable GetBranchMarkers(string branchId)
 		{

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -505,6 +505,25 @@ namespace BizHawk.Client.EmuHawk
 				indexFrom: 0);
 		}
 
+		[LuaMethodExample("local markers = tastudio.getbranchmarkers(tastudio.getbranches()[1]\r\nfor i = 0, #makers, 1 do\r\n\tconsole.log(v[i].Text)\r\nend")]
+		[LuaMethod("getbranchmarkers", "returns a table of all markers with fields Frame and Text")]
+		public LuaTable GetBranchMarkers(string branchId)
+		{
+			if (!Engaged()) return _th.CreateTable();
+
+			var branch = Tastudio.CurrentTasMovie.Branches.FirstOrDefault(b => b.Uuid.ToString() == branchId);
+
+			return _th.EnumerateToLuaTable(
+				branch.Markers.Select(m =>
+				{
+					var table = _th.CreateTable();
+					table["Frame"] = m.Frame;
+					table["Text"] = m.Message;
+					return table;
+				}),
+				indexFrom: 0);
+		}
+
 		[LuaMethodExample("tastudio.removemarker( 500 );")]
 		[LuaMethod("removemarker", "if there is a marker for the given frame, it will be removed")]
 		public void RemoveMarker(int frame)

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -459,6 +459,20 @@ namespace BizHawk.Client.EmuHawk
 			return "";
 		}
 
+		[LuaMethodExample("local marker = tastudio.getmarkerabove(100)")]
+		[LuaMethod("getmarkerabove", "returns a table of the marker at or above the given frame with fields Frame and Text")]
+		public LuaTable GetMarkerAbove(int frame)
+		{
+			var table = _th.CreateTable();
+			if (!Engaged()) return table;
+
+			var marker = Tastudio.CurrentTasMovie.Markers.PreviousOrCurrent(frame);
+			table["Frame"] = marker.Frame;
+			table["Text"] = marker.Message;
+
+			return table;
+		}
+
 		[LuaMethodExample("local markers = tastudio.getmarkers()\r\nfor i = 0, #makers, 1 do\r\n\tconsole.log(v[i].Text)\r\nend")]
 		[LuaMethod("getmarkers", "returns a table of all markers with with fields Frame and Text")]
 		public LuaTable GetMarkers()


### PR DESCRIPTION
Implements four new lua functions:

- tastudio.getmarkerabove(frame)
returns a table with fields Frame and Text for the marker that is at or above the given frame, where the field Frame is the actual frame where the marker is located
- tastudio.getmarkers()
returns a list with all markers for the loaded movie, for which each entry has a table with fields Frame and Text
- tastudio.getbranchmarkerabove(branchId, frame)
returns a table with fields Frame and Text for the marker that is at or above the given frame for the given branchId
- tastudio.getbranchmarkers(branchId)
returns a list with all markers for the loaded movies for the given branchId

Those functions returned the tables in with no time drawbacks in constant time.

With those function it's possible to do what's possible in FCEUX TAS Editor, thus this PR implements all functionality from and resolves #1161. Furthermore it's not needed to have a function that gets a "marker index", since the "Id" can just be set in tastudio.getmarkers()[index].
It also makes it possible to delete a marker by index with tastudio.removemarker(tastudio.getmarkers()[index].Frame).
