### PR TITLE
Fixed incorrect behavior of SHA, SHX, SHY, and SHS in NesHawk

### DIFF
--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
@@ -196,7 +196,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			/*TYA [implied]*/ new Uop[] { Uop.Imp_TYA, Uop.End },
 			/*STA addr,Y [absolute indexed WRITE]*/ new Uop[] { Uop.Fetch2, Uop.AbsIdx_Stage3_Y, Uop.AbsIdx_Stage4, Uop.AbsIdx_WRITE_Stage5_STA, Uop.End },
 			/*TXS [implied]*/ new Uop[] { Uop.Imp_TXS, Uop.End },
-			/*SHS* addr,Y [absolute indexed WRITE Y] [unofficial] */ new Uop[] { Uop.Fetch2, Uop.AbsIdx_Stage3_Y, Uop.AbsIdx_Stage4, Uop.AbsIdx_WRITE_Stage5_ERROR, Uop.End },
+			/*SHS* addr,Y [absolute indexed WRITE Y] [unofficial] */ new Uop[] { Uop.Fetch2, Uop.AbsIdx_Stage3_Y, Uop.AbsIdx_Stage4_SHS, Uop.AbsIdx_WRITE_Stage5_SHS, Uop.End },
 			/*SHY** [absolute indexed WRITE] [unofficial]*/ new Uop[] { Uop.Fetch2, Uop.AbsIdx_Stage3_X, Uop.AbsIdx_Stage4_SHY, Uop.AbsIdx_WRITE_Stage5_SHY, Uop.End },
 			/*STA addr,X [absolute indexed WRITE]*/ new Uop[] { Uop.Fetch2, Uop.AbsIdx_Stage3_X, Uop.AbsIdx_Stage4, Uop.AbsIdx_WRITE_Stage5_STA, Uop.End },
 			/*SHX* addr,Y [absolute indexed WRITE Y] [unofficial]*/ new Uop[] { Uop.Fetch2, Uop.AbsIdx_Stage3_Y, Uop.AbsIdx_Stage4_SHX, Uop.AbsIdx_WRITE_Stage5_SHX, Uop.End },
@@ -416,7 +416,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			//[absolute indexed WRITE]
 			AbsIdx_WRITE_Stage5_STA,
 			AbsIdx_WRITE_Stage5_SHY, AbsIdx_WRITE_Stage5_SHX, //unofficials
-			AbsIdx_WRITE_Stage5_ERROR,
+			AbsIdx_WRITE_Stage5_SHS,
 			//[absolute indexed READ]
 			AbsIdx_READ_Stage4,
 			AbsIdx_READ_Stage5_LDA, AbsIdx_READ_Stage5_CMP, AbsIdx_READ_Stage5_SBC, AbsIdx_READ_Stage5_ADC, AbsIdx_READ_Stage5_EOR, AbsIdx_READ_Stage5_LDX, AbsIdx_READ_Stage5_AND, AbsIdx_READ_Stage5_ORA, AbsIdx_READ_Stage5_LDY, AbsIdx_READ_Stage5_NOP,
@@ -474,7 +474,8 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			IndIdx_WRITE_Stage5_SHA,
 			AbsIdx_Stage4_SHX,
 			AbsIdx_Stage4_SHY,
-			AbsIdx_Stage4_SHA
+			AbsIdx_Stage4_SHA,
+			AbsIdx_Stage4_SHS
 		}
 
 		private void InitOpcodeHandlers()
@@ -524,6 +525,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		public int mi; //microcode index
 		private bool iflag_pending; //iflag must be stored after it is checked in some cases (CLI and SEI).
 		public bool rdy_freeze; //true if the CPU must be frozen
+		private byte H; //internal temp varaible used in the "unstable high byte group" of unofficial instructions
 
 		//tracks whether an interrupt condition has popped up recently.
 		//not sure if this is real or not but it helps with the branch_irq_hack
@@ -957,6 +959,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		private void IndIdx_WRITE_Stage5_SHA()
 		{
 			rdy_freeze = !RDY;
+			H = (byte) ((ea >> 8) + 1);
 			if (RDY)
 			{
 				_link.ReadMemory((ushort) ea);
@@ -965,8 +968,6 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 				{
 					ea = (ushort) (ea & 0xFF | ((ea + 0x100) & 0xFF00 & ((A & X) << 8)));
 				}
-
-				ea += unchecked((ushort) (alu_temp & 0xFF00));
 			}
 		}
 
@@ -1008,13 +1009,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 
 		private void IndIdx_WRITE_Stage6_SHA()
 		{
-			alu_temp = A & X;
-
-			if (RDY)
-			{
-				alu_temp &= unchecked((byte) ((ea >> 8) + 1));
-			}
-
+			alu_temp = A & X & H;
 			_link.WriteMemory((ushort) ea, unchecked((byte) alu_temp));
 		}
 
@@ -2490,6 +2485,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		private void AbsIdx_Stage4()
 		{
 			rdy_freeze = !RDY;
+			H = (byte) ((ea >> 8) + 1);
 
 			if (RDY)
 			{
@@ -2506,6 +2502,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		private void AbsIdx_Stage4_SHX()
 		{
 			rdy_freeze = !RDY;
+			H = (byte) ((ea >> 8) + 1);
 
 			if (RDY)
 			{
@@ -2522,6 +2519,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		private void AbsIdx_Stage4_SHY()
 		{
 			rdy_freeze = !RDY;
+			H = (byte) ((ea >> 8) + 1);
 
 			if (RDY)
 			{
@@ -2538,6 +2536,24 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		private void AbsIdx_Stage4_SHA()
 		{
 			rdy_freeze = !RDY;
+			H = (byte)((ea >> 8) + 1);
+
+			if (RDY)
+			{
+				var adjust = alu_temp.Bit(8);
+				alu_temp = _link.ReadMemory((ushort) ea);
+
+				if (adjust)
+				{
+					ea = (ushort) (ea & 0xFF | ((ea + 0x100) & 0xFF00 & ((A & X) << 8)));
+				}
+			}
+		}
+
+		private void AbsIdx_Stage4_SHS()
+		{
+			rdy_freeze = !RDY;
+			H = (byte) ((ea >> 8) + 1);
 
 			if (RDY)
 			{
@@ -2558,44 +2574,26 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 
 		private void AbsIdx_WRITE_Stage5_SHY()
 		{
-			alu_temp = Y;
-
-			if (RDY)
-			{
-				alu_temp &= unchecked((byte)((ea >> 8) + 1));
-			}
-
+			alu_temp = Y & H;
 			_link.WriteMemory((ushort) ea, (byte) alu_temp);
 		}
 
 		private void AbsIdx_WRITE_Stage5_SHX()
 		{
-			alu_temp = X;
-
-			if (RDY)
-			{
-				alu_temp &= unchecked((byte)((ea >> 8) + 1));
-			}
-
+			alu_temp = X & H;
 			_link.WriteMemory((ushort) ea, (byte) alu_temp);
 		}
 
 		private void AbsIdx_WRITE_Stage5_SHA()
 		{
-			alu_temp = A & X;
-
-			if (RDY)
-			{
-				alu_temp &= unchecked((byte)((ea >> 8) + 1));
-			}
-
+			alu_temp = A & X & H;
 			_link.WriteMemory((ushort) ea, (byte) alu_temp);
 		}
 
-		private void AbsIdx_WRITE_Stage5_ERROR()
+		private void AbsIdx_WRITE_Stage5_SHS()
 		{
 			S = (byte)(X & A);
-			_link.WriteMemory((ushort)ea, (byte)(S & (opcode3+1)));
+			_link.WriteMemory((ushort)ea, (byte)(S & H));
 		}
 
 		private void AbsIdx_RMW_Stage5()
@@ -3225,11 +3223,12 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 				case Uop.AbsIdx_Stage4_SHX: AbsIdx_Stage4_SHX(); break;
 				case Uop.AbsIdx_Stage4_SHY: AbsIdx_Stage4_SHY(); break;
 				case Uop.AbsIdx_Stage4_SHA: AbsIdx_Stage4_SHA(); break;
+				case Uop.AbsIdx_Stage4_SHS: AbsIdx_Stage4_SHS(); break;
 				case Uop.AbsIdx_WRITE_Stage5_STA: AbsIdx_WRITE_Stage5_STA(); break;
 				case Uop.AbsIdx_WRITE_Stage5_SHY: AbsIdx_WRITE_Stage5_SHY(); break;
 				case Uop.AbsIdx_WRITE_Stage5_SHX: AbsIdx_WRITE_Stage5_SHX(); break;
 				case Uop.AbsIdx_WRITE_Stage5_SHA: AbsIdx_WRITE_Stage5_SHA(); break;
-				case Uop.AbsIdx_WRITE_Stage5_ERROR: AbsIdx_WRITE_Stage5_ERROR(); break;
+				case Uop.AbsIdx_WRITE_Stage5_SHS: AbsIdx_WRITE_Stage5_SHS(); break;
 				case Uop.AbsIdx_RMW_Stage5: AbsIdx_RMW_Stage5(); break;
 				case Uop.AbsIdx_RMW_Stage7: AbsIdx_RMW_Stage7(); break;
 				case Uop.AbsIdx_RMW_Stage6_DEC: AbsIdx_RMW_Stage6_DEC(); break;

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
@@ -626,7 +626,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				opcode3 = _link.ReadMemory(PC++);
-				address_bus = (ushort)((opcode3 << 8) | opcode2);
+				address_bus = (ushort) ((opcode3 << 8) | opcode2);
 			}
 		}
 

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
@@ -475,7 +475,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			AbsIdx_Stage4_SHX,
 			AbsIdx_Stage4_SHY,
 			AbsIdx_Stage4_SHA,
-			AbsIdx_Stage4_SHS
+			AbsIdx_Stage4_SHS,
 		}
 
 		private void InitOpcodeHandlers()

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
@@ -3321,7 +3321,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (!rdy_freeze)
 				mi++;
 
-			if(Microcode[opcode][mi] == Uop.End)
+			if (Microcode[opcode][mi] is Uop.End)
 			{
 				address_bus = PC; // If the next cycle is the start of a new instruction, the address bus needs to be set to the PC now, so a DMC DMA's halt cycles don't use the wrong address bus value.
 			}

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
@@ -2050,7 +2050,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				ea = _link.ReadMemory((ushort)alu_temp);
-				address_bus = (ushort)ea;
+				address_bus = (ushort) ea;
 			}
 		}
 

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
@@ -525,7 +525,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		public int mi; //microcode index
 		private bool iflag_pending; //iflag must be stored after it is checked in some cases (CLI and SEI).
 		public bool rdy_freeze; //true if the CPU must be frozen
-		private byte H; //internal temp varaible used in the "unstable high byte group" of unofficial instructions
+		private byte H; //internal temp variable used in the "unstable high byte group" of unofficial instructions
 
 		//tracks whether an interrupt condition has popped up recently.
 		//not sure if this is real or not but it helps with the branch_irq_hack

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
@@ -960,7 +960,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		private void IndIdx_WRITE_Stage5_SHA()
 		{
 			rdy_freeze = !RDY;
-			
+
 			if (RDY)
 			{
 				H |= (byte) ((ea >> 8) + 1);
@@ -2550,7 +2550,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		private void AbsIdx_Stage4_SHA()
 		{
 			rdy_freeze = !RDY;
-			
+
 			if (RDY)
 			{
 				H |= (byte) ((ea >> 8) + 1);

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
@@ -2622,7 +2622,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		private void AbsIdx_WRITE_Stage5_SHS()
 		{
 			S = (byte)(X & A);
-			_link.WriteMemory((ushort)ea, (byte)(S & H));
+			_link.WriteMemory((ushort) ea, (byte) (S & H));
 		}
 
 		private void AbsIdx_RMW_Stage5()

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
@@ -2566,7 +2566,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 
 				if (adjust)
 				{
-					ea = (ushort) (ea & 0xFF | ((ea + 0x100) & 0xFF00 & ((A & X) << 8)));
+					ea = (ushort) ((ea & 0xFF) | ((ea + 0x100) & 0xFF00 & ((A & X) << 8)));
 				}
 			}
 			else

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/MOS6502X.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/MOS6502X.cs
@@ -185,6 +185,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			ser.Sync(nameof(rdy_freeze), ref rdy_freeze);
 			ser.Sync(nameof(ext_ppu_cycle), ref ext_ppu_cycle);
 			ser.Sync(nameof(H), ref H);
+			ser.Sync(nameof(address_bus), ref address_bus);
 			ser.EndSection();
 		}
 

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/MOS6502X.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/MOS6502X.cs
@@ -184,6 +184,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			ser.Sync(nameof(branch_irq_hack), ref branch_irq_hack);
 			ser.Sync(nameof(rdy_freeze), ref rdy_freeze);
 			ser.Sync(nameof(ext_ppu_cycle), ref ext_ppu_cycle);
+			ser.Sync(nameof(H), ref H);
 			ser.EndSection();
 		}
 

--- a/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/MOS6502X.cs
+++ b/src/BizHawk.Emulation.Cores/CPUs/MOS 6502X/MOS6502X.cs
@@ -157,7 +157,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		public bool NMI;
 		public bool RDY;
 
-		// ppu cycle (used with SubNESHawk)
+		// ppu cycle
 		public int ext_ppu_cycle = 0;
 
 		public void SyncState(Serializer ser)

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6510.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6510.cs
@@ -54,7 +54,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 			_cpu = new MOS6502X<CpuLink>(new CpuLink(this))
 			{
 				// Required to pass the Lorenz test suite.
-				AneConstant = 0xEF,
+				AneConstant = 0xEE,
 				LxaConstant = 0xEE
 			};
 

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6510.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6510.cs
@@ -55,7 +55,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 			{
 				// Required to pass the Lorenz test suite.
 				AneConstant = 0xEF,
-				LxaConstant = 0xFE
+				LxaConstant = 0xEE
 			};
 
 			// perform hard reset

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6510.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6510.cs
@@ -55,7 +55,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 			{
 				// Required to pass the Lorenz test suite.
 				AneConstant = 0xEE,
-				LxaConstant = 0xEE
+				LxaConstant = 0xEE,
 			};
 
 			// perform hard reset

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
@@ -1334,6 +1334,16 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 		public void RunOneLast()
 		{
+			// The controllers only get strobed when transitioning from a get cyclte to a put cycle.
+			if(dmc.timer % 2 == 1)
+			{
+				if(nes.joypadStrobed)
+				{
+					nes.joypadStrobed = false;
+					nes.strobe_joyport();
+				}
+			}
+
 			// we need to predict if there will be a length clock here, because the sequencer ticks last, but the
 			// timer reload shouldn't happen if length clock and write happen simultaneously
 			// I'm not sure if we can avoid this by simply processing the sequencer first

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
@@ -13,7 +13,6 @@
 using System.Runtime.CompilerServices;
 using BizHawk.Common;
 using BizHawk.Common.NumberExtensions;
-using Jellyfish.Virtu;
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
@@ -13,6 +13,7 @@
 using System.Runtime.CompilerServices;
 using BizHawk.Common;
 using BizHawk.Common.NumberExtensions;
+using Jellyfish.Virtu;
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
@@ -1030,6 +1031,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		public void RunDMCFetch()
 		{
 			dmc.Fetch();
+		}
+
+		public void RunDMCHaltFetch()
+		{
+			nes.ReadMemory(nes.cpu.address_bus);
 		}
 
 		private readonly int[][] sequencer_lut = new int[2][];

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
@@ -1334,7 +1334,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 		public void RunOneLast()
 		{
-			if(dmc.timer % 2 == 1)
+			if (dmc.timer % 2 is 1)
 			{
 				// The controllers only get strobed when transitioning from a get cycle to a put cycle.
 				if (nes.joypadStrobed)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
@@ -1303,7 +1303,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 					{
 						byte ret = PeekReg(0x4015);
 						// Console.WriteLine("{0} {1,5} $4015 clear irq, was at {2}", nes.Frame, sequencer_counter, sequencer_irq);
-						sequencer_irq_flag = false;
+						sequencer_irq_clear_pending = true;
 						SyncIRQ();
 						return ret;
 					}
@@ -1334,13 +1334,22 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 		public void RunOneLast()
 		{
-			// The controllers only get strobed when transitioning from a get cyclte to a put cycle.
 			if(dmc.timer % 2 == 1)
 			{
-				if(nes.joypadStrobed)
+				// The controllers only get strobed when transitioning from a get cycle to a put cycle.
+				if (nes.joypadStrobed)
 				{
 					nes.joypadStrobed = false;
 					nes.strobe_joyport();
+				}
+			}
+			else
+			{
+				// The frame counter interrupt flag is only cleared when transitioning from a put cycle to a get cycle.
+				if (sequencer_irq_clear_pending)
+				{
+					sequencer_irq_clear_pending = false;
+					sequencer_irq_flag = false;
 				}
 			}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -621,7 +621,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 					else
 					{
 						// special hardware glitch case
-						if (dmc_dma_exec && ppu.region != PPU.Region.NTSC)
+						if (dmc_dma_exec && ppu.region is not PPU.Region.NTSC)
 						{
 							return DB;
 						}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -84,6 +84,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		public int old_s = 0;
 
 		public long double_controller_read = 0;
+		public ushort double_controller_read_address = 0;
 		public byte previous_controller1_read = 0;
 		public byte previous_controller2_read = 0;
 		public bool joypadStrobed;
@@ -803,7 +804,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			}
 			else
 			{
-				if (TotalExecutedCycles == double_controller_read)
+				if (TotalExecutedCycles == double_controller_read && addr == double_controller_read_address)
 				{
 					if (addr == 0x4016)
 					{
@@ -816,16 +817,18 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				}
 				else
 				{
-					ret = addr == 0x4016 ? ControllerDeck.ReadA(_controller) : ControllerDeck.ReadB(_controller);
 					if (addr == 0x4016)
 					{
-						previous_controller1_read = ret;
+						ret = ControllerDeck.ReadA(_controller);
+						previous_controller1_read = ret; // If the following CPU cycle is also reading from this controller port, read the same value without clocking the controller.
 					}
 					else
 					{
+						ret = ControllerDeck.ReadB(_controller);
 						previous_controller2_read = ret;
 					}
 				}
+				double_controller_read_address = (ushort) addr;
 				double_controller_read = TotalExecutedCycles + 1; // The shift register in the controller is only updated if the previous CPU cycle did not read from the controller port.
 			}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -783,7 +783,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			var si = new StrobeInfo(latched4016, joypadStrobeValue);
 			ControllerDeck.Strobe(si, _controller);
 			latched4016 = joypadStrobeValue;
-			new_strobe = (joypadStrobeValue & 1) > 0;
+			new_strobe = (joypadStrobeValue & 1) is not 0;
 			if (current_strobe && !new_strobe)
 			{
 				controller_was_latched = true;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -343,6 +343,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 					VS_coin_inserted &= 1;
 			}
 
+			cpu.ext_ppu_cycle=0; // Reset this value at the beginning of each frame
+
 			if (ppu.ppudead > 0)
 			{
 				while (ppu.ppudead > 0)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -777,7 +777,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 		public void strobe_joyport()
 		{
-			// The controllers only get strobed when transitioning from a get cyclte to a put cycle.
+			// The controllers only get strobed when transitioning from a get cycle to a put cycle.
 
 			//Console.WriteLine("cont " + value + " frame " + Frame);
 			var si = new StrobeInfo(latched4016, joypadStrobeValue);

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -343,7 +343,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 					VS_coin_inserted &= 1;
 			}
 
-			cpu.ext_ppu_cycle=0; // Reset this value at the beginning of each frame
+			cpu.ext_ppu_cycle = 0; // Reset this value at the beginning of each frame
 
 			if (ppu.ppudead > 0)
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IStatable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IStatable.cs
@@ -28,13 +28,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			ser.Sync(nameof(oam_dma_byte), ref oam_dma_byte);
 			ser.Sync(nameof(dmc_dma_exec), ref dmc_dma_exec);
 			ser.Sync(nameof(dmc_realign), ref dmc_realign);
-			ser.Sync(nameof(reread_trigger), ref reread_trigger);
-			ser.Sync(nameof(do_the_reread_2002), ref do_the_reread_2002);
-			ser.Sync(nameof(do_the_reread_2007), ref do_the_reread_2007);
-			ser.Sync(nameof(do_the_reread_cont_1), ref do_the_reread_cont_1);
-			ser.Sync(nameof(do_the_reread_cont_2), ref do_the_reread_cont_2);
-			ser.Sync(nameof(reread_opp_4016), ref reread_opp_4016);
-			ser.Sync(nameof(reread_opp_4017), ref reread_opp_4017);
 
 			// VS related
 			ser.Sync("VS", ref _isVS);

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.cs
@@ -438,6 +438,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				nes.Board.ClockPpu();
 			}
 			_totalCycles += 1;
+			nes.cpu.ext_ppu_cycle += 1;
 		}
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.cs
@@ -258,7 +258,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			ser.Sync("Spr_zero_in_Range", ref sprite_zero_in_range);
 			ser.Sync(nameof(is_even_cycle), ref is_even_cycle);
 			ser.Sync(nameof(soam_index), ref soam_index);
-			ser.Sync(nameof(soam_m_index), ref soam_m_index);
 			ser.Sync(nameof(oam_index), ref oam_index);
 			ser.Sync(nameof(oam_index_aux), ref oam_index_aux);
 			ser.Sync(nameof(soam_index_aux), ref soam_index_aux);

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.regs.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.regs.cs
@@ -430,6 +430,9 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				{
 					// glitchy increment of OAM index
 					oam_index += 4;
+					oam_index &= 0x1FC;
+					reg_2003 += 4;
+					reg_2003 &= 0xFC;
 				}
 				else
 				{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.regs.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.regs.cs
@@ -8,6 +8,7 @@
 
 using System.Runtime.CompilerServices;
 using BizHawk.Common;
+using Jellyfish.Virtu;
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
@@ -344,24 +345,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		private byte read_2002()
 		{
 			byte ret = peek_2002();
-			/*
-			if (nes.do_the_reread_2002 > 0)
-			{
-				if (Reg2002_vblank_active || Reg2002_vblank_active_pending)
-					Console.WriteLine("reread 2002");
-			}
-			*/
 
 			// reading from $2002 resets the destination for $2005 and $2006 writes
 			vtoggle = false;
 			Reg2002_vblank_active = 0;
 			Reg2002_vblank_active_pending = false;
-
-			if (nes.do_the_reread_2002 > 0)
-			{
-				ret = peek_2002();
-				// could be another reread, but no other side effects, so don't bother
-			}
 
 			// update the open bus here
 			ppu_open_bus = ret;
@@ -681,7 +669,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				case 6: return read_2006();
 				case 7:
 					{
-						if (nes.cpu.TotalExecutedCycles == double_2007_read)
+						if (nes.cpu.TotalExecutedCycles == double_2007_read && !nes.dmc_dma_exec)
 						{
 							return ppu_open_bus;
 						}
@@ -689,13 +677,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 						{
 							ret_spec = read_2007();
 							double_2007_read = nes.cpu.TotalExecutedCycles + 1;
-						}
-
-						if (nes.do_the_reread_2007 > 0)
-						{
-							ret_spec = read_2007();
-							ret_spec = read_2007();
-							// always 2?
 						}
 						return ret_spec;
 					}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.regs.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.regs.cs
@@ -8,7 +8,6 @@
 
 using System.Runtime.CompilerServices;
 using BizHawk.Common;
-using Jellyfish.Virtu;
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.IEmulator.cs
@@ -111,6 +111,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubNESHawk
 
 		private void DoFrame(IController controller)
 		{
+			_nesCore.cpu.ext_ppu_cycle = 0; // Reset this value at the beginning of each frame
 			stop_cur_frame = false;
 			while (!stop_cur_frame)
 			{
@@ -121,7 +122,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubNESHawk
 				}
 				_nesCore.do_single_step(controller, out pass_new_input, out pass_a_frame);
 				current_cycle++;
-				_nesCore.cpu.ext_ppu_cycle = current_cycle;
 				stop_cur_frame |= pass_a_frame;
 				stop_cur_frame |= pass_new_input;
 			}


### PR DESCRIPTION
Opcodes $93, $9B, $9C, $9E, and $9F, also referred to as the "Unstable High Byte Group", all rely on the High Byte of the target address being incremented internally when the processor adds the X or Y register as an offset, and this new value of the high byte is ANDed with the value being stored.

In addition to adding the byte H, which is currently only updated in the relevant cycles for the Unstable High Byte Group instructions, I also added the private void AbsIdx_Stage4_SHS(), which is pretty much the same as AbsIdx_Stage4() but it updates H. I've removed some lines from the various AbsIdx_WRITE_Stage5 functions which were incorrectly modifying the target address "ea".

I also renamed AbsIdx_WRITE_Stage5_ERROR to AbsIdx_WRITE_Stage5_SHS

This should now match the behavior documented in the "No More Secrets" MOS 6510 Unintended Opcodes document. I have created [a test rom](https://github.com/100thCoin/AccuracyCoin/blob/main/AccuracyCoin.nes) for the purposes of verifying this behavior, and both my console and now NesHawk pass the test. It's worth noting that Blargg's accuracy tests that check for the unofficial opcodes don't actually check any of these except opcode $9E, and that test was written long before the research done for the "No More Secrets" document.

Here's how my test cartridge looks on my physical NES

![ConsoleResults](https://github.com/user-attachments/assets/84d6024b-2b2a-430d-89a1-b5ccb89a0952)

NesHawk before this change fails this test when checking the behavior of opcode $9F: (The error codes in this ROM are a work in progress, but that's what that "D" next to "FAIL" is indicating.) 

![Results_Before](https://github.com/user-attachments/assets/543780d3-099b-478c-ad98-ca3f0aa34233)

And after the change:

![Results_After](https://github.com/user-attachments/assets/2dad23b2-1204-4c15-9ce0-322d0242275e)