### PR TITLE
Undo redo

### DIFF
--- a/src/BizHawk.Client.Common/movie/bk2/StringLogs.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/StringLogs.cs
@@ -37,6 +37,9 @@ namespace BizHawk.Client.Common
 				}
 			}
 
+			if (newLog.Count != currentLog.Count)
+				return Math.Min(newLog.Count, currentLog.Count);
+
 			return null;
 		}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
@@ -11,13 +11,7 @@ namespace BizHawk.Client.Common
 
 		public override void RecordFrame(int frame, IController source)
 		{
-			// RetroEdit: This check is questionable; recording at frame 0 is valid and should be reversible.
-			// Also, frame - 1, why?
-			// Is the precondition compensating for frame - 1 reindexing?
-			if (frame != 0)
-			{
-				ChangeLog.AddGeneralUndo(frame - 1, frame - 1, $"Record Frame: {frame}");
-			}
+			ChangeLog.AddGeneralUndo(frame, frame, $"Record Frame: {frame}");
 
 			SetFrameAt(frame, Bk2LogEntryGenerator.GenerateLogEntry(source));
 
@@ -31,10 +25,7 @@ namespace BizHawk.Client.Common
 				InvalidateAfter(frame);
 			}
 
-			if (frame != 0)
-			{
-				ChangeLog.SetGeneralRedo();
-			}
+			ChangeLog.SetGeneralRedo();
 		}
 
 		public override void Truncate(int frame)

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
@@ -164,8 +164,6 @@ namespace BizHawk.Client.Common
 			ShiftBindedMarkers(removeUpTo, removeStart - removeUpTo);
 
 			Changes = true;
-			InvalidateAfter(removeStart);
-
 			ChangeLog.AddRemoveFrames(
 				removeStart,
 				removeUpTo,
@@ -173,6 +171,8 @@ namespace BizHawk.Client.Common
 				removedMarkers,
 				$"Remove frames {removeStart}-{removeUpTo - 1}"
 			);
+
+			InvalidateAfter(removeStart);
 		}
 
 		public void InsertInput(int frame, string inputState)
@@ -188,9 +188,9 @@ namespace BizHawk.Client.Common
 			ShiftBindedMarkers(frame, inputLog.Count());
 
 			Changes = true;
-			InvalidateAfter(frame);
-
 			ChangeLog.AddInsertInput(frame, inputLog.ToList(), $"Insert {inputLog.Count()} frame(s) at {frame}");
+
+			InvalidateAfter(frame);
 		}
 
 		public void InsertInput(int frame, IEnumerable<IController> inputStates)
@@ -258,9 +258,9 @@ namespace BizHawk.Client.Common
 			ShiftBindedMarkers(frame, count);
 
 			Changes = true;
-			InvalidateAfter(frame);
-
 			ChangeLog.AddInsertFrames(frame, count, $"Insert {count} empty frame(s) at {frame}");
+
+			InvalidateAfter(frame);
 		}
 
 		private void ExtendMovieForEdit(int numFrames)
@@ -295,12 +295,12 @@ namespace BizHawk.Client.Common
 
 			var adapter = GetInputState(frame);
 			adapter.SetBool(buttonName, !adapter.IsPressed(buttonName));
-
 			Log[frame] = Bk2LogEntryGenerator.GenerateLogEntry(adapter);
-			Changes = true;
-			InvalidateAfter(frame);
 
+			Changes = true;
 			ChangeLog.AddBoolToggle(frame, buttonName, !adapter.IsPressed(buttonName), $"Toggle {buttonName}: {frame}");
+
+			InvalidateAfter(frame);
 		}
 
 		public void SetBoolState(int frame, string buttonName, bool val)
@@ -318,9 +318,9 @@ namespace BizHawk.Client.Common
 
 			if (old != val)
 			{
-				InvalidateAfter(frame);
 				Changes = true;
 				ChangeLog.AddBoolToggle(frame, buttonName, old, $"Set {buttonName}({(val ? "On" : "Off")}): {frame}");
+				InvalidateAfter(frame);
 			}
 		}
 
@@ -372,9 +372,9 @@ namespace BizHawk.Client.Common
 
 			if (old != val)
 			{
-				InvalidateAfter(frame);
 				Changes = true;
 				ChangeLog.AddAxisChange(frame, buttonName, old, val, $"Set {buttonName}({val}): {frame}");
+				InvalidateAfter(frame);
 			}
 		}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
@@ -237,15 +237,20 @@ namespace BizHawk.Client.Common
 				Log[frame + i] = entry;
 			}
 
-			ChangeLog.EndBatch();
-			Changes = true;
 			if (firstChangedFrame != -1)
 			{
-				// TODO: Throw out the undo action if there are no changes.
+				ChangeLog.EndBatch();
+				Changes = true;
+
 				InvalidateAfter(firstChangedFrame);
+
+				ChangeLog.SetGeneralRedo();
+			}
+			else
+			{
+				ChangeLog.AbortBatch();
 			}
 
-			ChangeLog.SetGeneralRedo();
 			return firstChangedFrame;
 		}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.History.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.History.cs
@@ -11,6 +11,7 @@ namespace BizHawk.Client.Common
 		bool IsRecording { get; set; }
 		void Clear(int upTo = -1);
 		bool BeginNewBatch(string name = "", bool keepOldBatch = false);
+		void AbortBatch();
 		void EndBatch();
 		int Undo();
 		int Redo();
@@ -147,6 +148,16 @@ namespace BizHawk.Client.Common
 		}
 
 		/// <summary>
+		/// Ends the current undo batch and deletes any undo actions it contains.
+		/// </summary>
+		public void AbortBatch()
+		{
+			_history.RemoveAt(_history.Count - 1);
+			Names.RemoveAt(Names.Count - 1);
+			UndoIndex--;
+		}
+
+		/// <summary>
 		/// Ends the current undo batch. Future changes will be one undo each.
 		/// If not already recording a batch, does nothing.
 		/// </summary>
@@ -161,9 +172,7 @@ namespace BizHawk.Client.Common
 			var last = LatestBatch;
 			if (last.Count == 0) // Remove batch if it's empty.
 			{
-				_history.RemoveAt(_history.Count - 1);
-				Names.RemoveAt(Names.Count - 1);
-				UndoIndex--;
+				AbortBatch();
 			}
 			else
 			{

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
@@ -149,7 +149,7 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		public string DisplayValue(int frame, string buttonName)
 		{
-			if (_displayCache.Frame != frame)
+			if (_displayCache.Frame != frame || Log.Count == 1)
 			{
 				_displayCache.Controller ??= new Bk2Controller(Session.MovieController.Definition, LogKey);
 				_displayCache.Controller.SetFromMnemonic(Log[frame]);

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -345,7 +345,7 @@ namespace BizHawk.Client.EmuHawk
 						}
 					}
 					_changeList.Clear();
-				});
+				}, "Lua: tastudio.applyinputchanges");
 
 				_luaLibsImpl.IsUpdateSupressed = false;
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
@@ -55,7 +55,7 @@ namespace BizHawk.Client.EmuHawk
 
 		protected override void UpdateBefore()
 		{
-			if (CurrentTasMovie.IsAtEnd())
+			if (CurrentTasMovie.IsAtEnd() && !CurrentTasMovie.IsRecording())
 			{
 				CurrentTasMovie.RecordFrame(CurrentTasMovie.Emulator.Frame, MovieSession.StickySource);
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -27,6 +27,7 @@ namespace BizHawk.Client.EmuHawk
 		private int _startRow;
 		private int _batchEditMinFrame = -1;
 		private bool _batchEditing;
+		private bool _batchEditControlsUndoBatch;
 		private bool _editIsFromLua;
 
 		// Editing analog input
@@ -766,15 +767,22 @@ namespace BizHawk.Client.EmuHawk
 		/// <summary>
 		/// Begins a batch of edits, for auto-restore purposes. Auto-restore will be delayed until EndBatchEdit is called.
 		/// </summary>
-		private void BeginBatchEdit()
+		/// <param name="undoHistoryBatchName">The name to give to the item in the undo history. Pass null to not make an undo history batch.</param>
+		private void BeginBatchEdit(string undoHistoryBatchName)
 		{
 			_batchEditing = true;
+			if (undoHistoryBatchName != null)
+				_batchEditControlsUndoBatch = CurrentTasMovie.ChangeLog.BeginNewBatch(undoHistoryBatchName, true);
+			else
+				_batchEditControlsUndoBatch = false;
 		}
 
 		/// <returns>Returns true if the input list was redrawn.</returns>
 		private bool EndBatchEdit()
 		{
 			_batchEditing = false;
+			if (_batchEditControlsUndoBatch) CurrentTasMovie.ChangeLog.EndBatch();
+
 			if (_batchEditMinFrame != -1)
 			{
 				return FrameEdited(_batchEditMinFrame);
@@ -783,11 +791,11 @@ namespace BizHawk.Client.EmuHawk
 			return false;
 		}
 
-		public void ApiHawkBatchEdit(Action action)
+		public void ApiHawkBatchEdit(Action action, string undoHistoryBatchName)
 		{
 			// This is only caled from Lua.
 			_editIsFromLua = true;
-			BeginBatchEdit();
+			BeginBatchEdit(undoHistoryBatchName);
 			try
 			{
 				action();
@@ -1322,7 +1330,7 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 
-			BeginBatchEdit();
+			BeginBatchEdit(null);
 
 			int value = CurrentTasMovie.GetAxisState(_axisEditRow, _axisEditColumn);
 			string prevTyped = _axisTypedValue;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -874,11 +874,18 @@ namespace BizHawk.Client.EmuHawk
 					RefreshDialog();
 					return true;
 				}
-				else if (TasView.RowCount != CurrentTasMovie.InputLogLength + 1)
+				else
 				{
-					// Row count must always be kept up to date even if last row is not directly visible.
-					TasView.RowCount = CurrentTasMovie.InputLogLength + 1;
-					return true;
+					if (_undoForm != null && !_undoForm.IsDisposed)
+					{
+						_undoForm.UpdateValues();
+					}
+					if (TasView.RowCount != CurrentTasMovie.InputLogLength + 1)
+					{
+						// Row count must always be kept up to date even if last row is not directly visible.
+						TasView.RowCount = CurrentTasMovie.InputLogLength + 1;
+						return true;
+					}
 				}
 			}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -281,14 +281,9 @@ namespace BizHawk.Client.EmuHawk
 
 		private void UndoMenuItem_Click(object sender, EventArgs e)
 		{
-			if (CurrentTasMovie.ChangeLog.Undo() < Emulator.Frame)
-			{
-				GoToFrame(CurrentTasMovie.ChangeLog.PreviousUndoFrame);
-			}
-			else
-			{
-				RefreshDialog();
-			}
+			BeginBatchEdit(null);
+			CurrentTasMovie.ChangeLog.Undo();
+			EndBatchEdit();
 
 			// Currently I don't have a way to easily detect when CanUndo changes, so this button should be enabled always.
 			// UndoMenuItem.Enabled = CurrentTasMovie.ChangeLog.CanUndo;
@@ -297,14 +292,9 @@ namespace BizHawk.Client.EmuHawk
 
 		private void RedoMenuItem_Click(object sender, EventArgs e)
 		{
-			if (CurrentTasMovie.ChangeLog.Redo() < Emulator.Frame)
-			{
-				GoToFrame(CurrentTasMovie.ChangeLog.PreviousRedoFrame);
-			}
-			else
-			{
-				RefreshDialog();
-			}
+			BeginBatchEdit(null);
+			CurrentTasMovie.ChangeLog.Redo();
+			EndBatchEdit();
 
 			// Currently I don't have a way to easily detect when CanUndo changes, so this button should be enabled always.
 			// UndoMenuItem.Enabled = CurrentTasMovie.ChangeLog.CanUndo;
@@ -487,7 +477,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 
 				Clipboard.SetDataObject(sb.ToString());
-				BeginBatchEdit(); // movie's RemoveFrames may make multiple separate invalidations
+				BeginBatchEdit($"Delete selected frames starting at {TasView.FirstSelectedRowIndex}"); // movie's RemoveFrames may make multiple separate invalidations
 				CurrentTasMovie.RemoveFrames(list);
 				EndBatchEdit();
 				SetSplicer();
@@ -499,14 +489,12 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (TasView.Focused && TasView.AnyRowsSelected)
 			{
-				BeginBatchEdit();
-				CurrentTasMovie.ChangeLog.BeginNewBatch($"Clear frames {TasView.SelectionStartIndex}-{TasView.SelectionEndIndex}");
+				BeginBatchEdit($"Clear selected frames starting at {TasView.FirstSelectedRowIndex}");
 				foreach (int frame in TasView.SelectedRows)
 				{
 					CurrentTasMovie.ClearFrame(frame);
 				}
 
-				CurrentTasMovie.ChangeLog.EndBatch();
 				EndBatchEdit();
 			}
 		}
@@ -524,7 +512,7 @@ namespace BizHawk.Client.EmuHawk
 					return;
 				}
 
-				BeginBatchEdit(); // movie's RemoveFrames may make multiple separate invalidations
+				BeginBatchEdit($"Delete selected frames starting at {selectionStart}"); // movie's RemoveFrames may make multiple separate invalidations
 				CurrentTasMovie.RemoveFrames(TasView.SelectedRows.ToArray());
 				EndBatchEdit();
 				SetTasViewRowCount();
@@ -548,10 +536,13 @@ namespace BizHawk.Client.EmuHawk
 
 		private void CloneFramesXTimes(int timesToClone)
 		{
-			BeginBatchEdit();
-			for (int i = 0; i < timesToClone; i++)
+			if (TasView.Focused && TasView.AnyRowsSelected)
 			{
-				if (TasView.Focused && TasView.AnyRowsSelected)
+				string batchName = $"Clone selected frames starting at {TasView.FirstSelectedRowIndex}";
+				if (timesToClone != 1) batchName += $"{timesToClone} times";
+				BeginBatchEdit(batchName);
+
+				for (int i = 0; i < timesToClone; i++)
 				{
 					var framesToInsert = TasView.SelectedRows;
 					var insertionFrame = Math.Min((TasView.SelectionEndIndex ?? 0) + 1, CurrentTasMovie.InputLogLength);
@@ -562,8 +553,8 @@ namespace BizHawk.Client.EmuHawk
 
 					CurrentTasMovie.InsertInput(insertionFrame, inputLog);
 				}
+				EndBatchEdit();
 			}
-			EndBatchEdit();
 		}
 
 		private void InsertFrameMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -869,14 +869,9 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (beginningFrame < CurrentTasMovie.InputLogLength)
 			{
-				// movie's RemoveFrames might do multiple separate invalidations
-				BeginBatchEdit();
-
 				int[] framesToRemove = Enumerable.Range(beginningFrame, numberOfFrames).ToArray();
 				CurrentTasMovie.RemoveFrames(framesToRemove);
 				SetSplicer();
-
-				EndBatchEdit();
 			}
 		}
 
@@ -884,7 +879,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (beginningFrame < CurrentTasMovie.InputLogLength)
 			{
-				BeginBatchEdit();
+				BeginBatchEdit($"Clear frames {beginningFrame}-{beginningFrame+numberOfFrames}");
 
 				int last = Math.Min(beginningFrame + numberOfFrames, CurrentTasMovie.InputLogLength);
 				for (int i = beginningFrame; i < last; i++)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/UndoHistoryForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/UndoHistoryForm.cs
@@ -86,12 +86,16 @@ namespace BizHawk.Client.EmuHawk
 		private void UndoToHere(int index)
 		{
 			int earliestFrame = int.MaxValue;
-			while (Log.UndoIndex > index)
+			_tastudio.ApiHawkBatchEdit(() =>
 			{
-				int frame = Log.Undo();
-				if (frame < earliestFrame)
-					earliestFrame = frame;
-			}
+				while (Log.UndoIndex > index)
+				{
+					int frame = Log.Undo();
+					if (frame < earliestFrame)
+						earliestFrame = frame;
+				}
+			}, null);
+
 
 			UpdateValues();
 
@@ -137,12 +141,15 @@ namespace BizHawk.Client.EmuHawk
 		private void RedoHereMenuItem_Click(object sender, EventArgs e)
 		{
 			int earliestFrame = int.MaxValue;
-			while (Log.UndoIndex < SelectedItem)
+			_tastudio.ApiHawkBatchEdit(() =>
 			{
-				int frame = Log.Redo();
-				if (earliestFrame < frame)
-					earliestFrame = frame;
-			}
+				while (Log.UndoIndex < SelectedItem)
+				{
+					int frame = Log.Redo();
+					if (earliestFrame < frame)
+						earliestFrame = frame;
+				}
+			}, null);
 
 			UpdateValues();
 

--- a/src/BizHawk.Tests/Client.Common/Movie/FakeMovieSession.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/FakeMovieSession.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+using BizHawk.Client.Common;
+using BizHawk.Emulation.Common;
+using BizHawk.Tests.Emulation.Common;
+
+namespace BizHawk.Tests.Client.Common.Movie
+{
+	internal class FakeMovieSession : IMovieSession
+	{
+		public IMovieConfig Settings { get; set; }
+
+		public required IMovie Movie { get; set; }
+
+		public bool ReadOnly { get => false; set { } }
+
+		public bool NewMovieQueued => throw new NotImplementedException();
+
+		public string QueuedSyncSettings => throw new NotImplementedException();
+
+		public string QueuedCoreName => throw new NotImplementedException();
+
+		public string QueuedSysID => throw new NotImplementedException();
+
+		public IDictionary<string, object> UserBag { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+
+		public IMovieController MovieController => FakeEmulator.Controller;
+
+		public IController StickySource { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+		public IController MovieIn { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+		public IInputAdapter MovieOut => throw new NotImplementedException();
+
+		public string BackupDirectory { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+		public FakeMovieSession()
+		{
+			Settings = new MovieConfig();
+		}
+
+		public void AbortQueuedMovie() => throw new NotImplementedException();
+		public bool CheckSavestateTimeline(TextReader reader) => throw new NotImplementedException();
+		public IMovieController GenerateMovieController(ControllerDefinition? definition = null, string? logKey = null) => throw new NotImplementedException();
+		public IMovie Get(string path, bool loadMovie = false) => throw new NotImplementedException();
+		public void HandleFrameAfter(bool ignoreMovieEndAction) => throw new NotImplementedException();
+		public void HandleFrameBefore() => throw new NotImplementedException();
+		public bool HandleLoadState(TextReader reader) => throw new NotImplementedException();
+		public void HandleSaveState(TextWriter writer) => throw new NotImplementedException();
+		public void PopupMessage(string message) => throw new NotImplementedException();
+		public void QueueNewMovie(IMovie movie, string systemId, string loadedRomHash, PathEntryCollection pathEntries, IDictionary<string, string> preferredCores) => throw new NotImplementedException();
+		public void RunQueuedMovie(bool recordMode, IEmulator emulator) => throw new NotImplementedException();
+		public void StopMovie(bool saveChanges = true) => Movie.Stop();
+	}
+}

--- a/src/BizHawk.Tests/Client.Common/Movie/MovieUndoTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/MovieUndoTests.cs
@@ -1,0 +1,174 @@
+﻿using BizHawk.Client.Common;
+using BizHawk.Tests.Emulation.Common;
+
+namespace BizHawk.Tests.Client.Common.Movie
+{
+	[TestClass]
+	public class MovieUndoTests
+	{
+		private TasMovie MakeMovie(int numberOfFrames)
+		{
+			FakeMovieSession session = new() { Movie = null! };
+			TasMovie movie = new(session, "/fake/path");
+			session.Movie = movie;
+
+			movie.Attach(new FakeEmulator());
+			movie.InsertEmptyFrame(0, numberOfFrames);
+
+			return movie;
+		}
+
+		private void ValidateActionCanUndoAndRedo(TasMovie movie, Action action, int expectedUndoItems = 1)
+		{
+			IStringLog originalLog = movie.GetLogEntries().Clone();
+			int originalUndoLength = movie.ChangeLog.UndoIndex;
+			action();
+
+			IStringLog changedLog = movie.GetLogEntries().Clone();
+			int changedUndoLength = movie.ChangeLog.UndoIndex;
+			int firstEditedFrame = originalLog.DivergentPoint(changedLog) ?? movie.InputLogLength;
+
+			Assert.AreEqual(originalUndoLength + expectedUndoItems, changedUndoLength);
+
+			// undo
+			int undoFrame = int.MaxValue;
+			for (int i = 0; i < expectedUndoItems; i++)
+				undoFrame = Math.Min(undoFrame, movie.ChangeLog.Undo());
+			Assert.AreEqual(firstEditedFrame, undoFrame);
+			Assert.IsNull(originalLog.DivergentPoint(movie.GetLogEntries()));
+
+			// redo
+			int redoFrame = int.MaxValue;
+			for (int i = 0; i < expectedUndoItems; i++)
+				redoFrame = Math.Min(redoFrame, movie.ChangeLog.Redo());
+			Assert.AreEqual(firstEditedFrame, redoFrame);
+			Assert.IsNull(changedLog.DivergentPoint(movie.GetLogEntries()));
+		}
+
+		[TestMethod]
+		public void SetBool()
+		{
+			TasMovie movie = MakeMovie(5);
+
+			ValidateActionCanUndoAndRedo(movie, () =>
+			{
+				movie.SetBoolState(2, "A", true);
+			});
+		}
+
+		[TestMethod]
+		public void SetAxis()
+		{
+			TasMovie movie = MakeMovie(5);
+
+			ValidateActionCanUndoAndRedo(movie, () =>
+			{
+				movie.SetAxisState(2, "Stick", 20);
+			});
+		}
+
+		[TestMethod]
+		public void InsertFrame()
+		{
+			TasMovie movie = MakeMovie(5);
+			movie.SetBoolState(2, "A", true);
+			movie.SetBoolState(3, "B", true);
+
+			ValidateActionCanUndoAndRedo(movie, () =>
+			{
+				movie.InsertEmptyFrame(3);
+			});
+		}
+
+		[TestMethod]
+		public void DeleteFrame()
+		{
+			TasMovie movie = MakeMovie(5);
+			movie.SetBoolState(2, "A", true);
+			movie.SetBoolState(4, "B", true);
+
+			ValidateActionCanUndoAndRedo(movie, () =>
+			{
+				movie.RemoveFrame(3);
+			});
+		}
+
+		[TestMethod]
+		public void CloneFrame()
+		{
+			TasMovie movie = MakeMovie(5);
+			movie.SetBoolState(2, "A", true);
+			movie.SetBoolState(3, "B", true);
+
+			ValidateActionCanUndoAndRedo(movie, () =>
+			{
+				movie.InsertInput(2, movie.GetInputLogEntry(3));
+			});
+		}
+
+		[TestMethod]
+		public void MultipleEdits()
+		{
+			TasMovie movie = MakeMovie(5);
+
+			ValidateActionCanUndoAndRedo(movie, () =>
+			{
+				movie.SetBoolState(2, "A", true);
+				movie.SetBoolState(3, "B", true);
+			}, 2);
+		}
+
+		[TestMethod]
+		public void BatchedEdit()
+		{
+			TasMovie movie = MakeMovie(5);
+
+			ValidateActionCanUndoAndRedo(movie, () =>
+			{
+				movie.ChangeLog.BeginNewBatch();
+				movie.SetBoolState(2, "A", true);
+				movie.SetBoolState(3, "B", true);
+				movie.ChangeLog.EndBatch();
+			});
+		}
+
+		[TestMethod]
+		public void RecordFrameAtEnd()
+		{
+			TasMovie movie = MakeMovie(5);
+
+			ValidateActionCanUndoAndRedo(movie, () =>
+			{
+				Bk2Controller controller = new Bk2Controller(movie.Emulator.ControllerDefinition);
+				controller.SetBool("A", true);
+				movie.RecordFrame(5, controller);
+			});
+		}
+
+		[TestMethod]
+		public void RecordFrameInMiddle()
+		{
+			TasMovie movie = MakeMovie(5);
+
+			ValidateActionCanUndoAndRedo(movie, () =>
+			{
+				Bk2Controller controller = new Bk2Controller(movie.Emulator.ControllerDefinition);
+				controller.SetBool("A", true);
+				movie.RecordFrame(2, controller);
+			});
+		}
+
+		[TestMethod]
+		public void RecordFrameZero()
+		{
+			TasMovie movie = MakeMovie(5);
+
+			ValidateActionCanUndoAndRedo(movie, () =>
+			{
+				Bk2Controller controller = new Bk2Controller(movie.Emulator.ControllerDefinition);
+				controller.SetBool("A", true);
+				movie.RecordFrame(0, controller);
+			});
+		}
+	}
+}

--- a/src/BizHawk.Tests/Emulation.Common/Base Implementations/FakeEmulator.cs
+++ b/src/BizHawk.Tests/Emulation.Common/Base Implementations/FakeEmulator.cs
@@ -1,0 +1,75 @@
+﻿using System.IO;
+
+using BizHawk.Client.Common;
+using BizHawk.Common;
+using BizHawk.Emulation.Common;
+
+namespace BizHawk.Tests.Emulation.Common
+{
+	internal class FakeEmulator : IEmulator, IStatable, IInputPollable
+	{
+		private BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
+
+		private readonly static ControllerDefinition _cd = new ControllerDefinition("fake controller")
+		{
+			BoolButtons = { "A", "B" },
+		}
+			.AddAxis("Stick", (-100).RangeTo(100), 0)
+			.MakeImmutable();
+		public static IMovieController Controller;
+		static FakeEmulator()
+		{
+			_cd.BuildMnemonicsCache("fake");
+			Controller = new Bk2Controller(_cd);
+		}
+
+		public ControllerDefinition ControllerDefinition => Controller.Definition;
+
+		public int Frame { get; set; }
+
+		public string SystemId => "fake";
+
+		public bool DeterministicEmulation => true;
+
+		public bool AvoidRewind => false;
+
+		public int LagCount { get; set; }
+		public bool IsLagFrame { get; set; }
+
+		public IInputCallbackSystem InputCallbacks => throw new NotImplementedException();
+
+		public FakeEmulator()
+		{
+			_serviceProvider = new(this);
+		}
+
+		public void Dispose() { }
+		public bool FrameAdvance(IController controller, bool render, bool renderSound = true)
+		{
+			Frame++;
+			return true;
+		}
+
+		public void LoadStateBinary(BinaryReader reader)
+		{
+			Frame = reader.ReadInt32();
+			LagCount = reader.ReadInt32();
+			IsLagFrame = reader.ReadBoolean();
+		}
+
+		public void ResetCounters()
+		{
+			Frame = 0;
+			LagCount = 0;
+			IsLagFrame = false;
+		}
+
+		public void SaveStateBinary(BinaryWriter writer)
+		{
+			writer.Write(Frame);
+			writer.Write(LagCount);
+			writer.Write(IsLagFrame);
+		}
+	}
+}


### PR DESCRIPTION
Fixes various issues with undo and redo.

There are new tests. I put together a `FakeEmulator` and `FakeMovieSession` to make these tests possible. I just got the tests to run, this may not be the best way to set things up.

Questions:
1) What should happen if the user presses Ctrl+Z in the middle of painting inputs (while the mouse button is down)? The current behavior appears to be that it undoes whatever paint has already been done but the user can still continue painting. In this state, each new painted frame will be its own undo action. Should we disallow undo during paint? Stop the paint? Keep painting but start a new batch?
2) It's been mentioned in #2301 that using undo can move the green arrow. I am not sure what the exact behavior was when that was written, but current behavior will move the green arrow if (and only if) making that same edit manually (e.g. paint an input with the mouse) would move the green arrow. (That is, if the user has manually changed the current frame [seeking by doing anything other than editing inputs], is not currently seeking to the green arrow, and the modified frame is in the past.) This seems reasonable to me, but @RetroEdit might disagree.

Also I am aware of one issue that persists: If the movie has no inputs and you record a frame (which will be frame 0), then undo that frame record, TAStudio will automatically re-record a blank frame on frame 0 which deletes the redo history. This seems like a minor edge case bug and I don't see an easy fix so it may not be worth fixing.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant