### PR TITLE
Fix NesHawk APU Status open bus behavior

### DIFF
--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -1078,7 +1078,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				MemoryCallbacks.CallMemoryCallbacks(addr, ret, flags, "System Bus");
 			}
 
-			DB = ret;
+			if (addr != 0x4015)
+			{
+				// This register is internal to the CPU and so the external CPU data bus is disconnected when reading it.
+				// Therefore the returned value cannot be seen by external devices and the value does not affect open bus.
+				DB = ret;
+			}
+
 			return ret;
 		}
 


### PR DESCRIPTION
Reading from $4015 no longer updates the data bus.

Per the [NesDev Wiki](https://www.nesdev.org/wiki/APU#Status_($4015)):

> This register is internal to the CPU and so the external CPU data bus is disconnected when reading it. Therefore the returned value cannot be seen by external devices and the value does not affect [open bus](https://www.nesdev.org/wiki/Open_bus_behavior).

This can very easily be tested by running
 LDX #$16
 LDA $40FF, X
 
The dummy read cycle will read from $4015 before the CPU will read from $4115, returning open bus. If the dummy read of $4015 incorrectly updates the data bus, then the result would be zero:

![Before](https://github.com/user-attachments/assets/71e6baf2-9a16-4b34-963b-ca2a14bb36bb)

But by correcting this behavior, the value of $40 (from reading the second operand) remains on the data bus even after the dummy read cycle.

![After](https://github.com/user-attachments/assets/958d6b9b-0177-44ee-8805-75fb041e8d69)
