### PR TITLE
Add flake.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -174,9 +174,9 @@ in {
 		IDEs = {
 			kate = [ kate omnisharp-roslyn ];
 		};
-		shellHook = drv: ''
+		shellHook = isFlake: drv: ''
 			export BIZHAWKBUILD_HOME='${builtins.toString ./.}'
-			export BIZHAWK_HOME="$BIZHAWKBUILD_HOME/output/"
+			export BIZHAWK_HOME="${if isFlake then "$(pwd -P)" else "$BIZHAWKBUILD_HOME"}/output/"
 			ldLibPath='${lib.makeLibraryPath drv.buildInputs}' # for running tests
 			if [ -z "$LD_LIBRARY_PATH" ]; then
 				export LD_LIBRARY_PATH="$ldLibPath"

--- a/default.nix
+++ b/default.nix
@@ -150,9 +150,11 @@ in {
 			|| isVersionAtLeast "2.6" value.hawkSourceInfo.version))
 	];
 	latestVersionFrag = lib.head releaseFrags;
-	combined = pp // asmsFromReleaseArtifacts // releasesEmuHawkInstallables // {
-		inherit depsForHistoricalRelease populateHawkSourceInfo releaseTagSourceInfos;
-		inherit (emuhawk-local.assemblies) libretroCores;
+	combined = let
+		launchScriptsForLocalBuild = launchScriptsFor emuhawk-local.assemblies true;
+	in (pp // asmsFromReleaseArtifacts // releasesEmuHawkInstallables // {
+		inherit depsForHistoricalRelease populateHawkSourceInfo releaseTagSourceInfos launchScriptsForLocalBuild;
+		inherit (emuhawk-local.assemblies) libretroCores;		
 		bizhawkAssemblies = pp.buildAssembliesFor (fillTargetOSDifferences hawkSourceInfoDevBuild);
 		"bizhawkAssemblies-${latestVersionFrag}" = pp.buildAssembliesFor
 			(fillTargetOSDifferences releaseTagSourceInfos."info-${latestVersionFrag}");
@@ -172,8 +174,27 @@ in {
 		IDEs = {
 			kate = [ kate omnisharp-roslyn ];
 		};
-		launchScriptsForLocalBuild = launchScriptsFor emuhawk-local.assemblies true;
-	};
+		shellHook = drv: ''
+			export BIZHAWKBUILD_HOME='${builtins.toString ./.}'
+			export BIZHAWK_HOME="$BIZHAWKBUILD_HOME/output/"
+			ldLibPath='${lib.makeLibraryPath drv.buildInputs}' # for running tests
+			if [ -z "$LD_LIBRARY_PATH" ]; then
+				export LD_LIBRARY_PATH="$ldLibPath"
+			else
+				export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$ldLibPath"
+			fi
+			alias discohawk-monort-local='${launchScriptsForLocalBuild.discohawk}'
+			alias emuhawk-monort-local='${launchScriptsForLocalBuild.emuhawk}'
+			case "$-" in *i*)
+				pfx="$(realpath --relative-to="$PWD" "$BIZHAWKBUILD_HOME")/"
+				if [ "$pfx" = "./" ]; then pfx=""; fi
+				printf "%s\n%s\n" \
+					"Run ''${pfx}Dist/Build{Debug,Release}.sh to build the solution. You may need to clean up with ''${pfx}Dist/CleanupBuildOutputDirs.sh." \
+					"Once built, running {discohawk,emuhawk}-monort-local will pull from ''${pfx}output/* and use Mono from Nixpkgs."
+				;;
+			esac
+		'';
+	});
 in combined // lib.listToAttrs (lib.concatLists (builtins.map
 	(f: [
 		{ name = f "latest-bin"; value = combined.${f "${latestVersionFrag}-bin"}; }

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735651292,
-        "narHash": "sha256-YLbzcBtYo1/FEzFsB3AnM16qFc6fWPMIoOuSoDwvg9g=",
+        "lastModified": 1717179513,
+        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0da3c44a9460a26d2025ec3ed2ec60a895eb1114",
+        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.05",
+        "ref": "24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735651292,
+        "narHash": "sha256-YLbzcBtYo1/FEzFsB3AnM16qFc6fWPMIoOuSoDwvg9g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0da3c44a9460a26d2025ec3ed2ec60a895eb1114",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -44,13 +44,5 @@
           default = self.devShells.${system}.emuhawk-latest;
         }
       ) nixpkgsFor;
-      overlays.default =
-        final: prev:
-        # filter derivations to only include `emuhawk` and `discohawk` ones (i.e. excluding `bizhawkAssemblies`)
-        std.filterAttrs (name: pkg: (std.hasPrefix "emuhawk" name) || (std.hasPrefix "discohawk" name)) (
-          # import `default.nix` with the overlayed package set
-          # (i don't know the circumstances under which `final` wouldn't have a `system` attribute, but we may as well account for it)
-          importDefaultDerivationsWith (final.system or "") final
-        );
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
         (std.filterAttrs (name: val: std.isDerivation val) (import ./default.nix { inherit system pkgs; }));
     in
     {
-      formatter = mapAttrs (system: pkgs: pkgs.nixfmt-rfc-style) nixpkgsFor;
       packages = mapAttrs (
         system: pkgs:
         (importDefaultDerivationsWith system pkgs)

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     let
       std = nixpkgs.lib;
       systems = [
-        # TODO :: can we build for aarch64-linux?
+        # this is currently the only supported system, according to https://github.com/TASEmulators/BizHawk/issues/1430#issue-396452488
         "x86_64-linux"
       ];
       nixpkgsFor = std.genAttrs systems (

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "EmuHawk is a multi-system emulator written in C#. As well as quality-of-life features for casual players, it also has recording/playback and debugging tools, making it the first choice for TASers (Tool-Assisted Speedrunners).";
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=24.05";
   };
   outputs =
     inputs@{ self, nixpkgs, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -20,8 +20,6 @@
           overlays = [ ];
         }
       );
-      # because for some reason the standard library doesn't include this (i think?)
-      startsWith = prefix: st: (substring 0 (stringLength prefix) st) == prefix;
       # import the derivations from default.nix for the given system & package set
       importDefaultDerivationsWith =
         system: pkgs:
@@ -50,7 +48,7 @@
       overlays.default =
         final: prev:
         # filter derivations to only include `emuhawk` and `discohawk` ones (i.e. excluding `bizhawkAssemblies`)
-        std.filterAttrs (name: pkg: (startsWith "emuhawk" name) || (startsWith "discohawk" name)) (
+        std.filterAttrs (name: pkg: (std.hasPrefix "emuhawk" name) || (std.hasPrefix "discohawk" name)) (
           # import `default.nix` with the overlayed package set
           # (i don't know the circumstances under which `prev` wouldn't have a `system` attribute, but we may as well account for it)
           importDefaultDerivationsWith (prev.system or "") prev
@@ -64,7 +62,7 @@
               type = "app";
               # this seems to be correct, but I'm not entirely sure
               program = "${pkg}/bin/${pkg.name}";
-            }) (std.filterAttrs (name: val: startsWith app name) pkgs);
+            }) (std.filterAttrs (name: val: std.hasPrefix app name) pkgs);
         in
         mapAttrs (
           system: pkgs:

--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,12 @@
     inputs@{ self, nixpkgs, ... }:
     with builtins;
     let
-      std = nixpkgs.lib;
+      inherit (nixpkgs) lib;
       systems = [
         # this is currently the only supported system, according to https://github.com/TASEmulators/BizHawk/issues/1430#issue-396452488
         "x86_64-linux"
       ];
-      nixpkgsFor = std.genAttrs systems (
+      nixpkgsFor = lib.genAttrs systems (
         system:
         import nixpkgs {
           localSystem = builtins.currentSystem or system;
@@ -24,7 +24,7 @@
       importDefaultDerivationsWith =
         system: pkgs:
         # ./default.nix outputs some non-derivation attributes, so we have to filter those out
-        (std.filterAttrs (name: val: std.isDerivation val) (import ./default.nix { inherit system pkgs; }));
+        (lib.filterAttrs (name: val: lib.isDerivation val) (import ./default.nix { inherit system pkgs; }));
     in
     {
       packages = mapAttrs (
@@ -37,8 +37,8 @@
       devShells = mapAttrs (
         system: pkgs:
         # ./shell.nix outputs some non-derivation attributes and some extraneous derivations, so we have to filter those out
-        (std.filterAttrs (
-          name: val: std.isDerivation val && name != "stdenv" && name != "out" && name != "inputDerivation"
+        (lib.filterAttrs (
+          name: val: lib.isDerivation val && name != "stdenv" && name != "out" && name != "inputDerivation"
         ) (import ./shell.nix { inherit system pkgs; }))
         // {
           default = self.devShells.${system}.emuhawk-latest;

--- a/flake.nix
+++ b/flake.nix
@@ -49,8 +49,8 @@
         # filter derivations to only include `emuhawk` and `discohawk` ones (i.e. excluding `bizhawkAssemblies`)
         std.filterAttrs (name: pkg: (std.hasPrefix "emuhawk" name) || (std.hasPrefix "discohawk" name)) (
           # import `default.nix` with the overlayed package set
-          # (i don't know the circumstances under which `prev` wouldn't have a `system` attribute, but we may as well account for it)
-          importDefaultDerivationsWith (prev.system or "") prev
+          # (i don't know the circumstances under which `final` wouldn't have a `system` attribute, but we may as well account for it)
+          importDefaultDerivationsWith (final.system or "") final
         );
       apps =
         let

--- a/flake.nix
+++ b/flake.nix
@@ -48,26 +48,16 @@
               inputsFrom = [ drv ];
               shellHook = avail.shellHook drv;
             };
-          shells = lib.pipe avail [
-            (lib.mapAttrs (
-              name: drv: if lib.hasPrefix "bizhawkAssemblies-" name then drv else drv.assemblies or null
-            ))
-            (lib.filterAttrs (_: drv: drv != null))
-            (lib.mapAttrs (
-              _: asms:
-              lib.traceIf (lib.hasSuffix "-bin" asms.name)
-                "the attr specified packages BizHawk from release artifacts; some builddeps may be missing from this shell"
-                mkShellCustom
-                asms
-            ))
-          ];
         in
-        (
-          shells
-          // {
-            default = self.devShells.${system}.emuhawk-latest;
-          }
-        )
+        {
+          bizhawkAssemblies-latest = mkShellCustom avail.bizhawkAssemblies-latest;
+          discohawk-latest = self.devShells.${system}.bizhawkAssemblies-latest;
+          emuhawk-latest = self.devShells.${system}.bizhawkAssemblies-latest;
+          default = pkgs.mkShell {
+            packages = [ avail.emuhawk.hawkSourceInfo.dotnet-sdk ];
+            inputsFrom = [ self.devShells.${system}.emuhawk-latest ];
+          };
+        }
       ) nixpkgsFor;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "BizHawk is a multi-system emulator written in C#. BizHawk provides nice features for casual gamers such as full screen, and joypad support in addition to full rerecording and debugging tools for all system cores.";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+  };
+  outputs =
+    inputs@{ self, nixpkgs, ... }:
+    with builtins;
+    let
+      std = nixpkgs.lib;
+      systems = [
+        # TODO :: can we build for aarch64-linux?
+        "x86_64-linux"
+      ];
+      nixpkgsFor = std.genAttrs systems (
+        system:
+        import nixpkgs {
+          localSystem = builtins.currentSystem or system;
+          crossSystem = system;
+          overlays = [ ];
+        }
+      );
+    in
+    {
+      formatter = mapAttrs (system: pkgs: pkgs.nixfmt-rfc-style) nixpkgsFor;
+      packages = mapAttrs (
+        system: pkgs:
+        # ./default.nix outputs some non-derivation attributes, so we have to filter those out
+        (std.filterAttrs (name: val: std.isDerivation val) (import ./default.nix { inherit system pkgs; }))
+        // {
+          default = self.packages.${system}.emuhawk-latest-bin;
+        }
+      ) nixpkgsFor;
+      devShells = mapAttrs (
+        system: pkgs:
+        # ./shell.nix outputs some non-derivation attributes and some extraneous derivations, so we have to filter those out
+        (std.filterAttrs (
+          name: val: std.isDerivation val && name != "stdenv" && name != "out" && name != "inputDerivation"
+        ) (import ./shell.nix { inherit system pkgs; }))
+        // {
+          default = self.devShells.${system}.emuhawk-latest;
+        }
+      ) nixpkgsFor;
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -52,26 +52,5 @@
           # (i don't know the circumstances under which `final` wouldn't have a `system` attribute, but we may as well account for it)
           importDefaultDerivationsWith (final.system or "") final
         );
-      apps =
-        let
-          toApps =
-            app: pkgs:
-            # filter packages to only include ones whose name starts with `app`, then map them to app definitions
-            mapAttrs (name: pkg: {
-              type = "app";
-              # this seems to be correct, but I'm not entirely sure
-              program = "${pkg}/bin/${pkg.name}";
-            }) (std.filterAttrs (name: val: std.hasPrefix app name) pkgs);
-        in
-        mapAttrs (
-          system: pkgs:
-          (
-            (toApps "emuhawk" pkgs)
-            // (toApps "discohawk" pkgs)
-            // {
-              default = self.apps.${system}.emuhawk-latest-bin;
-            }
-          )
-        ) self.packages;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,6 @@
           (
             (toApps "emuhawk" pkgs)
             // (toApps "discohawk" pkgs)
-            # TODO :: should `bizhawkAssemblies` be included here?
             // {
               default = self.apps.${system}.emuhawk-latest-bin;
             }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "BizHawk is a multi-system emulator written in C#. BizHawk provides nice features for casual gamers such as full screen, and joypad support in addition to full rerecording and debugging tools for all system cores.";
+  description = "EmuHawk is a multi-system emulator written in C#. As well as quality-of-life features for casual players, it also has recording/playback and debugging tools, making it the first choice for TASers (Tool-Assisted Speedrunners).";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
                 powershell
               ];
               inputsFrom = [ drv ];
-              shellHook = avail.shellHook drv;
+              shellHook = avail.shellHook true drv;
             };
         in
         {

--- a/shell.nix
+++ b/shell.nix
@@ -25,26 +25,7 @@
 			++ lib.optionals useVSCode [] #TODO https://devblogs.microsoft.com/dotnet/csharp-dev-kit-now-generally-available/ https://learn.microsoft.com/en-us/training/modules/implement-visual-studio-code-debugging-tools/
 			;
 		inputsFrom = [ drv ];
-		shellHook = ''
-			export BIZHAWKBUILD_HOME='${builtins.toString ./.}'
-			export BIZHAWK_HOME="$BIZHAWKBUILD_HOME/output/"
-			ldLibPath='${lib.makeLibraryPath drv.buildInputs}' # for running tests
-			if [ -z "$LD_LIBRARY_PATH" ]; then
-				export LD_LIBRARY_PATH="$ldLibPath"
-			else
-				export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$ldLibPath"
-			fi
-			alias discohawk-monort-local='${avail.launchScriptsForLocalBuild.discohawk}'
-			alias emuhawk-monort-local='${avail.launchScriptsForLocalBuild.emuhawk}'
-			case "$-" in *i*)
-				pfx="$(realpath --relative-to="$PWD" "$BIZHAWKBUILD_HOME")/"
-				if [ "$pfx" = "./" ]; then pfx=""; fi
-				printf "%s\n%s\n" \
-					"Run ''${pfx}Dist/Build{Debug,Release}.sh to build the solution. You may need to clean up with ''${pfx}Dist/CleanupBuildOutputDirs.sh." \
-					"Once built, running {discohawk,emuhawk}-monort-local will pull from ''${pfx}output/* and use Mono from Nixpkgs."
-				;;
-			esac
-		'';
+		shellHook = avail.shellHook drv;
 	};
 	shells = lib.pipe avail [
 		(lib.mapAttrs (name: drv: if lib.hasPrefix "bizhawkAssemblies-" name then drv else drv.assemblies or null))

--- a/shell.nix
+++ b/shell.nix
@@ -25,7 +25,7 @@
 			++ lib.optionals useVSCode [] #TODO https://devblogs.microsoft.com/dotnet/csharp-dev-kit-now-generally-available/ https://learn.microsoft.com/en-us/training/modules/implement-visual-studio-code-debugging-tools/
 			;
 		inputsFrom = [ drv ];
-		shellHook = avail.shellHook drv;
+		shellHook = avail.shellHook false drv;
 	};
 	shells = lib.pipe avail [
 		(lib.mapAttrs (name: drv: if lib.hasPrefix "bizhawkAssemblies-" name then drv else drv.assemblies or null))


### PR DESCRIPTION
Adds a `flake.nix` (and its attendant `flake.lock`), containing outputs for all of the packages and devshells output by `default.nix` and `shell.nix`, an overlay output, and an `apps` output (to make it possible to run emuhawk with just `nix run github:TASEmulators/BizHawk`).

Notes:
- ~~The flake description is just copied straight from the github repo short description~~
- I set the `nixpkgs` input to match the default already present in `default.nix`
- ~~I also set a formatter output (which tells `nix fmt` what formatter to use), which may or may not be desired~~
- The default package and app are `emuhawk-latest-bin`, and the default devshell is `emuhawk-latest`, because that made sense to me, but it could also make sense to have them all be `emuhawk-latest`
- ~~The `apps` output may not be completely correct -- it works for the default, but I haven't checked that the generated program path is accurate for all packages~~
- `nix flake show` acts weird if you don't set `--option allow-import-from-derivation true`

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [ ] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
