### PR TITLE
Add some hotkeys for markers, and display them in tool tips.

### DIFF
--- a/src/BizHawk.Client.Common/config/Binding.cs
+++ b/src/BizHawk.Client.Common/config/Binding.cs
@@ -137,6 +137,10 @@ namespace BizHawk.Client.Common
 			Bind("TAStudio", "Toggle Turbo Seek", "Shift+S");
 			Bind("TAStudio", "Undo", "Ctrl+Z"); // TODO: these are getting not unique enough
 			Bind("TAStudio", "Redo", "Ctrl+Y");
+			Bind("TAStudio", "Seek To Prev Marker", "Shift+PageUp");
+			Bind("TAStudio", "Seek To Next Marker", "Shift+PageDown");
+			Bind("TAStudio", "Set Marker", "M");
+			Bind("TAStudio", "Delete Marker", "Ctrl+M");
 			Bind("TAStudio", "Sel. bet. Markers", "Ctrl+A");
 			Bind("TAStudio", "Select All", "Ctrl+Shift+A");
 			Bind("TAStudio", "Reselect Clip.", "Ctrl+B");

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -755,6 +755,8 @@ namespace BizHawk.Client.EmuHawk
 
 			InitControls();
 			InputManager.SyncControls(Emulator, MovieSession, Config);
+
+			Tools.HandleHotkeyUpdate();
 		}
 
 		private void OpenFWConfigRomLoadFailed(RomLoader.RomErrorArgs args)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Hotkey.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Hotkey.cs
@@ -395,6 +395,22 @@ namespace BizHawk.Client.EmuHawk
 					if (!Tools.IsLoaded<TAStudio>()) return false;
 					Tools.TAStudio.RedoExternal();
 					break;
+				case "Seek To Prev Marker":
+					if (!Tools.IsLoaded<TAStudio>()) return false;
+					Tools.TAStudio.GoToPreviousMarker();
+					break;
+				case "Seek To Next Marker":
+					if (!Tools.IsLoaded<TAStudio>()) return false;
+					Tools.TAStudio.GoToNextMarker();
+					break;
+				case "Set Marker":
+					if (!Tools.IsLoaded<TAStudio>()) return false;
+					Tools.TAStudio.SetMarker();
+					break;
+				case "Delete Marker":
+					if (!Tools.IsLoaded<TAStudio>()) return false;
+					Tools.TAStudio.RemoveMarker();
+					break;
 				case "Sel. bet. Markers":
 					if (!Tools.IsLoaded<TAStudio>()) return false;
 					Tools.TAStudio.SelectBetweenMarkersExternal();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/MarkerControl.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/MarkerControl.cs
@@ -39,6 +39,12 @@ namespace BizHawk.Client.EmuHawk
 			MarkerView.QueryItemText += MarkerView_QueryItemText;
 		}
 
+		public void UpdateHotkeyTooltips(Config config)
+		{
+			toolTip1.SetToolTip(AddMarkerButton, $"Add Marker to Emulated Frame ({config.HotkeyBindings["Set Marker"]})");
+			toolTip1.SetToolTip(AddMarkerWithTextButton, $"Add Marker with Text to Emulated Frame ({config.HotkeyBindings["Set Marker"]} {config.HotkeyBindings["Set Marker"]})");
+		}
+
 		private void SetupColumns()
 		{
 			MarkerView.AllColumns.Clear();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/PlaybackBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/PlaybackBox.cs
@@ -62,6 +62,12 @@ namespace BizHawk.Client.EmuHawk
 			InitializeComponent();
 		}
 
+		public void UpdateHotkeyTooltips(Config config)
+		{
+			toolTip1.SetToolTip(NextMarkerButton, config.HotkeyBindings["Seek To Next Marker"]);
+			toolTip1.SetToolTip(PreviousMarkerButton, config.HotkeyBindings["Seek To Prev Marker"]);
+		}
+
 		protected override void OnLoad(EventArgs e)
 		{
 			base.OnLoad(e);

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -999,24 +999,40 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		public void SetMarker() => SetMarker(Emulator.Frame);
+
+		private void SetMarker(int frame)
+		{
+			TasMovieMarker/*?*/ existingMarker = CurrentTasMovie.Markers.FirstOrDefault(m => m.Frame == frame);
+
+			if (existingMarker != null)
+			{
+				MarkerControl.EditMarkerPopUp(existingMarker);
+			}
+			else
+			{
+				MarkerControl.AddMarker(frame);
+			}
+		}
+
+		public void RemoveMarker()
+		{
+			TasMovieMarker/*?*/ existingMarker = CurrentTasMovie.Markers.FirstOrDefault(m => m.Frame == Emulator.Frame);
+			if (existingMarker == null) return;
+
+			CurrentTasMovie. Markers.Remove(existingMarker);
+			MarkerControl.UpdateMarkerCount();
+		}
+
 		private void TasView_MouseDoubleClick(object sender, MouseEventArgs e)
 		{
 			if (TasView.CurrentCell?.Column is not { Name: var columnName }) return;
 
 			if (e.Button == MouseButtons.Left)
 			{
-				if (!AxisEditingMode && TasView.CurrentCell.RowIndex is not null && columnName is FrameColumnName)
+				if (!AxisEditingMode && columnName is FrameColumnName)
 				{
-					var existingMarker = CurrentTasMovie.Markers.FirstOrDefault(m => m.Frame == TasView.CurrentCell.RowIndex.Value);
-
-					if (existingMarker != null)
-					{
-						MarkerControl.EditMarkerPopUp(existingMarker);
-					}
-					else
-					{
-						MarkerControl.AddMarker(TasView.CurrentCell.RowIndex.Value);
-					}
+					SetMarker(TasView.CurrentCell.RowIndex.Value);
 				}
 			}
 		}
@@ -1469,15 +1485,7 @@ namespace BizHawk.Client.EmuHawk
 		private void TasView_KeyDown(object sender, KeyEventArgs e)
 		{
 			// taseditor uses Ctrl for selection and Shift for frame cursor
-			if (e.IsShift(Keys.PageUp))
-			{
-				GoToPreviousMarker();
-			}
-			else if (e.IsShift(Keys.PageDown))
-			{
-				GoToNextMarker();
-			}
-			else if (e.IsShift(Keys.Home))
+			if (e.IsShift(Keys.Home))
 			{
 				GoToFrame(0);
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -277,18 +277,6 @@ namespace BizHawk.Client.EmuHawk
 			GreenzoneICheckSeparator.Visible =
 				StateHistoryIntegrityCheckMenuItem.Visible =
 				VersionInfo.DeveloperBuild;
-
-			UndoMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Undo"];
-			RedoMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Redo"];
-			SelectBetweenMarkersMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Sel. bet. Markers"];
-			SelectAllMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Select All"];
-			ReselectClipboardMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Reselect Clip."];
-			ClearFramesMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clear Frames"];
-			DeleteFramesMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Delete Frames"];
-			InsertFrameMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Insert Frame"];
-			InsertNumFramesMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Insert # Frames"];
-			CloneFramesMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clone Frames"];
-			CloneFramesXTimesMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clone # Times"];
 		}
 
 		private void UndoMenuItem_Click(object sender, EventArgs e)
@@ -1327,14 +1315,6 @@ namespace BizHawk.Client.EmuHawk
 			RemoveMarkersContextMenuItem.Enabled = CurrentTasMovie.Markers.Any(m => TasView.IsRowSelected(m.Frame)); // Disable the option to remove markers if no markers are selected (FCEUX does this).
 			CancelSeekContextMenuItem.Enabled = _seekingTo != -1;
 			BranchContextMenuItem.Visible = TasView.CurrentCell?.RowIndex == Emulator.Frame;
-
-			SelectBetweenMarkersContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Sel. bet. Markers"];
-			ClearContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clear Frames"];
-			DeleteFramesContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Delete Frames"];
-			InsertFrameContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Insert Frame"];
-			InsertNumFramesContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Insert # Frames"];
-			CloneContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clone Frames"];
-			CloneXTimesContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clone # Times"];
 		}
 
 		private void CancelSeekContextMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -208,9 +208,37 @@ namespace BizHawk.Client.EmuHawk
 				Settings.BranchMarkerSplitDistance,
 				_defaultBranchMarkerSplitDistance);
 
+			HandleHotkeyUpdate();
+
 			TasView.Font = TasViewFont;
 			RefreshDialog();
 			_initialized = true;
+		}
+
+		public override void HandleHotkeyUpdate()
+		{
+			UndoMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Undo"];
+			RedoMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Redo"];
+			SelectBetweenMarkersMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Sel. bet. Markers"];
+			SelectAllMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Select All"];
+			ReselectClipboardMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Reselect Clip."];
+			ClearFramesMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clear Frames"];
+			DeleteFramesMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Delete Frames"];
+			InsertFrameMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Insert Frame"];
+			InsertNumFramesMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Insert # Frames"];
+			CloneFramesMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clone Frames"];
+			CloneFramesXTimesMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clone # Times"];
+
+			SelectBetweenMarkersContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Sel. bet. Markers"];
+			ClearContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clear Frames"];
+			DeleteFramesContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Delete Frames"];
+			InsertFrameContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Insert Frame"];
+			InsertNumFramesContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Insert # Frames"];
+			CloneContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clone Frames"];
+			CloneXTimesContextMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Clone # Times"];
+
+			TasPlaybackBox.UpdateHotkeyTooltips(Config);
+			MarkerControl.UpdateHotkeyTooltips(Config);
 		}
 
 		private bool LoadMostRecentOrStartNew()

--- a/src/BizHawk.Client.EmuHawk/tools/ToolFormBase.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolFormBase.cs
@@ -134,5 +134,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 			base.OnLoad(e);
 		}
+
+		public virtual void HandleHotkeyUpdate() { }
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -793,6 +793,17 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		public void HandleHotkeyUpdate()
+		{
+			foreach (var tool in _tools)
+			{
+				if (tool.IsActive && tool is ToolFormBase toolForm)
+				{
+					toolForm.HandleHotkeyUpdate();
+				}
+			}
+		}
+
 		private static readonly IList<string> PossibleToolTypeNames = EmuHawk.ReflectionCache.Types.Select(t => t.AssemblyQualifiedName).ToList();
 
 		public bool IsAvailable(Type tool)


### PR DESCRIPTION
Hotkeys:
Add marker (default M): Adds a marker to the emulated frame, same as the add marker button under the markers list.
Delete marker (default Ctrl+M): Deletes a marker on the emulated frame
Seek to prev/next marker (default Shift+PageUp/Down): Already existed, they are just now configurable.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
