### PR TITLE
Working examples for Lua functions emu.getregister and emu.setregister

### DIFF
--- a/src/BizHawk.Client.Common/lua/CommonLibs/EmulationLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/EmulationLuaLibrary.cs
@@ -47,7 +47,7 @@ namespace BizHawk.Client.Common
 		}
 
 		// TODO: what about 64 bit registers?
-		[LuaMethodExample("local inemuget = emu.getregister( emu.getregisters( )[ 0 ] );")]
+		[LuaMethodExample("local regname = next( emu.getregisters( ) ); -- an arbitrary register name\r\nlocal value = emu.getregister( regname );")]
 		[LuaMethod("getregister", "returns the value of a cpu register or flag specified by name. For a complete list of possible registers or flags for a given core, use getregisters")]
 		public int GetRegister(string name)
 			=> (int?) APIs.Emulation.GetRegister(name) ?? 0;
@@ -57,7 +57,7 @@ namespace BizHawk.Client.Common
 		public LuaTable GetRegisters()
 			=> _th.DictToTable(APIs.Emulation.GetRegisters());
 
-		[LuaMethodExample("emu.setregister( emu.getregisters( )[ 0 ], -1000 );")]
+		[LuaMethodExample("local regname = next( emu.getregisters( ) ); -- an arbitrary register name\r\nemu.setregister( regname, -1000 );")]
 		[LuaMethod("setregister", "sets the given register name to the given value")]
 		public void SetRegister(string register, int value)
 			=> APIs.Emulation.SetRegister(register, value);


### PR DESCRIPTION
The old examples were trying to use `emu.getregisters()[0]` to get an arbitrary register name for the current core. But `emu.getregisters()` returns a key–value table, not a sequential table, so it's not correct to index it with an integer. Even if it were a sequential table, the first element would be at index 1, not 0.

The new examples use the [Lua function `next`](https://www.lua.org/manual/5.4/manual.html#pdf-next) to get an arbitrary register name. They also replace the apparently autogenerated variable name `inemuget` with more meaningful ones (`regname` and `value`).

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [ ] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
