### PR TITLE
Make the number of frames per TAStudio rewind configurable.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
+++ b/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
@@ -34,8 +34,9 @@ namespace BizHawk.Client.EmuHawk
 
 		/// <remarks>only referenced from <see cref="LuaConsole"/></remarks>
 		bool IsTurboing { get; }
-		bool IsFastForwarding { get; }
 
+		/// <remarks>only referenced from <see cref="TAStudio"/></remarks>
+		bool IsFastForwarding { get; }
 
 		int? PauseOnFrame { get; set; }
 

--- a/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
+++ b/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
@@ -34,6 +34,8 @@ namespace BizHawk.Client.EmuHawk
 
 		/// <remarks>only referenced from <see cref="LuaConsole"/></remarks>
 		bool IsTurboing { get; }
+		bool IsFastForwarding { get; }
+
 
 		int? PauseOnFrame { get; set; }
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1100,6 +1100,7 @@ namespace BizHawk.Client.EmuHawk
 		public bool IsSeeking => PauseOnFrame.HasValue;
 		private bool IsTurboSeeking => PauseOnFrame.HasValue && Config.TurboSeek;
 		public bool IsTurboing => InputManager.ClientControls["Turbo"] || IsTurboSeeking;
+		public bool IsFastForwarding => InputManager.ClientControls["Fast Forward"] || IsTurboing || InvisibleEmulation;
 
 		/// <summary>
 		/// Used to disable secondary throttling (e.g. vsync, audio) for unthrottled modes or when the primary (clock) throttle is taking over (e.g. during fast forward/rewind).

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3102,7 +3102,8 @@ namespace BizHawk.Client.EmuHawk
 			// BlockFrameAdvance (true when input it being editted in TAStudio) supercedes all other frame advance conditions
 			if ((runFrame || force) && !BlockFrameAdvance)
 			{
-				var isFastForwardingOrRewinding = IsFastForwarding || isRewinding || Config.Unthrottled;
+				var isFastForwarding = IsFastForwarding;
+				var isFastForwardingOrRewinding = isFastForwarding || isRewinding || Config.Unthrottled;
 
 				if (isFastForwardingOrRewinding != _lastFastForwardingOrRewinding)
 				{
@@ -3228,7 +3229,7 @@ namespace BizHawk.Client.EmuHawk
 				{
 					_framesSinceLastFpsUpdate++;
 
-					CalcFramerateAndUpdateDisplay(currentTimestamp, isRewinding);
+					CalcFramerateAndUpdateDisplay(currentTimestamp, isRewinding, isFastForwarding);
 				}
 
 				if (IsSeeking && PauseOnFrame.Value <= Emulator.Frame)
@@ -3260,7 +3261,7 @@ namespace BizHawk.Client.EmuHawk
 			Sound.UpdateSound(atten, DisableSecondaryThrottling);
 		}
 
-		private void CalcFramerateAndUpdateDisplay(long currentTimestamp, bool isRewinding)
+		private void CalcFramerateAndUpdateDisplay(long currentTimestamp, bool isRewinding, bool isFastForwarding)
 		{
 			double elapsedSeconds = (currentTimestamp - _timestampLastFpsUpdate) / (double)Stopwatch.Frequency;
 
@@ -3285,11 +3286,11 @@ namespace BizHawk.Client.EmuHawk
 			var fpsString = $"{_lastFpsRounded} fps";
 			if (isRewinding)
 			{
-				fpsString += IsTurboing || IsFastForwarding ?
+				fpsString += IsTurboing || isFastForwarding ?
 					" <<<<" :
 					" <<";
 			}
-			else if (IsFastForwarding)
+			else if (isFastForwarding)
 			{
 				fpsString += IsTurboing ?
 					" >>>>" :

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3102,8 +3102,7 @@ namespace BizHawk.Client.EmuHawk
 			// BlockFrameAdvance (true when input it being editted in TAStudio) supercedes all other frame advance conditions
 			if ((runFrame || force) && !BlockFrameAdvance)
 			{
-				var isFastForwarding = InputManager.ClientControls["Fast Forward"] || IsTurboing || InvisibleEmulation;
-				var isFastForwardingOrRewinding = isFastForwarding || isRewinding || Config.Unthrottled;
+				var isFastForwardingOrRewinding = IsFastForwarding || isRewinding || Config.Unthrottled;
 
 				if (isFastForwardingOrRewinding != _lastFastForwardingOrRewinding)
 				{
@@ -3229,7 +3228,7 @@ namespace BizHawk.Client.EmuHawk
 				{
 					_framesSinceLastFpsUpdate++;
 
-					CalcFramerateAndUpdateDisplay(currentTimestamp, isRewinding, isFastForwarding);
+					CalcFramerateAndUpdateDisplay(currentTimestamp, isRewinding);
 				}
 
 				if (IsSeeking && PauseOnFrame.Value <= Emulator.Frame)
@@ -3261,7 +3260,7 @@ namespace BizHawk.Client.EmuHawk
 			Sound.UpdateSound(atten, DisableSecondaryThrottling);
 		}
 
-		private void CalcFramerateAndUpdateDisplay(long currentTimestamp, bool isRewinding, bool isFastForwarding)
+		private void CalcFramerateAndUpdateDisplay(long currentTimestamp, bool isRewinding)
 		{
 			double elapsedSeconds = (currentTimestamp - _timestampLastFpsUpdate) / (double)Stopwatch.Frequency;
 
@@ -3286,11 +3285,11 @@ namespace BizHawk.Client.EmuHawk
 			var fpsString = $"{_lastFpsRounded} fps";
 			if (isRewinding)
 			{
-				fpsString += IsTurboing || isFastForwarding ?
+				fpsString += IsTurboing || IsFastForwarding ?
 					" <<<<" :
 					" <<";
 			}
-			else if (isFastForwarding)
+			else if (IsFastForwarding)
 			{
 				fpsString += IsTurboing ?
 					" >>>>" :

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
@@ -81,7 +81,7 @@ namespace BizHawk.Client.EmuHawk
 			this.StateHistoryIntegrityCheckMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SetMaxUndoLevelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.setFastFramesPerRewindMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SetRewindStepFastMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CopyIncludesFrameNoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator26 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.autosaveToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -191,7 +191,7 @@ namespace BizHawk.Client.EmuHawk
 			this.BranchesMarkersSplit = new System.Windows.Forms.SplitContainer();
 			this.MainVertialSplit = new System.Windows.Forms.SplitContainer();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-			this.setFramesPerRewindMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SetRewindStepMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.TASMenu.SuspendLayout();
 			this.TasStatusStrip.SuspendLayout();
 			this.RightClickMenu.SuspendLayout();
@@ -478,8 +478,8 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.SetMaxUndoLevelsMenuItem,
-			this.setFramesPerRewindMenuItem,
-			this.setFastFramesPerRewindMenuItem,
+			this.SetRewindStepMenuItem,
+			this.SetRewindStepFastMenuItem,
             this.CopyIncludesFrameNoMenuItem,
             this.toolStripSeparator26,
             this.autosaveToolStripMenuItem,
@@ -507,10 +507,10 @@ namespace BizHawk.Client.EmuHawk
 			this.SetMaxUndoLevelsMenuItem.Text = "Set max Undo Levels";
 			this.SetMaxUndoLevelsMenuItem.Click += new System.EventHandler(this.SetMaxUndoLevelsMenuItem_Click);
 			// 
-			// setFastFramesPerRewindMenuItem
+			// SetRewindStepFastMenuItem
 			// 
-			this.setFastFramesPerRewindMenuItem.Text = "Set Frames per Fast-Forward Rewind";
-			this.setFastFramesPerRewindMenuItem.Click += new System.EventHandler(this.SetFastFramesPerRewindMenuItem_Click);
+			this.SetRewindStepFastMenuItem.Text = "Set Fast-Forward Rewind Step";
+			this.SetRewindStepFastMenuItem.Click += new System.EventHandler(this.SetRewindStepFastMenuItem_Click);
 			// 
 			// CopyIncludesFrameNoMenuItem
 			// 
@@ -1161,10 +1161,10 @@ namespace BizHawk.Client.EmuHawk
 			this.MainVertialSplit.TabIndex = 10;
 			this.MainVertialSplit.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.MainVerticalSplit_SplitterMoved);
 			// 
-			// setFramesPerRewindMenuItem
+			// SetRewindStepMenuItem
 			// 
-			this.setFramesPerRewindMenuItem.Text = "Set Frames per Rewind";
-			this.setFramesPerRewindMenuItem.Click += new System.EventHandler(this.SetFramesPerRewindMenuItem_Click);
+			this.SetRewindStepMenuItem.Text = "Set Rewind Step";
+			this.SetRewindStepMenuItem.Click += new System.EventHandler(this.SetRewindStepMenuItem_Click);
 			// 
 			// TAStudio
 			// 
@@ -1363,7 +1363,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetFontMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyIncludesFrameNoMenuItem;
 		private System.Windows.Forms.ToolTip toolTip1;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx setFastFramesPerRewindMenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx setFramesPerRewindMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetRewindStepFastMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetRewindStepMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
@@ -478,8 +478,8 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.SetMaxUndoLevelsMenuItem,
-			this.SetRewindStepMenuItem,
-			this.SetRewindStepFastMenuItem,
+            this.SetRewindStepMenuItem,
+            this.SetRewindStepFastMenuItem,
             this.CopyIncludesFrameNoMenuItem,
             this.toolStripSeparator26,
             this.autosaveToolStripMenuItem,

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
@@ -81,6 +81,7 @@ namespace BizHawk.Client.EmuHawk
 			this.StateHistoryIntegrityCheckMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SetMaxUndoLevelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.setFastFramesPerRewindMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CopyIncludesFrameNoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator26 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.autosaveToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -190,6 +191,7 @@ namespace BizHawk.Client.EmuHawk
 			this.BranchesMarkersSplit = new System.Windows.Forms.SplitContainer();
 			this.MainVertialSplit = new System.Windows.Forms.SplitContainer();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+			this.setFramesPerRewindMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.TASMenu.SuspendLayout();
 			this.TasStatusStrip.SuspendLayout();
 			this.RightClickMenu.SuspendLayout();
@@ -476,6 +478,8 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.SetMaxUndoLevelsMenuItem,
+			this.setFramesPerRewindMenuItem,
+			this.setFastFramesPerRewindMenuItem,
             this.CopyIncludesFrameNoMenuItem,
             this.toolStripSeparator26,
             this.autosaveToolStripMenuItem,
@@ -502,6 +506,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SetMaxUndoLevelsMenuItem.Text = "Set max Undo Levels";
 			this.SetMaxUndoLevelsMenuItem.Click += new System.EventHandler(this.SetMaxUndoLevelsMenuItem_Click);
+			// 
+			// setFastFramesPerRewindMenuItem
+			// 
+			this.setFastFramesPerRewindMenuItem.Text = "Set Frames per Fast-Forward Rewind";
+			this.setFastFramesPerRewindMenuItem.Click += new System.EventHandler(this.SetFastFramesPerRewindMenuItem_Click);
 			// 
 			// CopyIncludesFrameNoMenuItem
 			// 
@@ -917,7 +926,7 @@ namespace BizHawk.Client.EmuHawk
 			// MessageStatusLabel
 			// 
 			this.MessageStatusLabel.Name = "MessageStatusLabel";
-			this.MessageStatusLabel.Size = new System.Drawing.Size(103, 17);
+			this.MessageStatusLabel.Size = new System.Drawing.Size(104, 17);
 			this.MessageStatusLabel.Text = "TAStudio engaged";
 			// 
 			// ProgressBar
@@ -928,7 +937,7 @@ namespace BizHawk.Client.EmuHawk
 			// toolStripStatusLabel2
 			// 
 			this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
-			this.toolStripStatusLabel2.Size = new System.Drawing.Size(269, 17);
+			this.toolStripStatusLabel2.Size = new System.Drawing.Size(268, 17);
 			this.toolStripStatusLabel2.Spring = true;
 			// 
 			// SplicerStatusLabel
@@ -1152,6 +1161,11 @@ namespace BizHawk.Client.EmuHawk
 			this.MainVertialSplit.TabIndex = 10;
 			this.MainVertialSplit.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.MainVerticalSplit_SplitterMoved);
 			// 
+			// setFramesPerRewindMenuItem
+			// 
+			this.setFramesPerRewindMenuItem.Text = "Set Frames per Rewind";
+			this.setFramesPerRewindMenuItem.Click += new System.EventHandler(this.SetFramesPerRewindMenuItem_Click);
+			// 
 			// TAStudio
 			// 
 			this.AllowDrop = true;
@@ -1349,5 +1363,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetFontMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyIncludesFrameNoMenuItem;
 		private System.Windows.Forms.ToolTip toolTip1;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx setFastFramesPerRewindMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx setFramesPerRewindMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
@@ -926,7 +926,7 @@ namespace BizHawk.Client.EmuHawk
 			// MessageStatusLabel
 			// 
 			this.MessageStatusLabel.Name = "MessageStatusLabel";
-			this.MessageStatusLabel.Size = new System.Drawing.Size(104, 17);
+			this.MessageStatusLabel.Size = new System.Drawing.Size(103, 17);
 			this.MessageStatusLabel.Text = "TAStudio engaged";
 			// 
 			// ProgressBar
@@ -937,7 +937,7 @@ namespace BizHawk.Client.EmuHawk
 			// toolStripStatusLabel2
 			// 
 			this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
-			this.toolStripStatusLabel2.Size = new System.Drawing.Size(268, 17);
+			this.toolStripStatusLabel2.Size = new System.Drawing.Size(269, 17);
 			this.toolStripStatusLabel2.Spring = true;
 			// 
 			// SplicerStatusLabel

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
@@ -77,18 +77,18 @@
 
 		public bool Rewind()
 		{
-			int framesPerRewind = MainForm.IsFastForwarding ? Settings.FastFramesPerRewind : Settings.FramesPerRewind;
+			int rewindStep = MainForm.IsFastForwarding ? Settings.RewindStepFast : Settings.RewindStep;
 			// copy pasted from TasView_MouseWheel(), just without notch logic
 			if (MainForm.IsSeeking && !MainForm.EmulatorPaused)
 			{
-				MainForm.PauseOnFrame -= framesPerRewind;
+				MainForm.PauseOnFrame -= rewindStep;
 
 				// that's a weird condition here, but for whatever reason it works best
 				if (Emulator.Frame >= MainForm.PauseOnFrame)
 				{
 					MainForm.PauseEmulator();
 					StopSeeking();
-					GoToFrame(Math.Max(0, Emulator.Frame - framesPerRewind));
+					GoToFrame(Math.Max(0, Emulator.Frame - rewindStep));
 				}
 
 				RefreshDialog();
@@ -96,7 +96,7 @@
 			else
 			{
 				StopSeeking(); // late breaking memo: don't know whether this is needed
-				GoToFrame(Math.Max(0, Emulator.Frame - framesPerRewind));
+				GoToFrame(Math.Max(0, Emulator.Frame - rewindStep));
 			}
 
 			return true;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
@@ -77,17 +77,18 @@
 
 		public bool Rewind()
 		{
+			int framesPerRewind = MainForm.IsFastForwarding ? Settings.FastFramesPerRewind : Settings.FramesPerRewind;
 			// copy pasted from TasView_MouseWheel(), just without notch logic
 			if (MainForm.IsSeeking && !MainForm.EmulatorPaused)
 			{
-				MainForm.PauseOnFrame--;
+				MainForm.PauseOnFrame -= framesPerRewind;
 
 				// that's a weird condition here, but for whatever reason it works best
 				if (Emulator.Frame >= MainForm.PauseOnFrame)
 				{
 					MainForm.PauseEmulator();
 					StopSeeking();
-					GoToPreviousFrame();
+					GoToFrame(Math.Max(0, Emulator.Frame - framesPerRewind));
 				}
 
 				RefreshDialog();
@@ -95,7 +96,7 @@
 			else
 			{
 				StopSeeking(); // late breaking memo: don't know whether this is needed
-				GoToPreviousFrame();
+				GoToFrame(Math.Max(0, Emulator.Frame - framesPerRewind));
 			}
 
 			return true;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -798,13 +798,13 @@ namespace BizHawk.Client.EmuHawk
 				}
 			}
 		}
-		private void SetFastFramesPerRewindMenuItem_Click(object sender, EventArgs e)
+		private void SetRewindStepFastMenuItem_Click(object sender, EventArgs e)
 		{
 			using var prompt = new InputPrompt
 			{
 				TextInputType = InputPrompt.InputType.Unsigned,
 				Message = "Number of frames to go back\nwhen pressing the rewind key\nwhile fast-forwarding:",
-				InitialValue = Settings.FastFramesPerRewind.ToString(),
+				InitialValue = Settings.RewindStepFast.ToString(),
 			};
 
 			var result = MainForm.DoWithTempMute(() => prompt.ShowDialogOnScreen());
@@ -822,18 +822,18 @@ namespace BizHawk.Client.EmuHawk
 
 				if (val > 0)
 				{
-					Settings.FastFramesPerRewind = val;
+					Settings.RewindStepFast = val;
 				}
 			}
 		}
 
-		private void SetFramesPerRewindMenuItem_Click(object sender, EventArgs e)
+		private void SetRewindStepMenuItem_Click(object sender, EventArgs e)
 		{
 			using var prompt = new InputPrompt
 			{
 				TextInputType = InputPrompt.InputType.Unsigned,
 				Message = "Number of frames to go back\nwhen pressing the rewind key:",
-				InitialValue = Settings.FramesPerRewind.ToString(),
+				InitialValue = Settings.RewindStep.ToString(),
 			};
 
 			var result = MainForm.DoWithTempMute(() => prompt.ShowDialogOnScreen());
@@ -851,7 +851,7 @@ namespace BizHawk.Client.EmuHawk
 
 				if (val > 0)
 				{
-					Settings.FramesPerRewind = val;
+					Settings.RewindStep = val;
 				}
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -798,6 +798,63 @@ namespace BizHawk.Client.EmuHawk
 				}
 			}
 		}
+		private void SetFastFramesPerRewindMenuItem_Click(object sender, EventArgs e)
+		{
+			using var prompt = new InputPrompt
+			{
+				TextInputType = InputPrompt.InputType.Unsigned,
+				Message = "Number of frames to go back\nwhen pressing the rewind key\nwhile fast-forwarding:",
+				InitialValue = Settings.FastFramesPerRewind.ToString(),
+			};
+
+			var result = MainForm.DoWithTempMute(() => prompt.ShowDialogOnScreen());
+			if (result.IsOk())
+			{
+				int val = 0;
+				try
+				{
+					val = int.Parse(prompt.PromptText);
+				}
+				catch
+				{
+					DialogController.ShowMessageBox("Invalid Entry.", "Input Error", EMsgBoxIcon.Error);
+				}
+
+				if (val > 0)
+				{
+					Settings.FastFramesPerRewind = val;
+				}
+			}
+		}
+
+		private void SetFramesPerRewindMenuItem_Click(object sender, EventArgs e)
+		{
+			using var prompt = new InputPrompt
+			{
+				TextInputType = InputPrompt.InputType.Unsigned,
+				Message = "Number of frames to go back\nwhen pressing the rewind key:",
+				InitialValue = Settings.FramesPerRewind.ToString(),
+			};
+
+			var result = MainForm.DoWithTempMute(() => prompt.ShowDialogOnScreen());
+			if (result.IsOk())
+			{
+				int val = 0;
+				try
+				{
+					val = int.Parse(prompt.PromptText);
+				}
+				catch
+				{
+					DialogController.ShowMessageBox("Invalid Entry.", "Input Error", EMsgBoxIcon.Error);
+				}
+
+				if (val > 0)
+				{
+					Settings.FramesPerRewind = val;
+				}
+			}
+		}
 
 		private void CopyIncludesFrameNoMenuItem_Click(object sender, EventArgs e)
 			=> Settings.CopyIncludesFrameNo = !Settings.CopyIncludesFrameNo;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -808,22 +808,24 @@ namespace BizHawk.Client.EmuHawk
 			};
 
 			var result = MainForm.DoWithTempMute(() => prompt.ShowDialogOnScreen());
-			if (result.IsOk())
+			if (!result.IsOk())
 			{
-				int val = 0;
-				try
-				{
-					val = int.Parse(prompt.PromptText);
-				}
-				catch
-				{
-					DialogController.ShowMessageBox("Invalid Entry.", "Input Error", EMsgBoxIcon.Error);
-				}
+				return;
+			}
 
-				if (val > 0)
-				{
-					Settings.RewindStepFast = val;
-				}
+			int val = 0;
+			try
+			{
+				val = int.Parse(prompt.PromptText);
+			}
+			catch
+			{
+				DialogController.ShowMessageBox("Invalid Entry.", "Input Error", EMsgBoxIcon.Error);
+			}
+
+			if (val > 0)
+			{
+				Settings.RewindStepFast = val;
 			}
 		}
 
@@ -837,22 +839,24 @@ namespace BizHawk.Client.EmuHawk
 			};
 
 			var result = MainForm.DoWithTempMute(() => prompt.ShowDialogOnScreen());
-			if (result.IsOk())
+			if (!result.IsOk())
 			{
-				int val = 0;
-				try
-				{
-					val = int.Parse(prompt.PromptText);
-				}
-				catch
-				{
-					DialogController.ShowMessageBox("Invalid Entry.", "Input Error", EMsgBoxIcon.Error);
-				}
+				return;
+			}
 
-				if (val > 0)
-				{
-					Settings.RewindStep = val;
-				}
+			int val = 0;
+			try
+			{
+				val = int.Parse(prompt.PromptText);
+			}
+			catch
+			{
+				DialogController.ShowMessageBox("Invalid Entry.", "Input Error", EMsgBoxIcon.Error);
+			}
+
+			if (val > 0)
+			{
+				Settings.RewindStep = val;
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -114,6 +114,8 @@ namespace BizHawk.Client.EmuHawk
 			public bool AutoadjustInput { get; set; }
 			public TAStudioPalette Palette { get; set; }
 			public int MaxUndoSteps { get; set; } = 1000;
+			public int FramesPerRewind { get; set; } = 1;
+			public int FastFramesPerRewind { get; set; } = 4;
 		}
 
 		public TAStudio()

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -114,8 +114,8 @@ namespace BizHawk.Client.EmuHawk
 			public bool AutoadjustInput { get; set; }
 			public TAStudioPalette Palette { get; set; }
 			public int MaxUndoSteps { get; set; } = 1000;
-			public int FramesPerRewind { get; set; } = 1;
-			public int FastFramesPerRewind { get; set; } = 4;
+			public int RewindStep { get; set; } = 1;
+			public int RewindStepFast { get; set; } = 4;
 		}
 
 		public TAStudio()


### PR DESCRIPTION
Currently, rewinds in TAStudio always go back exactly 1 frame.

This patch adds the following features to TAStudio:
- Rewinds now go back a X frames.
- While fast-forwarding, rewinds instead go back Y frames.
- X and Y are configurable. The default values are X=1 and Y=4.

## Why add these features?

Broadly speaking, there are 3 ways of tasing in Bizhawk. This patch only affects (2).

1) use saves states and rewinds, but not TAStudio (aka the piano roll).
2) use TAStudio keyboard only and navigate with the frame advance and rewind keys.
3) use TAStudio with a mouse and paint inputs on the piano roll.

Each of these has advantages and disadvantages. From my experience: (2) is more versatile than (1), since you can go back and edit inputs; and (2) is faster than (3) when playing a section for the first time, since you can use all ten fingers to input multiple buttons at once.

Currently, pressing the rewind key while TAStudio is open goes back exactly 1 frame.
Hence, if you need to go back 5 frames, you need to press rewind 5 times (or move your hand from the keyboard to the mouse and back). This is slow and strains your hands. In addition, the rewinder outside of TAStudio supports "rewinds every X frames", so being forced into X=1 feels like a downgrade when switching from (1) to (2).

It is worth noting that you can still go back exactly 1 frame even if X, Y > 1: Simply frame advance X-1 times and then press rewind.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [X] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant

see also #2893