### PR TITLE
Don't save when the user says no.

### DIFF
--- a/src/BizHawk.Client.Common/movie/MovieSession.cs
+++ b/src/BizHawk.Client.Common/movie/MovieSession.cs
@@ -270,11 +270,12 @@ namespace BizHawk.Client.Common
 
 				message += "stopped.";
 
-				var result = Movie.Stop(saveChanges);
-				if (result)
+				if (saveChanges && Movie.Changes)
 				{
+					Movie.Save();
 					Output($"{Path.GetFileName(Movie.Filename)} written to disk.");
 				}
+				Movie.Stop();
 
 				Output(message);
 				ReadOnly = true;
@@ -390,7 +391,7 @@ namespace BizHawk.Client.Common
 			switch (Settings.MovieEndAction)
 			{
 				case MovieEndAction.Stop:
-					Movie.Stop();
+					StopMovie();
 					break;
 				case MovieEndAction.Record:
 					Movie.SwitchToRecord();

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.ModeApi.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.ModeApi.cs
@@ -20,23 +20,6 @@
 		public void SwitchToRecord() => Mode = MovieMode.Record;
 		public void SwitchToPlay() => Mode = MovieMode.Play;
 		public void FinishedMode() => Mode = MovieMode.Finished;
-
-		public virtual bool Stop(bool saveChanges = true)
-		{
-			bool saved = false;
-			if (saveChanges)
-			{
-				if (Mode == MovieMode.Record || (this.IsActive() && Changes))
-				{
-					Save();
-					saved = true;
-				}
-			}
-
-			Changes = false;
-			Mode = MovieMode.Inactive;
-
-			return saved;
-		}
+		public void Stop() =>  Mode = MovieMode.Inactive;
 	}
 }

--- a/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
+++ b/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
@@ -121,11 +121,8 @@ namespace BizHawk.Client.Common
 
 		/// <summary>
 		/// Sets the movie to inactive (note that it will still be in memory)
-		/// The saveChanges flag will tell the movie to save its contents to disk
 		/// </summary>
-		/// <param name="saveChanges">if true, will save to disk</param>
-		/// <returns>Whether or not the movie was saved</returns>
-		bool Stop(bool saveChanges = true);
+		void Stop();
 
 		/// <summary>
 		/// Switches to record mode


### PR DESCRIPTION
If the user closed a movie in TAStudio while in recording mode and clicked "no" when asked if they want to save, the movie would get saved anyway. The recording mode check doesn't seem to do any good; if the user has recorded anything (or truncated the movie by loading a savestate to enter recording mode) then `Changes` will be set. From looking at the commit history, the check for recording mode was implemented before recording itself was implemented. So it probably should never have been there to begin with.
Edit: To clarify, this bug only actually happens if you open a (new or existing) movie while in recording mode, and not if you close TAStudio.

It's unclear why there is also a check for `IsActive`. It probably isn't doing any harm, but it is confusing. Commit 06605346e0eaf3352cd9b562bd6968e130aac14c says
> Fix a nasty bug in bk2 and tasmovie that was saving a movie even if it was inactive

I have no idea how this bug would have been triggered, since a movie shouldn't be able to be changed while inactive. The only way to make a movie inactive seems to be to stop it, and stopping it (used to) clears the `Changes` flag. So it would have had to be modified after stopping, then stopped again... even though ever call is made only on the condition that the movie is active. (Similarly, it is unclear why the movie stop method cleared the changes flag.)

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
