### PR TITLE
Watches with pointers

### DIFF
--- a/src/BizHawk.Client.Common/tools/Cheat.cs
+++ b/src/BizHawk.Client.Common/tools/Cheat.cs
@@ -167,17 +167,24 @@ namespace BizHawk.Client.Common
 			{
 				if (ShouldPoke())
 				{
-					switch (_watch.Size)
+					try
 					{
-						case WatchSize.Byte:
-							_watch.Poke(((ByteWatch)_watch).FormatValue((byte)_val));
-							break;
-						case WatchSize.Word:
-							_watch.Poke(((WordWatch)_watch).FormatValue((ushort)_val));
-							break;
-						case WatchSize.DWord:
-							_watch.Poke(((DWordWatch)_watch).FormatValue((uint)_val));
-							break;
+						switch (_watch.Size)
+						{
+							case WatchSize.Byte:
+								_watch.PokeByte(unchecked((byte) _val));
+								break;
+							case WatchSize.Word:
+								_watch.PokeWord(unchecked((ushort) _val));
+								break;
+							case WatchSize.DWord:
+								_watch.PokeDWord(unchecked((uint) _val));
+								break;
+						}
+					}
+					catch
+					{
+						// ignore (matches `*Watch.Poke` implementations)
 					}
 				}
 

--- a/src/BizHawk.Client.Common/tools/Cheat.cs
+++ b/src/BizHawk.Client.Common/tools/Cheat.cs
@@ -91,35 +91,20 @@ namespace BizHawk.Client.Common
 
 		public string AddressStr => _watch.AddressString;
 
-		public string ValueStr =>
-			_watch.Size switch
-				{
-					WatchSize.Byte => ((ByteWatch) _watch).FormatValue((byte)_val),
-					WatchSize.Word => ((WordWatch) _watch).FormatValue((ushort)_val),
-					WatchSize.DWord => ((DWordWatch) _watch).FormatValue((uint)_val),
-					WatchSize.Separator => "",
-					_ => string.Empty,
-				};
+		public string ValueStr
+			=> _watch.Size is WatchSize.Byte or WatchSize.Word or WatchSize.DWord
+				? _watch.IsValid
+					? Watch.FormatValue(unchecked((uint) _val), _watch.Size, _watch.Type)
+					: "-"
+				: string.Empty;
 
 		public string CompareStr
-		{
-			get
-			{
-				if (_compare.HasValue)
-				{
-					return _watch.Size switch
-					{
-						WatchSize.Byte => ((ByteWatch) _watch).FormatValue((byte)_compare.Value),
-						WatchSize.Word => ((WordWatch) _watch).FormatValue((ushort)_compare.Value),
-						WatchSize.DWord => ((DWordWatch) _watch).FormatValue((uint)_compare.Value),
-						WatchSize.Separator => "",
-						_ => string.Empty,
-					};
-				}
-				
-				return "";
-			}
-		}
+			=> _compare.Value is int compareValue
+				&& _watch.Size is WatchSize.Byte or WatchSize.Word or WatchSize.DWord
+					? _watch.IsValid
+						? Watch.FormatValue(unchecked((uint) compareValue), _watch.Size, _watch.Type)
+						: "-"
+					: string.Empty;
 
 		public CompareType ComparisonType { get; }
 

--- a/src/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
@@ -99,10 +99,6 @@ namespace BizHawk.Client.Common
 
 		public override string Diff => $"{_value - _previous:+#;-#;0}";
 
-		public override bool IsValid => Domain.Size == 0 || Address < Domain.Size;
-
-		public override uint MaxValue => byte.MaxValue;
-
 		public override int Value => GetByte();
 
 		public override string ValueString => FormatValue(GetByte());

--- a/src/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using System.Globalization;
+
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
@@ -56,16 +56,7 @@ namespace BizHawk.Client.Common
 		{
 			try
 			{
-				byte val = Type switch
-				{
-					WatchDisplayType.Unsigned => byte.Parse(value),
-					WatchDisplayType.Signed => (byte)sbyte.Parse(value),
-					WatchDisplayType.Hex => byte.Parse(value, NumberStyles.HexNumber),
-					WatchDisplayType.Binary => Convert.ToByte(value, 2),
-					_ => 0,
-				};
-
-				PokeByte(val);
+				PokeByte(unchecked((byte) Watch.ParseValue(value, Size, Type)));
 				return true;
 			}
 			catch
@@ -104,17 +95,7 @@ namespace BizHawk.Client.Common
 
 		// TODO: Implements IFormattable
 		public string FormatValue(byte val)
-		{
-			return Type switch
-			{
-				_ when !IsValid => "-",
-				WatchDisplayType.Unsigned => val.ToString(),
-				WatchDisplayType.Signed => ((sbyte) val).ToString(),
-				WatchDisplayType.Hex => $"{val:X2}",
-				WatchDisplayType.Binary => Convert.ToString(val, 2).PadLeft(8, '0').Insert(4, " "),
-				_ => val.ToString(),
-			};
-		}
+			=> IsValid ? Watch.FormatValue(val, Size, Type) : "-";
 
 		public override string Diff => $"{_value - _previous:+#;-#;0}";
 

--- a/src/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
@@ -42,29 +42,16 @@ namespace BizHawk.Client.Common
 			WatchDisplayType.Binary,
 		];
 
-		/// <summary>
-		/// Get a list a <see cref="WatchDisplayType"/> that can be used for this <see cref="ByteWatch"/>
-		/// </summary>
-		/// <returns>An enumeration that contains all valid <see cref="WatchDisplayType"/></returns>
 		public override IEnumerable<WatchDisplayType> AvailableTypes()
 		{
 			return ValidTypes;
 		}
 
-		/// <summary>
-		/// Reset the previous value; set it to the current one
-		/// </summary>
 		public override void ResetPrevious()
 		{
 			_previous = GetByte();
 		}
 
-		/// <summary>
-		/// Try to sets the value into the <see cref="MemoryDomain"/>
-		/// at the current <see cref="Watch"/> address
-		/// </summary>
-		/// <param name="value">Value to set</param>
-		/// <returns>True if value successfully sets; otherwise, false</returns>
 		public override bool Poke(string value)
 		{
 			try
@@ -87,9 +74,6 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		/// <summary>
-		/// Update the Watch (read it from <see cref="MemoryDomain"/>
-		/// </summary>
 		public override void Update(PreviousType previousType)
 		{
 			switch (previousType)
@@ -132,40 +116,18 @@ namespace BizHawk.Client.Common
 			};
 		}
 
-		/// <summary>
-		/// Get a string representation of difference
-		/// between current value and the previous one
-		/// </summary>
 		public override string Diff => $"{_value - _previous:+#;-#;0}";
 
-		/// <summary>
-		/// Returns true if the Watch is valid, false otherwise
-		/// </summary>
 		public override bool IsValid => Domain.Size == 0 || Address < Domain.Size;
 
-		/// <summary>
-		/// Get the maximum possible value
-		/// </summary>
 		public override uint MaxValue => byte.MaxValue;
 
-		/// <summary>
-		/// Get the current value
-		/// </summary>
 		public override int Value => GetByte();
 
-		/// <summary>
-		/// Get a string representation of the current value
-		/// </summary>
 		public override string ValueString => FormatValue(GetByte());
 
-		/// <summary>
-		/// Get the previous value
-		/// </summary>
 		public override uint Previous => _previous;
 
-		/// <summary>
-		/// Get a string representation of the previous value
-		/// </summary>
 		public override string PreviousStr => FormatValue(_previous);
 	}
 }

--- a/src/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
@@ -100,10 +100,6 @@ namespace BizHawk.Client.Common
 
 		public override string Diff => $"{_value - (long)_previous:+#;-#;0}";
 
-		public override bool IsValid => Domain.Size == 0 || Address < (Domain.Size - 3);
-
-		public override uint MaxValue => uint.MaxValue;
-
 		public override int Value => (int)GetDWord();
 
 		public override string ValueString => FormatValue(GetDWord());

--- a/src/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
@@ -46,27 +46,14 @@ namespace BizHawk.Client.Common
 			WatchDisplayType.Float,
 		];
 
-		/// <summary>
-		/// Get a list of <see cref="WatchDisplayType"/> that can be used for a <see cref="DWordWatch"/>
-		/// </summary>
-		/// <returns>An enumeration that contains all valid <see cref="WatchDisplayType"/></returns>
 		public override IEnumerable<WatchDisplayType> AvailableTypes()
 		{
 			return ValidTypes;
 		}
 
-		/// <summary>
-		/// Reset the previous value; set it to the current one
-		/// </summary>
 		public override void ResetPrevious()
 			=> _previous = GetDWord();
 
-		/// <summary>
-		/// Try to sets the value into the <see cref="MemoryDomain"/>
-		/// at the current <see cref="Watch"/> address
-		/// </summary>
-		/// <param name="value">Value to set</param>
-		/// <returns>True if value successfully sets; otherwise, false</returns>
 		public override bool Poke(string value)
 		{
 			try
@@ -92,9 +79,6 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		/// <summary>
-		/// Update the Watch (read it from <see cref="MemoryDomain"/>
-		/// </summary>
 		public override void Update(PreviousType previousType)
 		{
 			switch (previousType)
@@ -156,40 +140,18 @@ namespace BizHawk.Client.Common
 			};
 		}
 
-		/// <summary>
-		/// Get a string representation of difference
-		/// between current value and the previous one
-		/// </summary>
 		public override string Diff => $"{_value - (long)_previous:+#;-#;0}";
 
-		/// <summary>
-		/// Returns true if the Watch is valid, false otherwise
-		/// </summary>
 		public override bool IsValid => Domain.Size == 0 || Address < (Domain.Size - 3);
 
-		/// <summary>
-		/// Get the maximum possible value
-		/// </summary>
 		public override uint MaxValue => uint.MaxValue;
 
-		/// <summary>
-		/// Get the current value
-		/// </summary>
 		public override int Value => (int)GetDWord();
 
-		/// <summary>
-		/// Get a string representation of the current value
-		/// </summary>
 		public override string ValueString => FormatValue(GetDWord());
 
-		/// <summary>
-		/// Get the previous value
-		/// </summary>
 		public override uint Previous => _previous;
 
-		/// <summary>
-		/// Get a string representation of the previous value
-		/// </summary>
 		public override string PreviousStr => FormatValue(_previous);
 	}
 }

--- a/src/BizHawk.Client.Common/tools/Watch/NeoWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/NeoWatch.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+using BizHawk.Emulation.Common;
+
+namespace BizHawk.Client.Common
+{
+	/// <summary>an extremely versatile implementation (pointers!), but with presumably lower performance</summary>
+	public sealed class NeoWatch : Watch
+	{
+		private static long CollapseAddress(long address, MemoryDomain domain)
+			=> address;
+
+		private Expression _addressAST;
+
+		private uint _previous;
+
+		private uint _value;
+
+		private Watch _wrapped;
+
+		public override string AddressString
+			=> _addressAST.ToString();
+
+		public override string Diff
+			=> $"{_value - (long) _previous:+#;-#;0}";
+
+		public override uint Previous
+			=> _previous;
+
+		public override string PreviousStr
+			=> Watch.FormatValue(_previous, Size, Type);
+
+		public override int Value
+			=> _wrapped.Value;
+
+		public override string ValueString
+			=> _wrapped.ValueString;
+
+		public int Width;
+
+		private NeoWatch(Watch wrapped)
+			: base(
+				wrapped.Domain,
+				wrapped.Address,
+				wrapped.Size,
+				wrapped.Type,
+				bigEndian: wrapped.BigEndian,
+				note: wrapped.Notes)
+			=> _wrapped = wrapped;
+
+		internal NeoWatch(
+			MemoryDomain domain,
+			long address,
+			WatchSize size,
+			WatchDisplayType type,
+			bool bigEndian)
+				: this(Watch.GenerateWatch(
+					domain,
+					CollapseAddress(address, domain),
+					size,
+					type,
+					bigEndian: bigEndian)) {}
+
+		public override IEnumerable<WatchDisplayType> AvailableTypes()
+			=> Size switch
+			{
+				WatchSize.Byte => ByteWatch.ValidTypes,
+				WatchSize.Word => WordWatch.ValidTypes,
+				WatchSize.DWord => DWordWatch.ValidTypes,
+				_ => [ ]
+			};
+
+		private void CollapseAddress()
+		{
+			//TODO
+		}
+
+		private uint CollapseAndPeek()
+		{
+			CollapseAddress();
+			return Size switch
+			{
+				WatchSize.Byte => GetByte(),
+				WatchSize.Word => GetWord(),
+				_ => GetDWord()
+			};
+		}
+
+		public override bool Poke(string value)
+		{
+			CollapseAddress();
+			try
+			{
+				var parsed = Watch.ParseValue(value, Size, Type);
+				switch (Size)
+				{
+					case WatchSize.Byte:
+						PokeByte(unchecked((byte) parsed));
+						break;
+					case WatchSize.Word:
+						PokeWord(unchecked((ushort) parsed));
+						break;
+					case WatchSize.DWord:
+						PokeDWord(parsed);
+						break;
+				}
+				return true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
+		public override void ResetPrevious()
+			=> _previous = CollapseAndPeek();
+
+		public override void Update(PreviousType previousType)
+		{
+			switch (previousType)
+			{
+				case PreviousType.Original:
+					CollapseAddress();
+					// no-op
+					break;
+				case PreviousType.LastSearch:
+					CollapseAddress();
+					//TODO no-op?
+					break;
+				case PreviousType.LastFrame:
+					_previous = _value;
+					_value = CollapseAndPeek();
+					if (_value != _previous) ChangeCount++;
+					break;
+				case PreviousType.LastChange:
+					var newValue = CollapseAndPeek();
+					if (newValue != _value)
+					{
+						_previous = _value;
+						ChangeCount++;
+					}
+					_value = newValue;
+					break;
+			}
+		}
+	}
+}

--- a/src/BizHawk.Client.Common/tools/Watch/SeparatorWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/SeparatorWatch.cs
@@ -56,11 +56,6 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		public override string PreviousStr => "";
 
-		/// <summary>
-		/// TTransform the current instance into a displayable (short representation) string
-		/// It's used by the "Display on screen" option in the RamWatch window
-		/// </summary>
-		/// <returns>A well formatted string representation</returns>
 		public override string ToDisplayString()
 		{
 			return string.IsNullOrEmpty(Notes)
@@ -68,10 +63,6 @@ namespace BizHawk.Client.Common
 				: Notes;
 		}
 
-		/// <summary>
-		/// Transforms the current instance into a string
-		/// </summary>
-		/// <returns>A <see cref="string"/> representation of the current <see cref="Watch"/></returns>
 		public override string ToString()
 		{
 			return $"0\tS\t_\t1\t\t{Notes.Trim('\r', '\n')}";

--- a/src/BizHawk.Client.Common/tools/Watch/SeparatorWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/SeparatorWatch.cs
@@ -93,11 +93,6 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Ignore that stuff
 		/// </summary>
-		public override uint MaxValue => 0;
-
-		/// <summary>
-		/// Ignore that stuff
-		/// </summary>
 		public override void Update(PreviousType previousType)
 		{
 		}

--- a/src/BizHawk.Client.Common/tools/Watch/Watch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/Watch.cs
@@ -558,7 +558,7 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Gets the address in the <see cref="MemoryDomain"/> formatted as string
 		/// </summary>
-		public string AddressString => Address.ToString(AddressFormatStr);
+		public virtual string AddressString => Address.ToString(AddressFormatStr);
 
 		/// <summary>
 		/// Gets or sets a value indicating the endianess of current <see cref="Watch"/>

--- a/src/BizHawk.Client.Common/tools/Watch/Watch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/Watch.cs
@@ -285,7 +285,7 @@ namespace BizHawk.Client.Common
 				: 0;
 		}
 
-		protected void PokeByte(byte val)
+		protected internal void PokeByte(byte val)
 		{
 			if (IsValid)
 			{
@@ -293,7 +293,7 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		protected void PokeWord(ushort val)
+		protected internal void PokeWord(ushort val)
 		{
 			if (IsValid)
 			{
@@ -301,7 +301,7 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		protected void PokeDWord(uint val)
+		protected internal void PokeDWord(uint val)
 		{
 			if (IsValid)
 			{

--- a/src/BizHawk.Client.Common/tools/Watch/Watch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/Watch.cs
@@ -502,7 +502,15 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Gets the maximum possible value
 		/// </summary>
-		public abstract uint MaxValue { get; }
+		public uint MaxValue
+			=> Size switch
+			{
+				WatchSize.Separator => 0,
+				WatchSize.Byte => byte.MaxValue,
+				WatchSize.Word => ushort.MaxValue,
+				WatchSize.DWord => uint.MaxValue,
+				_ => throw new InvalidOperationException()
+			};
 
 		/// <summary>
 		/// Gets the current value
@@ -517,7 +525,8 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Returns true if the Watch is valid, false otherwise
 		/// </summary>
-		public abstract bool IsValid { get; }
+		public virtual bool IsValid
+			=> Domain.Size is 0 || Address <= Domain.Size - unchecked((long) Size);
 
 		/// <summary>
 		/// Try to sets the value into the <see cref="MemoryDomain"/>

--- a/src/BizHawk.Client.Common/tools/Watch/WordWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/WordWatch.cs
@@ -43,26 +43,13 @@ namespace BizHawk.Client.Common
 			WatchDisplayType.FixedPoint_12_4,
 		];
 
-		/// <summary>
-		/// Get a list a <see cref="WatchDisplayType"/> that can be used for this <see cref="WordWatch"/>
-		/// </summary>
-		/// <returns>An enumeration that contains all valid <see cref="WatchDisplayType"/></returns>
 		public override IEnumerable<WatchDisplayType> AvailableTypes() => ValidTypes;
 
-		/// <summary>
-		/// Reset the previous value; set it to the current one
-		/// </summary>
 		public override void ResetPrevious()
 		{
 			_previous = GetWord();
 		}
 
-		/// <summary>
-		/// Try to sets the value into the <see cref="MemoryDomain"/>
-		/// at the current <see cref="Watch"/> address
-		/// </summary>
-		/// <param name="value">Value to set</param>
-		/// <returns>True if value successfully sets; otherwise, false</returns>
 		public override bool Poke(string value)
 		{
 			try
@@ -86,9 +73,6 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		/// <summary>
-		/// Update the Watch (read it from <see cref="MemoryDomain"/>
-		/// </summary>
 		public override void Update(PreviousType previousType)
 		{
 			switch (previousType)
@@ -137,40 +121,18 @@ namespace BizHawk.Client.Common
 			};
 		}
 
-		/// <summary>
-		/// Get a string representation of difference
-		/// between current value and the previous one
-		/// </summary>
 		public override string Diff => $"{_value - _previous:+#;-#;0}";
 
-		/// <summary>
-		/// Returns true if the Watch is valid, false otherwise
-		/// </summary>
 		public override bool IsValid => Domain.Size == 0 || Address < (Domain.Size - 1);
 
-		/// <summary>
-		/// Get the maximum possible value
-		/// </summary>
 		public override uint MaxValue => ushort.MaxValue;
 
-		/// <summary>
-		/// Gets the current value
-		/// </summary>
 		public override int Value => GetWord();
 
-		/// <summary>
-		/// Get a string representation of the current value
-		/// </summary>
 		public override string ValueString => FormatValue(GetWord());
 
-		/// <summary>
-		/// Get the previous value
-		/// </summary>
 		public override uint Previous => _previous;
 
-		/// <summary>
-		/// Get a string representation of the previous value
-		/// </summary>
 		public override string PreviousStr => FormatValue(_previous);
 	}
 }

--- a/src/BizHawk.Client.Common/tools/Watch/WordWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/WordWatch.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using System.Globalization;
+
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
@@ -54,17 +54,7 @@ namespace BizHawk.Client.Common
 		{
 			try
 			{
-				ushort val = Type switch
-				{
-					WatchDisplayType.Unsigned => ushort.Parse(value),
-					WatchDisplayType.Signed => (ushort)short.Parse(value),
-					WatchDisplayType.Hex => ushort.Parse(value, NumberStyles.HexNumber),
-					WatchDisplayType.Binary => Convert.ToUInt16(value, 2),
-					WatchDisplayType.FixedPoint_12_4 => (ushort)(double.Parse(value, NumberFormatInfo.InvariantInfo) * 16.0),
-					_ => 0,
-				};
-
-				PokeWord(val);
+				PokeWord(unchecked((ushort) Watch.ParseValue(value, Size, Type)));
 				return true;
 			}
 			catch
@@ -104,22 +94,7 @@ namespace BizHawk.Client.Common
 
 		// TODO: Implements IFormattable
 		public string FormatValue(ushort val)
-		{
-			return Type switch
-			{
-				_ when !IsValid => "-",
-				WatchDisplayType.Unsigned => val.ToString(),
-				WatchDisplayType.Signed => ((short) val).ToString(), WatchDisplayType.Hex => $"{val:X4}",
-				WatchDisplayType.FixedPoint_12_4 => ((short)val / 16.0).ToString("F4", NumberFormatInfo.InvariantInfo),
-				WatchDisplayType.Binary => Convert
-					.ToString(val, 2)
-					.PadLeft(16, '0')
-					.Insert(8, " ")
-					.Insert(4, " ")
-					.Insert(14, " "),
-				_ => val.ToString(),
-			};
-		}
+			=> IsValid ? Watch.FormatValue(val, Size, Type) : "-";
 
 		public override string Diff => $"{_value - _previous:+#;-#;0}";
 

--- a/src/BizHawk.Client.Common/tools/Watch/WordWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/WordWatch.cs
@@ -98,10 +98,6 @@ namespace BizHawk.Client.Common
 
 		public override string Diff => $"{_value - _previous:+#;-#;0}";
 
-		public override bool IsValid => Domain.Size == 0 || Address < (Domain.Size - 1);
-
-		public override uint MaxValue => ushort.MaxValue;
-
 		public override int Value => GetWord();
 
 		public override string ValueString => FormatValue(GetWord());

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/WatchEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/WatchEditor.cs
@@ -20,6 +20,8 @@ namespace BizHawk.Client.EmuHawk
 		private Mode _mode = Mode.New;
 		private bool _loading = true;
 
+		private string _sysBusDomainName = null!;
+
 		private bool _changedSize;
 		private bool _changedDisplayType;
 
@@ -28,6 +30,8 @@ namespace BizHawk.Client.EmuHawk
 		public Point InitialLocation { get; set;  } = new Point(0, 0);
 
 		private readonly HexTextBox AddressBox;
+
+		private readonly TextBox AddressWithPointersBox;
 
 		private readonly CheckBox BigEndianCheckBox;
 
@@ -48,6 +52,8 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		private readonly ComboBox SizeDropDown;
+
+		private readonly CheckBoxEx UsePointerSyntaxCheckbox;
 
 		public WatchEditor()
 		{
@@ -89,8 +95,40 @@ namespace BizHawk.Client.EmuHawk
 			{
 				Controls = { new LabelEx { Text = "0x" }, AddressBox },
 			};
+			AddressWithPointersBox = new() { Size = new(100, 20), Visible = false };
+			SingleColumnFLP flpAddrOptions = new()
+			{
+				Controls = { flpAddr, AddressWithPointersBox },
+			};
 			tlpMain.Controls.Add(label1, row: row, column: 0);
-			tlpMain.Controls.Add(flpAddr, row: row, column: 1);
+			tlpMain.Controls.Add(flpAddrOptions, row: row, column: 1);
+			row++;
+
+			UsePointerSyntaxCheckbox = new() { Enabled = MemoryDomains.HasSystemBus, Text = "Use pointer syntax" };
+			UsePointerSyntaxCheckbox.CheckedChanged += (checkedChangedSender, _) =>
+			{
+				var isChecked = ((CheckBox) checkedChangedSender).Checked;
+				flpAddr.Visible = !(AddressWithPointersBox.Visible = isChecked);
+				if (isChecked)
+				{
+					if ((string) DomainDropDown.SelectedItem == _sysBusDomainName!)
+					{
+						AddressWithPointersBox.Text = $"0x{AddressBox.Text}";
+					}
+					else
+					{
+						DomainDropDown.SelectedItem = _sysBusDomainName;
+						AddressWithPointersBox.Text = string.Empty;
+					}
+					AddressBox.Text = string.Empty;
+				}
+				else
+				{
+					//TODO eval and copy back
+					AddressWithPointersBox.Text = string.Empty;
+				}
+			};
+			tlpMain.Controls.Add(UsePointerSyntaxCheckbox, row: row, column: 1);
 			row++;
 
 			LocLabelEx label3 = new() { Anchor = AnchorStyles.Right, Text = "Size:" };
@@ -182,6 +220,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			_loading = false;
+			_sysBusDomainName = MemoryDomains.SystemBus.ToString();
 			SetAddressBoxProperties();
 
 			switch (_mode)
@@ -201,7 +240,9 @@ namespace BizHawk.Client.EmuHawk
 						NotesBox.Enabled = false;
 						NotesBox.Text = "";
 
-						AddressBox.Enabled = false;
+						AddressBox.Enabled = AddressWithPointersBox.Enabled
+							= UsePointerSyntaxCheckbox.Enabled
+							= false;
 						AddressBox.Text = Watches.Select(a => a.AddressString).Aggregate((addrStr, nextStr) => $"{addrStr},{nextStr}");
 
 						BigEndianCheckBox.ThreeState = true;
@@ -215,7 +256,15 @@ namespace BizHawk.Client.EmuHawk
 					{
 						NotesBox.Text = Watches[0].Notes;
 						NotesBox.Select();
-						AddressBox.SetFromLong(Watches[0].Address);
+						if (Watches[0] is NeoWatch neo)
+						{
+							UsePointerSyntaxCheckbox.Checked = true;
+							AddressWithPointersBox.Text = neo.AddressString;
+						}
+						else
+						{
+							AddressBox.SetFromLong(Watches[0].Address);
+						}
 					}
 
 					SetBigEndianCheckBox();
@@ -316,17 +365,25 @@ namespace BizHawk.Client.EmuHawk
 				default:
 				case Mode.New:
 					var domain = MemoryDomains.FirstOrDefault(d => d.Name == DomainDropDown.SelectedItem.ToString());
-					var address = AddressBox.ToLong() ?? 0;
 					var notes = NotesBox.Text;
 					var type = Watch.StringToDisplayType(DisplayTypeDropDown.SelectedItem.ToString());
 					var bigEndian = BigEndianCheckBox.Checked;
-					Watches.Add(Watch.GenerateWatch(
-						domain,
-						address,
-						(WatchSize) SelectedWidth,
-						type,
-						bigEndian: bigEndian,
-						note: notes));
+					var addrWithPointers = AddressWithPointersBox.Text;
+					if (addrWithPointers.Length is not 0)
+					{
+						//TODO
+					}
+					else
+					{
+						var address = AddressBox.ToLong() ?? 0;
+						Watches.Add(Watch.GenerateWatch(
+							domain,
+							address,
+							(WatchSize) SelectedWidth,
+							type,
+							bigEndian: bigEndian,
+							note: notes));
+					}
 					break;
 				case Mode.Edit:
 					DoEdit();


### PR DESCRIPTION
With this PR, I aim to implement #377. My goal is to have a checkbox in the watch editor which swaps out the address box for a freeform textbox (that's all done), into which you can type semi-arbitrary expressions involving pointer arithmetic (see below). The editor will store this with a new `Watch` subclass, which holds onto an AST of the expression (should be done modulo parsing), re-evaluating the effective address each time RAM Watch calls `Update` (should be done modulo the peeks). Addresses are assumed to be in the sysbus, and the editor enforces this, disabling pointer mode when no sysbus exists (done).

For the expressions, I plan use a C-like syntax with:
- hex literals (and only hex literals) for addresses;
- '$'-prefixed decimal literals (or '$0x'-prefixed hex literals) for constants;
- a pointer dereference operator;
- grouping with parentheses;
- addition, subtraction, and multiplication operators for offsets;
- bitwise intersection and conjunction (AND and OR) operators and a right shift operator for masking.
- Example: `*(0x1234 + 2 * (*0xABCD & $7))`
- And expressions will be typed—either pointer- or non-pointer-coloured u32—and operators will only accept certain types of argument.
	- Actually I think only binary operations on two pointer arguments and dereferencing on non-pointers need to be blocked? No reason to block arithmetic with non-pointers.
- I think I'll just copy [C#'s operator precedence](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#operator-precedence).
- My plan was to distinguish multiplication and dereferencing by requiring whitespace around all binary operators. I believe it would be possible to have a consistent parser even without whitespace (like... C#'s), it's just simpler that way. Alternatively, we could change the sigil for dereferencing to something unique, maybe '@'.