### PR TITLE
Fix clicking TAStudio column header with non-contiguous rows selected

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -390,18 +390,69 @@ namespace BizHawk.Client.EmuHawk
 						if (ModifierKeys != Keys.Alt)
 						{
 							// nifty taseditor logic
+							// your TAS Editor logic failed us (it didn't account for non-contiguous `SelectedRows`) --yoshi
 							var selection = TasView.SelectedRows.ToArray(); // sorted asc, length >= 1
 							bool allPressed = true;
-							foreach (var index in selection)
+							var contiguous = true;
+							var iSelection = 0;
+							var lastFrameIndexSeen = selection[iSelection] - 1;
+							while (iSelection < selection.Length)
 							{
+								var index = selection[iSelection];
+								if (index - lastFrameIndexSeen is not 1)
+								{
+									contiguous = false;
+									break;
+								}
+								lastFrameIndexSeen = index;
 								if (index == CurrentTasMovie.FrameCount // last movie frame can't have input, but can be selected
 									|| !CurrentTasMovie.BoolIsPressed(index, buttonName))
 								{
 									allPressed = false;
 									break;
 								}
+								iSelection++;
 							}
-							CurrentTasMovie.SetBoolStates(frame: selection[0], count: selection.Length, buttonName, val: !allPressed);
+							if (!allPressed)
+							{
+								// still need to check for discontinuity
+								while (iSelection < selection.Length)
+								{
+									var index = selection[iSelection];
+									if (index - lastFrameIndexSeen is not 1)
+									{
+										contiguous = false;
+										break;
+									}
+									lastFrameIndexSeen = index;
+									iSelection++;
+								}
+							}
+							else if (!contiguous)
+							{
+								// still need to check for `false` values
+								allPressed = allPressed && selection.Skip(iSelection - 1) // break'd before checking the next one, so less 1 (and can't get here if `iSelection` is 0 so that's safe)
+									.All(index => index < CurrentTasMovie.FrameCount // last movie frame can't have input, but can be selected
+										&& CurrentTasMovie.BoolIsPressed(index, buttonName));
+							}
+							// else all contiguous and all `true`
+
+							CurrentTasMovie.SetBoolStates(frame: selection[0], count: iSelection, buttonName, val: !allPressed);
+							var blockStart = iSelection;
+							lastFrameIndexSeen = selection[iSelection] - 1;
+							while (iSelection < selection.Length)
+							{
+								var index = selection[iSelection];
+								if (index - lastFrameIndexSeen is not 1)
+								{
+									// discontinuity; split off another block, and this is now the start of the next block
+									CurrentTasMovie.SetBoolStates(frame: selection[blockStart], count: iSelection - blockStart, buttonName, val: !allPressed);
+									blockStart = iSelection;
+								}
+								lastFrameIndexSeen = index;
+								iSelection++;
+							}
+							CurrentTasMovie.SetBoolStates(frame: selection[blockStart], count: iSelection - blockStart, buttonName, val: !allPressed);
 						}
 						else
 						{

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -371,6 +371,78 @@ namespace BizHawk.Client.EmuHawk
 			return (lag.Lagged.HasValue && lag.Lagged.Value) || (hideWasLag && lag.WasLagged.HasValue && lag.WasLagged.Value);
 		}
 
+		/// <param name="selection">
+		/// list of row indices sorted ascending, as returned by <c>TasView.SelectedRows</c>,
+		/// and must not be empty (so there must be a selection)
+		/// </param>
+		/// <remarks>fills with <see langword="false"/> (unheld) if held on all selected frames, <see langword="true"/> (held) otherwise</remarks>
+		private void ToggleButtonStateOnFrames(int[] selection, string buttonName)
+		{
+			// nifty taseditor logic
+			// your TAS Editor logic failed us (it didn't account for non-contiguous `SelectedRows`) --yoshi
+			bool allPressed = true;
+			var contiguous = true;
+			var iSelection = 0;
+			var lastFrameIndexSeen = selection[iSelection] - 1;
+			while (iSelection < selection.Length)
+			{
+				var index = selection[iSelection];
+				if (index - lastFrameIndexSeen is not 1)
+				{
+					contiguous = false;
+					break;
+				}
+				lastFrameIndexSeen = index;
+				if (index == CurrentTasMovie.FrameCount // last movie frame can't have input, but can be selected
+					|| !CurrentTasMovie.BoolIsPressed(index, buttonName))
+				{
+					allPressed = false;
+					break;
+				}
+				iSelection++;
+			}
+			if (!allPressed)
+			{
+				// still need to check for discontinuity
+				while (iSelection < selection.Length)
+				{
+					var index = selection[iSelection];
+					if (index - lastFrameIndexSeen is not 1)
+					{
+						contiguous = false;
+						break;
+					}
+					lastFrameIndexSeen = index;
+					iSelection++;
+				}
+			}
+			else if (!contiguous)
+			{
+				// still need to check for `false` values
+				allPressed = allPressed && selection.Skip(iSelection - 1) // break'd before checking the next one, so less 1 (and can't get here if `iSelection` is 0 so that's safe)
+					.All(index => index < CurrentTasMovie.FrameCount // last movie frame can't have input, but can be selected
+						&& CurrentTasMovie.BoolIsPressed(index, buttonName));
+			}
+			// else all contiguous and all `true`
+
+			CurrentTasMovie.SetBoolStates(frame: selection[0], count: iSelection, buttonName, val: !allPressed);
+			var blockStart = iSelection;
+			lastFrameIndexSeen = selection[iSelection] - 1;
+			while (iSelection < selection.Length)
+			{
+				var index = selection[iSelection];
+				if (index - lastFrameIndexSeen is not 1)
+				{
+					// discontinuity; split off another block, and this is now the start of the next block
+					CurrentTasMovie.SetBoolStates(frame: selection[blockStart], count: iSelection - blockStart, buttonName, val: !allPressed);
+					blockStart = iSelection;
+				}
+				lastFrameIndexSeen = index;
+				iSelection++;
+			}
+			CurrentTasMovie.SetBoolStates(frame: selection[blockStart], count: iSelection - blockStart, buttonName, val: !allPressed);
+		}
+
 		private void TasView_ColumnClick(object sender, InputRoll.ColumnClickEventArgs e)
 		{
 			if (TasView.AnyRowsSelected)
@@ -389,70 +461,7 @@ namespace BizHawk.Client.EmuHawk
 					{
 						if (ModifierKeys != Keys.Alt)
 						{
-							// nifty taseditor logic
-							// your TAS Editor logic failed us (it didn't account for non-contiguous `SelectedRows`) --yoshi
-							var selection = TasView.SelectedRows.ToArray(); // sorted asc, length >= 1
-							bool allPressed = true;
-							var contiguous = true;
-							var iSelection = 0;
-							var lastFrameIndexSeen = selection[iSelection] - 1;
-							while (iSelection < selection.Length)
-							{
-								var index = selection[iSelection];
-								if (index - lastFrameIndexSeen is not 1)
-								{
-									contiguous = false;
-									break;
-								}
-								lastFrameIndexSeen = index;
-								if (index == CurrentTasMovie.FrameCount // last movie frame can't have input, but can be selected
-									|| !CurrentTasMovie.BoolIsPressed(index, buttonName))
-								{
-									allPressed = false;
-									break;
-								}
-								iSelection++;
-							}
-							if (!allPressed)
-							{
-								// still need to check for discontinuity
-								while (iSelection < selection.Length)
-								{
-									var index = selection[iSelection];
-									if (index - lastFrameIndexSeen is not 1)
-									{
-										contiguous = false;
-										break;
-									}
-									lastFrameIndexSeen = index;
-									iSelection++;
-								}
-							}
-							else if (!contiguous)
-							{
-								// still need to check for `false` values
-								allPressed = allPressed && selection.Skip(iSelection - 1) // break'd before checking the next one, so less 1 (and can't get here if `iSelection` is 0 so that's safe)
-									.All(index => index < CurrentTasMovie.FrameCount // last movie frame can't have input, but can be selected
-										&& CurrentTasMovie.BoolIsPressed(index, buttonName));
-							}
-							// else all contiguous and all `true`
-
-							CurrentTasMovie.SetBoolStates(frame: selection[0], count: iSelection, buttonName, val: !allPressed);
-							var blockStart = iSelection;
-							lastFrameIndexSeen = selection[iSelection] - 1;
-							while (iSelection < selection.Length)
-							{
-								var index = selection[iSelection];
-								if (index - lastFrameIndexSeen is not 1)
-								{
-									// discontinuity; split off another block, and this is now the start of the next block
-									CurrentTasMovie.SetBoolStates(frame: selection[blockStart], count: iSelection - blockStart, buttonName, val: !allPressed);
-									blockStart = iSelection;
-								}
-								lastFrameIndexSeen = index;
-								iSelection++;
-							}
-							CurrentTasMovie.SetBoolStates(frame: selection[blockStart], count: iSelection - blockStart, buttonName, val: !allPressed);
+							ToggleButtonStateOnFrames(TasView.SelectedRows.ToArray(), buttonName);
 						}
 						else
 						{

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -383,7 +383,6 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else if (columnName != CursorColumnName)
 				{
-					var frame = TasView.AnyRowsSelected ? TasView.FirstSelectedRowIndex : 0;
 					var buttonName = TasView.CurrentCell.Column!.Name;
 
 					if (ControllerType.BoolButtons.Contains(buttonName))
@@ -391,8 +390,9 @@ namespace BizHawk.Client.EmuHawk
 						if (ModifierKeys != Keys.Alt)
 						{
 							// nifty taseditor logic
+							var selection = TasView.SelectedRows.ToArray(); // sorted asc, length >= 1
 							bool allPressed = true;
-							foreach (var index in TasView.SelectedRows)
+							foreach (var index in selection)
 							{
 								if (index == CurrentTasMovie.FrameCount // last movie frame can't have input, but can be selected
 									|| !CurrentTasMovie.BoolIsPressed(index, buttonName))
@@ -401,7 +401,7 @@ namespace BizHawk.Client.EmuHawk
 									break;
 								}
 							}
-							CurrentTasMovie.SetBoolStates(frame, TasView.SelectedRows.Count(), buttonName, !allPressed);
+							CurrentTasMovie.SetBoolStates(frame: selection[0], count: selection.Length, buttonName, val: !allPressed);
 						}
 						else
 						{


### PR DESCRIPTION
...and prepare for #1399. I just need to figure out where TAStudio would get called into when buttons are pressed, since that's normally handled via `InputManager` I believe.