### PR TITLE
Fix framebuffer when loading states/branches with OpenGL-supporting cores

### DIFF
--- a/src/BizHawk.Client.Common/savestates/SavestateFile.cs
+++ b/src/BizHawk.Client.Common/savestates/SavestateFile.cs
@@ -250,27 +250,9 @@ namespace BizHawk.Client.Common
 
 		private static void PopulateFramebuffer(BinaryReader br, IVideoProvider videoProvider)
 		{
-			try
+			using (new SimpleTime("Load Framebuffer"))
 			{
-				using (new SimpleTime("Load Framebuffer"))
-				{
-					QuickBmpFile.Load(videoProvider, br.BaseStream);
-				}
-			}
-			catch
-			{
-				var vb = videoProvider.GetVideoBuffer();
-				var vbLen = videoProvider.BufferWidth * videoProvider.BufferHeight;
-				try
-				{
-					for (var i = 0; i < vbLen; i++)
-					{
-						vb[i] = br.ReadInt32();
-					}
-				}
-				catch (EndOfStreamException)
-				{
-				}
+				QuickBmpFile.Load(videoProvider, br.BaseStream);
 			}
 		}
 	}

--- a/src/BizHawk.Client.Common/savestates/SavestateFile.cs
+++ b/src/BizHawk.Client.Common/savestates/SavestateFile.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 
 using BizHawk.Bizware.Graphics;
 using BizHawk.Common;
@@ -25,6 +24,7 @@ namespace BizHawk.Client.Common
 		private readonly IEmulator _emulator;
 		private readonly IStatable _statable;
 		private readonly IVideoProvider _videoProvider;
+		public IVideoProvider LoadedVideoProvider = null;
 		private readonly IMovieSession _movieSession;
 
 		private readonly SettingsAdapter _settable;
@@ -215,10 +215,8 @@ namespace BizHawk.Client.Common
 				}
 			}
 
-			if (_videoProvider != null)
-			{
-				bl.GetLump(BinaryStateLump.Framebuffer, false, br => PopulateFramebuffer(br, _videoProvider));
-			}
+
+			bl.GetLump(BinaryStateLump.Framebuffer, false, br => QuickBmpFile.LoadAuto(br.BaseStream, out LoadedVideoProvider));
 
 			string userData = "";
 			bl.GetLump(BinaryStateLump.UserData, abort: false, tr =>
@@ -246,14 +244,6 @@ namespace BizHawk.Client.Common
 			}
 
 			return true;
-		}
-
-		private static void PopulateFramebuffer(BinaryReader br, IVideoProvider videoProvider)
-		{
-			using (new SimpleTime("Load Framebuffer"))
-			{
-				QuickBmpFile.Load(videoProvider, br.BaseStream);
-			}
 		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
+++ b/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 using BizHawk.Bizware.Graphics;
 using BizHawk.Client.Common;
 using BizHawk.Emulation.Common;
@@ -63,6 +65,8 @@ namespace BizHawk.Client.EmuHawk
 
 		/// <remarks>only referenced from <see cref="BasicBot"/></remarks>
 		bool LoadQuickSave(int slot, bool suppressOSD = false);
+
+		void LoadState(BinaryReader coreData, IVideoProvider stateScreenshotProvider, string userFriendlyStateName);
 
 		/// <remarks>only referenced from <see cref="MultiDiskBundler"/></remarks>
 		bool LoadRom(string path, LoadRomArgs args);

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
@@ -1,4 +1,6 @@
-﻿using BizHawk.Client.Common;
+﻿using System.IO;
+
+using BizHawk.Client.Common;
 
 namespace BizHawk.Client.EmuHawk
 {
@@ -26,7 +28,7 @@ namespace BizHawk.Client.EmuHawk
 			var closestState = GetPriorStateForFramebuffer(frame);
 			if (frame < Emulator.Frame || closestState.Key > Emulator.Frame)
 			{
-				LoadState(closestState, true);
+				MainForm.LoadState(new BinaryReader(closestState.Value), null, $"frame {closestState.Key}");
 			}
 			closestState.Value.Dispose();
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -860,22 +860,6 @@ namespace BizHawk.Client.EmuHawk
 			return CurrentTasMovie.TasStateManager.GetStateClosestToFrame(frame > 0 ? frame - 1 : 0);
 		}
 
-		public void LoadState(KeyValuePair<int, Stream> state, bool discardApiHawkSurfaces = false)
-		{
-			StatableEmulator.LoadStateBinary(new BinaryReader(state.Value));
-
-			if (state.Key == 0 && CurrentTasMovie.StartsFromSavestate)
-			{
-				Emulator.ResetCounters();
-			}
-
-			UpdateTools();
-			if (discardApiHawkSurfaces)
-			{
-				DisplayManager.DiscardApiHawkSurfaces();
-			}
-		}
-
 		public void AddBranchExternal() => BookMarkControl.AddBranchExternal();
 		public void RemoveBranchExternal() => BookMarkControl.RemoveBranchExternal();
 
@@ -1146,10 +1130,12 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			CurrentTasMovie.LoadBranch(branch);
-			LoadState(new(branch.Frame, new MemoryStream(branch.CoreData, false)));
-
+			MainForm.LoadState(
+				new BinaryReader(new MemoryStream(branch.CoreData)),
+				new BitmapBufferVideoProvider(branch.CoreFrameBuffer),
+				$"branch {branch.UserText}"
+			);
 			CurrentTasMovie.TasStateManager.Capture(Emulator.Frame, Emulator.AsStatable());
-			QuickBmpFile.Copy(new BitmapBufferVideoProvider(branch.CoreFrameBuffer), VideoProvider);
 
 			if (Settings.OldControlSchemeForBranches && TasPlaybackBox.RecordingMode)
 			{


### PR DESCRIPTION
We used to load the framebuffer of savestates that had screenshots (including TAStudio branches) by copying (and potentially resizing) the image into the core's framebuffer. This does not work with the newer way for cores to provide video output (via OpenGL textures). This resulted in users seeing incorrect images after loading savestates on those cores.

This has been solved by creating a new, temporary IVideoProvider when loading states and using that instead of the core's IVideoProvider until the next frame advance.

Let me know if there are any potential issues with doing things this way. In particular, MainForm's new LoadStateCommon method does more things than TAStudio's branch loading did. I am not sure, but they seems like things that should happen. My Lua script that I regularly use appears to work correctly with this update, but I imagine there could be others that rely on the old behavior.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
