### PR TITLE
Put alt handling code in FormBase. Fixes #3584.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/FormBase.cs
+++ b/src/BizHawk.Client.EmuHawk/FormBase.cs
@@ -94,5 +94,40 @@ namespace BizHawk.Client.EmuHawk
 			=> base.Text = Config?.UseStaticWindowTitles == true
 				? (_windowTitleStatic ??= WindowTitleStatic)
 				: WindowTitle;
+
+		// Alt key hacks. We need this in order for hotkey bindings with alt to work.
+		/// <summary>sends a simulation of a plain alt key keystroke</summary>
+		internal void SendPlainAltKey(int lparam)
+		{
+			var m = new Message { WParam = new IntPtr(0xF100), LParam = new IntPtr(lparam), Msg = 0x0112, HWnd = Handle };
+			base.WndProc(ref m);
+		}
+
+		/// <summary>HACK to send an alt+mnemonic combination</summary>
+		internal void SendAltKeyChar(char c) => ProcessMnemonic(c);
+
+		protected override void WndProc(ref Message m)
+		{
+			if (!BlocksInputWhenFocused)
+			{
+				// this is necessary to trap plain alt keypresses so that only our hotkey system gets them
+				if (m.Msg == 0x0112) // WM_SYSCOMMAND
+				{
+					if (m.WParam.ToInt32() == 0xF100) // SC_KEYMENU
+					{
+						return;
+					}
+				}
+			}
+
+			base.WndProc(ref m);
+		}
+
+		protected override bool ProcessDialogChar(char charCode)
+		{
+			// this is necessary to trap alt+char combinations so that only our hotkey system gets them
+			return (ModifierKeys & Keys.Alt) != 0 || base.ProcessDialogChar(charCode);
+		}
+
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/src/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -36,7 +36,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private readonly Func<Config> _getConfigCallback;
 
-		internal Input(IntPtr mainFormHandle, Func<Config> getConfigCallback, Func<bool, AllowInput> mainFormInputAllowedCallback)
+		internal Input(IntPtr mainFormHandle, Func<Config> getConfigCallback, Func<AllowInput> mainFormInputAllowedCallback)
 		{
 			_getConfigCallback = getConfigCallback;
 			_currentConfig = _getConfigCallback();
@@ -133,7 +133,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void HandleAxis(string axis, int newValue)
 		{
-			if (ShouldSwallow(MainFormInputAllowedCallback(false), HostInputType.Pad))
+			if (ShouldSwallow(MainFormInputAllowedCallback(), HostInputType.Pad))
 				return;
 
 			if (_trackDeltas)
@@ -189,7 +189,7 @@ namespace BizHawk.Client.EmuHawk
 		/// <summary>
 		/// Controls whether MainForm generates input events. should be turned off for most modal dialogs
 		/// </summary>
-		public readonly Func<bool, AllowInput> MainFormInputAllowedCallback;
+		public readonly Func<AllowInput> MainFormInputAllowedCallback;
 
 		private void UpdateThreadProc()
 		{
@@ -262,13 +262,11 @@ namespace BizHawk.Client.EmuHawk
 					if (_newEvents.Count != 0)
 					{
 						//WHAT!? WE SHOULD NOT BE SO NAIVELY TOUCHING MAINFORM FROM THE INPUTTHREAD. ITS BUSY RUNNING.
-						AllowInput allowInput = MainFormInputAllowedCallback(false);
+						AllowInput allowInput = MainFormInputAllowedCallback();
 
 						foreach (var ie in _newEvents)
 						{
 							//events are swallowed in some cases:
-							if ((ie.LogicalButton.Modifiers & LogicalButton.MASK_ALT) is not 0U && ShouldSwallow(MainFormInputAllowedCallback(true), ie.Source))
-								continue;
 							if (ie.EventType == InputEventType.Press && ShouldSwallow(allowInput, ie.Source))
 								continue;
 
@@ -332,7 +330,7 @@ namespace BizHawk.Client.EmuHawk
 			lock (this)
 			{
 				if (_inputEvents.Count == 0) return null;
-				AllowInput allowInput = MainFormInputAllowedCallback(false);
+				AllowInput allowInput = MainFormInputAllowedCallback();
 
 				//wait for the first release after a press to complete input binding, because we need to distinguish pure modifierkeys from modified keys
 				//if you just pressed ctrl, wanting to bind ctrl, we'd see: pressed:ctrl, unpressed:ctrl

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -620,14 +619,13 @@ namespace BizHawk.Client.EmuHawk
 			Input.Instance = new Input(
 				Handle,
 				() => Config,
-				yieldAlt => ActiveForm switch
+				() => ActiveForm switch
 				{
 					null => Config.AcceptBackgroundInput // none of our forms are focused, check the background input config
 						? Config.AcceptBackgroundInputControllerOnly
 							? AllowInput.OnlyController
 							: AllowInput.All
 						: AllowInput.None,
-					TAStudio when yieldAlt => AllowInput.None,
 					FormBase { BlocksInputWhenFocused: false } => AllowInput.All,
 					ControllerConfig => AllowInput.All,
 					HotkeyConfig => AllowInput.All,
@@ -1267,7 +1265,7 @@ namespace BizHawk.Client.EmuHawk
 
 				// look for hotkey bindings for this key
 				var triggers = searchHotkeyBindings(ie.LogicalButton.ToString());
-				if (triggers.Count == 0)
+				if (triggers.Count == 0 && ActiveForm is FormBase afb)
 				{
 					// Maybe it is a system alt-key which hasn't been overridden
 					if (ie.EventType is InputEventType.Press && (ie.LogicalButton.Modifiers & LogicalButton.MASK_ALT) is not 0U)
@@ -1277,12 +1275,12 @@ namespace BizHawk.Client.EmuHawk
 							var c = ie.LogicalButton.Button.ToLowerInvariant()[0];
 							if ((c >= 'a' && c <= 'z') || c == ' ')
 							{
-								SendAltKeyChar(c);
+								afb.SendAltKeyChar(c);
 							}
 						}
 						else if (ie.LogicalButton.Button == "Space")
 						{
-							SendPlainAltKey(32);
+							afb.SendPlainAltKey(32);
 						}
 					}
 
@@ -2474,23 +2472,6 @@ namespace BizHawk.Client.EmuHawk
 				DisplayManager.UpdateSource(video);
 		}
 
-		// sends a simulation of a plain alt key keystroke
-		private void SendPlainAltKey(int lparam)
-		{
-			var m = new Message { WParam = new IntPtr(0xF100), LParam = new IntPtr(lparam), Msg = 0x0112, HWnd = Handle };
-			base.WndProc(ref m);
-		}
-
-		/// <summary>HACK to send an alt+mnemonic combination</summary>
-		private void SendAltKeyChar(char c)
-			=> _ = typeof(ToolStrip).InvokeMember(
-				OSTailoredCode.IsUnixHost ? "ProcessMnemonic" : "ProcessMnemonicInternal",
-				BindingFlags.NonPublic | BindingFlags.InvokeMethod | BindingFlags.Instance,
-				null,
-				MainformMenu,
-				new object/*?*/[] { c },
-				CultureInfo.InvariantCulture);
-
 		public static readonly FilesystemFilterSet ConfigFileFSFilterSet = new(new FilesystemFilter("Config File", new[] { "ini" }))
 		{
 			AppendAllFilesEntry = false,
@@ -2924,27 +2905,6 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		private const int WmDeviceChange = 0x0219;
-
-		// Alt key hacks
-		protected override void WndProc(ref Message m)
-		{
-			// this is necessary to trap plain alt keypresses so that only our hotkey system gets them
-			if (m.Msg == 0x0112) // WM_SYSCOMMAND
-			{
-				if (m.WParam.ToInt32() == 0xF100) // SC_KEYMENU
-				{
-					return;
-				}
-			}
-
-			base.WndProc(ref m);
-		}
-
-		protected override bool ProcessDialogChar(char charCode)
-		{
-			// this is necessary to trap alt+char combinations so that only our hotkey system gets them
-			return (ModifierKeys & Keys.Alt) != 0 || base.ProcessDialogChar(charCode);
-		}
 
 		private void UpdateCoreStatusBarButton()
 		{


### PR DESCRIPTION
This also allows for the use of alt keys to use the menu items in Virtual Pad. Although for some reason I can't figure out, pressing alt does not underline the relevant letters in the tool bar like it does for other windows.

Note: If a hotkey is set to a key combination that normally would open a menu (e.g. Alt+F, which normally opens the File menu) then the hotkey is triggered and the menu is not opened. This is the same as prior behavior in MainForm, just now applied to tools as well.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
