### PR TITLE
Make .editorconfig not root, and remove all rules less than a warning.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,3 @@
-root = true
-
 [*]
 indent_style = tab
 
@@ -20,38 +18,16 @@ trim_trailing_whitespace = true
 # Style rules
 # Can't be in .globalconfig because dotnet format doesn't respect that https://github.com/dotnet/format/issues/1643
 
-# Remove `this` or `Me` qualification
-dotnet_diagnostic.IDE0003.severity = silent
 # Remove unnecessary cast
 dotnet_diagnostic.IDE0004.severity = warning
 # Remove unnecessary import
 dotnet_diagnostic.IDE0005.severity = warning
-# Use var instead of explicit type
-dotnet_diagnostic.IDE0007.severity = suggestion
-# Use explicit type instead of var
-dotnet_diagnostic.IDE0008.severity = silent
-# Add `this` or `Me` qualification
-dotnet_diagnostic.IDE0009.severity = silent
 # Inline variable declaration
 dotnet_diagnostic.IDE0018.severity = warning
 # Use pattern matching to avoid as followed by a null check
 dotnet_diagnostic.IDE0019.severity = warning
 # Use pattern matching to avoid is check followed by a cast (with variable)
 dotnet_diagnostic.IDE0020.severity = warning
-# Use expression body for constructors
-dotnet_diagnostic.IDE0021.severity = silent # UseExpressionBodyDiagnosticAnalyzer very slow
-# Use expression body for methods
-dotnet_diagnostic.IDE0022.severity = silent # UseExpressionBodyDiagnosticAnalyzer very slow
-# Use expression body for conversion operators
-dotnet_diagnostic.IDE0023.severity = silent # UseExpressionBodyDiagnosticAnalyzer very slow
-# Use expression body for operators
-dotnet_diagnostic.IDE0024.severity = silent # UseExpressionBodyDiagnosticAnalyzer very slow
-# Use expression body for properties
-dotnet_diagnostic.IDE0025.severity = silent # UseExpressionBodyDiagnosticAnalyzer very slow
-# Use expression body for indexers
-dotnet_diagnostic.IDE0026.severity = silent # UseExpressionBodyDiagnosticAnalyzer very slow
-# Use expression body for accessors
-dotnet_diagnostic.IDE0027.severity = silent # UseExpressionBodyDiagnosticAnalyzer very slow
 # Null check can be simplified
 dotnet_diagnostic.IDE0029.severity = warning
 # Null check can be simplified
@@ -66,67 +42,33 @@ dotnet_diagnostic.IDE0034.severity = suggestion
 dotnet_diagnostic.IDE0038.severity = warning
 # Use is null check
 dotnet_diagnostic.IDE0041.severity = warning
-# Deconstruct variable declaration
-dotnet_diagnostic.IDE0042.severity = suggestion
 # dotnet_diagnostic.IDE0049.severity = error # see SA1121
-# Remove unused private member
-dotnet_diagnostic.IDE0051.severity = suggestion
-# Remove unread private member
-dotnet_diagnostic.IDE0052.severity = silent # TODO: should be warning imo, but there's too much violation currently
 # Use compound assignment
 dotnet_diagnostic.IDE0054.severity = warning
-# Use index operator
-dotnet_diagnostic.IDE0056.severity = suggestion
-# Use range operator
-dotnet_diagnostic.IDE0057.severity = suggestion
-# Use expression body for local functions
-dotnet_diagnostic.IDE0061.severity = silent # UseExpressionBodyDiagnosticAnalyzer very slow
-# Use simple using statement
-dotnet_diagnostic.IDE0063.severity = suggestion
 # Make struct fields writable
 dotnet_diagnostic.IDE0064.severity = error
 # using directive placement
 dotnet_diagnostic.IDE0065.severity = error
-# Use switch expression
-dotnet_diagnostic.IDE0066.severity = suggestion
 # Use System.HashCode.Combine
 dotnet_diagnostic.IDE0070.severity = warning
-# Simplify interpolation
-dotnet_diagnostic.IDE0071.severity = suggestion
-# Use coalesce compound assignment
-dotnet_diagnostic.IDE0074.severity = suggestion
-# Use pattern matching
-dotnet_diagnostic.IDE0078.severity = suggestion
 # Convert typeof to nameof
 dotnet_diagnostic.IDE0082.severity = warning
 # Use pattern matching (not operator)
 dotnet_diagnostic.IDE0083.severity = warning
-# Simplify new expression
-dotnet_diagnostic.IDE0090.severity = suggestion
 # Remove unnecessary equality operator
 dotnet_diagnostic.IDE0100.severity = warning
 # Remove unnecessary discard
 dotnet_diagnostic.IDE0110.severity = warning
 # Simplify LINQ expression
 dotnet_diagnostic.IDE0120.severity = error
-# Namespace does not match folder structure
-dotnet_diagnostic.IDE0130.severity = silent # should be warning imo
-# Use tuple to swap values
-dotnet_diagnostic.IDE0180.severity = suggestion
 # Use UTF-8 string literal
 dotnet_diagnostic.IDE0230.severity = warning
 # Nullable directive is redundant
 dotnet_diagnostic.IDE0240.severity = warning
 # Nullable directive is unnecessary
 dotnet_diagnostic.IDE0241.severity = warning
-# Struct can be made 'readonly'
-dotnet_diagnostic.IDE0250.severity = suggestion
-# Use pattern matching
-dotnet_diagnostic.IDE0260.severity = suggestion
 # Use nameof
 dotnet_diagnostic.IDE0280.severity = error
-# Collection initialization can be simplified
-dotnet_diagnostic.IDE0305.severity = silent
 
 csharp_style_var_when_type_is_apparent = true
 csharp_style_var_elsewhere = true


### PR DESCRIPTION
This allows users to configure their own style rules for things we allow both ways. It also allows users to make Visual Studio not fade out code that triggers a "silent" style rule.

It's very annoying having Visual Studio reduce contrast of code that violates "silent" rules (for example a new private method that isn't yet called, or using `this` when not necessary), and this is the only way I know how to disable that. (Really if Visual Studio weren't stupid and let the user disable that anti-feature I wouldn't care about this .editorconfig change).

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
