### PR TITLE
Handle exceptions while writing to files

### DIFF
--- a/.global.editorconfig.ini
+++ b/.global.editorconfig.ini
@@ -156,6 +156,15 @@ dotnet_diagnostic.CA2229.severity = silent
 # Opt in to preview features before using them
 dotnet_diagnostic.CA2252.severity = silent # CSharpDetectPreviewFeatureAnalyzer very slow
 
+## Nullable rules; generics are a bit wonky and I have no idea why we're allowed to configure these to be not errors or why they aren't errors by default.
+
+# Nullability of reference types in value doesn't match target type.
+dotnet_diagnostic.CS8619.severity = error
+# Make Foo<string?> an error for class Foo<T> where T : class. Use `where T : class?` if Foo<string?> should be allowed.
+dotnet_diagnostic.CS8634.severity = error
+# Nullability of type argument doesn't match 'notnull' constraint.
+dotnet_diagnostic.CS8714.severity = error
+
 ## .NET DocumentationAnalyzers style rules
 
 # Place text in paragraphs

--- a/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
@@ -160,6 +160,7 @@ namespace BizHawk.Client.Common
 
 		public void RebootCore() => _mainForm.RebootCore();
 
+		// TODO: Change return type to FileWriteResult.
 		public void SaveRam() => _mainForm.FlushSaveRAM();
 
 		// TODO: Change return type to FileWriteResult.

--- a/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
@@ -86,7 +86,7 @@ namespace BizHawk.Client.Common
 
 		public void CloseEmulator(int? exitCode = null) => _mainForm.CloseEmulator(exitCode);
 
-		public void CloseRom() => _mainForm.CloseRom();
+		public void CloseRom() => _mainForm.LoadNullRom();
 
 		public void DisplayMessages(bool value) => _config.DisplayMessages = value;
 

--- a/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/EmuClientApi.cs
@@ -162,7 +162,16 @@ namespace BizHawk.Client.Common
 
 		public void SaveRam() => _mainForm.FlushSaveRAM();
 
-		public void SaveState(string name) => _mainForm.SaveState(Path.Combine(_config.PathEntries.SaveStateAbsolutePath(Game.System), $"{name}.State"), name, fromLua: false);
+		// TODO: Change return type to FileWriteResult.
+		// We may wish to change more than that, since we have a mostly-dupicate ISaveStateApi.Save, neither has documentation indicating what the differences are.
+		public void SaveState(string name)
+		{
+			FileWriteResult result = _mainForm.SaveState(Path.Combine(_config.PathEntries.SaveStateAbsolutePath(Game.System), $"{name}.State"), name);
+			if (result.Exception != null && result.Exception is not UnlessUsingApiException)
+			{
+				throw result.Exception;
+			}
+		}
 
 		public int ScreenHeight() => _displayManager.GetPanelNativeSize().Height;
 

--- a/src/BizHawk.Client.Common/Api/Classes/MovieApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/MovieApi.cs
@@ -52,6 +52,7 @@ namespace BizHawk.Client.Common
 			return Bk2LogEntryGenerator.GenerateLogEntry(_movieSession.Movie.GetInputState(frame));
 		}
 
+		// TODO: Change return type to FileWriteResult
 		public void Save(string filename)
 		{
 			if (_movieSession.Movie.NotActive())
@@ -69,7 +70,8 @@ namespace BizHawk.Client.Common
 				}
 				_movieSession.Movie.Filename = filename;
 			}
-			_movieSession.Movie.Save();
+			FileWriteResult result = _movieSession.Movie.Save();
+			if (result.Exception != null) throw result.Exception;
 		}
 
 		public IReadOnlyDictionary<string, string> GetHeader()

--- a/src/BizHawk.Client.Common/Api/Classes/SaveStateApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/SaveStateApi.cs
@@ -39,8 +39,17 @@ namespace BizHawk.Client.Common
 			return _mainForm.LoadQuickSave(slotNum, suppressOSD: suppressOSD);
 		}
 
-		public void Save(string path, bool suppressOSD) => _mainForm.SaveState(path, path, true, suppressOSD);
+		// TODO: Change return type FileWriteResult.
+		public void Save(string path, bool suppressOSD)
+		{
+			FileWriteResult result = _mainForm.SaveState(path, path, suppressOSD);
+			if (result.Exception != null && result.Exception is not UnlessUsingApiException)
+			{
+				throw result.Exception;
+			}
+		}
 
+		// TODO: Change return type to FileWriteResult.
 		public void SaveSlot(int slotNum, bool suppressOSD)
 		{
 			if (slotNum is < 0 or > 10) throw new ArgumentOutOfRangeException(paramName: nameof(slotNum), message: ERR_MSG_NOT_A_SLOT);
@@ -49,7 +58,11 @@ namespace BizHawk.Client.Common
 				LogCallback(ERR_MSG_USE_SLOT_10);
 				slotNum = 10;
 			}
-			_mainForm.SaveQuickSave(slotNum, suppressOSD: suppressOSD, fromLua: true);
+			FileWriteResult result = _mainForm.SaveQuickSave(slotNum, suppressOSD: suppressOSD);
+			if (result.Exception != null && result.Exception is not UnlessUsingApiException)
+			{
+				throw result.Exception;
+			}
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/DialogControllerExtensions.cs
+++ b/src/BizHawk.Client.Common/DialogControllerExtensions.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace BizHawk.Client.Common
@@ -63,6 +64,20 @@ namespace BizHawk.Client.Common
 			string? caption = null,
 			EMsgBoxIcon? icon = null)
 				=> dialogParent.DialogController.ShowMessageBox3(owner: dialogParent, text: text, caption: caption, icon: icon);
+
+		public static void ErrorMessageBox(
+			this IDialogParent dialogParent,
+			FileWriteResult fileResult,
+			string? prefixMessage = null)
+		{
+			Debug.Assert(fileResult.IsError && fileResult.Exception != null, "Error box must have an error.");
+
+			string prefix = prefixMessage == null ? "" : prefixMessage + "\n";
+			dialogParent.ModalMessageBox(
+				text: $"{prefix}{fileResult.UserFriendlyErrorMessage()}\n{fileResult.Exception!.Message}",
+				caption: "Error",
+				icon: EMsgBoxIcon.Error);
+		}
 
 		/// <summary>Creates and shows a <c>System.Windows.Forms.OpenFileDialog</c> or equivalent with the receiver (<paramref name="dialogParent"/>) as its parent</summary>
 		/// <param name="discardCWDChange"><c>OpenFileDialog.RestoreDirectory</c> (isn't this useless when specifying <paramref name="initDir"/>? keeping it for backcompat)</param>

--- a/src/BizHawk.Client.Common/DialogControllerExtensions.cs
+++ b/src/BizHawk.Client.Common/DialogControllerExtensions.cs
@@ -6,6 +6,13 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace BizHawk.Client.Common
 {
+	public enum TryAgainResult
+	{
+		Saved,
+		IgnoredFailure,
+		Canceled,
+	}
+
 	public static class DialogControllerExtensions
 	{
 		public static void AddOnScreenMessage(
@@ -84,7 +91,7 @@ namespace BizHawk.Client.Common
 		/// The user will be repeatedly asked if they want to try again until either success or the user says no.
 		/// </summary>
 		/// <returns>Returns true on success or if the user said no. Returns false if the user said cancel.</returns>
-		public static bool DoWithTryAgainBox(
+		public static TryAgainResult DoWithTryAgainBox(
 			this IDialogParent dialogParent,
 			Func<FileWriteResult> action,
 			string message)
@@ -98,12 +105,12 @@ namespace BizHawk.Client.Common
 							$"{fileResult.UserFriendlyErrorMessage()}\n{fileResult.Exception!.Message}",
 						caption: "Error",
 						icon: EMsgBoxIcon.Error);
-				if (askResult == null) return false;
-				if (askResult == false) return true;
+				if (askResult == null) return TryAgainResult.Canceled;
+				if (askResult == false) return TryAgainResult.IgnoredFailure;
 				if (askResult == true) fileResult = action();
 			}
 
-			return true;
+			return TryAgainResult.Saved;
 		}
 
 		/// <summary>Creates and shows a <c>System.Windows.Forms.OpenFileDialog</c> or equivalent with the receiver (<paramref name="dialogParent"/>) as its parent</summary>

--- a/src/BizHawk.Client.Common/FileWriteResult.cs
+++ b/src/BizHawk.Client.Common/FileWriteResult.cs
@@ -1,0 +1,96 @@
+﻿#nullable enable
+
+using System.Diagnostics;
+using System.IO;
+
+namespace BizHawk.Client.Common
+{
+	public enum FileWriteEnum
+	{
+		Success,
+		FailedToOpen,
+		FailedDuringWrite,
+		FailedToDeleteOldFile,
+		FailedToRename,
+	}
+
+	/// <summary>
+	/// Provides information about the success or failure of an attempt to write to a file.
+	/// </summary>
+	public class FileWriteResult
+	{
+		public readonly FileWriteEnum Error = FileWriteEnum.Success;
+		public readonly Exception? Exception;
+		public readonly string WritePath;
+
+		public bool IsError => Error != FileWriteEnum.Success;
+
+		public FileWriteResult(FileWriteEnum error, string path, Exception? exception)
+		{
+			Error = error;
+			Exception = exception;
+			WritePath = path;
+		}
+
+		/// <summary>
+		/// Converts this instance to a different generic type.
+		/// The new instance will take the value given only if this instance has no error.
+		/// </summary>
+		/// <param name="value">The value of the new instance. Ignored if this instance has an error.</param>
+		public FileWriteResult<T> Convert<T>(T value) where T : class
+		{
+			if (Error == FileWriteEnum.Success) return new(value, WritePath);
+			else return new(this);
+		}
+
+		public FileWriteResult(FileWriteResult other) : this(other.Error, other.WritePath, other.Exception) { }
+
+		public string UserFriendlyErrorMessage()
+		{
+			switch (Error)
+			{
+				case FileWriteEnum.Success:
+					return $"The file {WritePath} was written successfully.";
+				case FileWriteEnum.FailedToOpen:
+					if (WritePath.Contains(".saving"))
+					{
+						return $"The temporary file {WritePath} already exists and could not be deleted.";
+					}
+					return $"The file {WritePath} could not be created.";
+				case FileWriteEnum.FailedDuringWrite:
+					return $"An error occurred while writing the file."; // No file name here; it should be deleted.
+				case FileWriteEnum.FailedToDeleteOldFile:
+					string fileWithoutPath = Path.GetFileName(WritePath);
+					return $"The file {WritePath} was created successfully, but the old file could not be deleted. You may manually rename the temporary file {fileWithoutPath}.";
+				case FileWriteEnum.FailedToRename:
+					fileWithoutPath = Path.GetFileName(WritePath);
+					return $"The file {WritePath} was created successfully, but could not be renamed. You may manually rename the temporary file {fileWithoutPath}.";
+				default:
+					return "unreachable";
+			}
+		}
+	}
+
+	/// <summary>
+	/// Provides information about the success or failure of an attempt to write to a file.
+	/// If successful, also provides a related object instance.
+	/// </summary>
+	public class FileWriteResult<T> : FileWriteResult where T : class // Note: "class" also means "notnull".
+	{
+		/// <summary>
+		/// Value will be null if <see cref="FileWriteResult.IsError"/> is true.
+		/// Otherwise, Value will not be null.
+		/// </summary>
+		public readonly T? Value = default;
+
+		public FileWriteResult(FileWriteEnum error, string path, Exception? exception) : base(error, path, exception) { }
+
+		public FileWriteResult(T value, string path) : base(FileWriteEnum.Success, path, null)
+		{
+			Debug.Assert(value != null, "Should not give a null value on success. Use the non-generic type if there is no value.");
+			Value = value;
+		}
+
+		public FileWriteResult(FileWriteResult other) : base(other.Error, other.WritePath, other.Exception) { }
+	}
+}

--- a/src/BizHawk.Client.Common/FileWriteResult.cs
+++ b/src/BizHawk.Client.Common/FileWriteResult.cs
@@ -7,12 +7,17 @@ namespace BizHawk.Client.Common
 	public enum FileWriteEnum
 	{
 		Success,
+		// Failures during a FileWriter write.
 		FailedToOpen,
 		FailedDuringWrite,
 		FailedToDeleteOldBackup,
 		FailedToMakeBackup,
 		FailedToDeleteOldFile,
 		FailedToRename,
+		Aborted,
+		// Failures from other sources
+		FailedToDeleteGeneric,
+		FailedToMoveForSwap,
 	}
 
 	/// <summary>
@@ -26,7 +31,7 @@ namespace BizHawk.Client.Common
 
 		public bool IsError => Error != FileWriteEnum.Success;
 
-		internal FileWriteResult(FileWriteEnum error, FileWritePaths writer, Exception? exception)
+		public FileWriteResult(FileWriteEnum error, FileWritePaths writer, Exception? exception)
 		{
 			Error = error;
 			Exception = exception;
@@ -65,6 +70,15 @@ namespace BizHawk.Client.Common
 					return $"The file \"{Paths.Final}\" could not be created.";
 				case FileWriteEnum.FailedDuringWrite:
 					return $"An error occurred while writing the file."; // No file name here; it should be deleted.
+				case FileWriteEnum.Aborted:
+					return "The operation was aborted.";
+
+				case FileWriteEnum.FailedToDeleteGeneric:
+					return $"The file \"{Paths.Final}\" could not be deleted.";
+				//case FileWriteEnum.FailedToDeleteForSwap:
+				//	return $"Failed to swap files. Unable to write to \"{Paths.Final}\"";
+				case FileWriteEnum.FailedToMoveForSwap:
+					return $"Failed to swap files. Unable to rename \"{Paths.Temp}\" to \"{Paths.Final}\"";
 			}
 
 			string success = $"The file was created successfully at \"{Paths.Temp}\" but could not be moved";
@@ -105,5 +119,13 @@ namespace BizHawk.Client.Common
 		}
 
 		public FileWriteResult(FileWriteResult other) : base(other.Error, other.Paths, other.Exception) { }
+	}
+
+	/// <summary>
+	/// This only exists as a way to avoid changing the API behavior.
+	/// </summary>
+	public class UnlessUsingApiException : Exception
+	{
+		public UnlessUsingApiException(string message) : base(message) { }
 	}
 }

--- a/src/BizHawk.Client.Common/FileWriter.cs
+++ b/src/BizHawk.Client.Common/FileWriter.cs
@@ -39,6 +39,23 @@ namespace BizHawk.Client.Common
 			_stream = stream;
 		}
 
+		public static FileWriteResult Write(string path, byte[] bytes, string? backupPath = null)
+		{
+			FileWriteResult<FileWriter> createResult = Create(path);
+			if (createResult.IsError) return createResult;
+
+			try
+			{
+				createResult.Value!.Stream.Write(bytes);
+			}
+			catch (Exception ex)
+			{
+				return new(FileWriteEnum.FailedDuringWrite, createResult.Value!.Paths, ex);
+			}
+
+			return createResult.Value.CloseAndDispose(backupPath);
+		}
+
 
 		/// <summary>
 		/// Create a FileWriter instance, or return an error if unable to access the file.

--- a/src/BizHawk.Client.Common/FileWriter.cs
+++ b/src/BizHawk.Client.Common/FileWriter.cs
@@ -167,8 +167,7 @@ namespace BizHawk.Client.Common
 			if (_dispoed) return;
 			_dispoed = true;
 
-			_stream!.Flush(flushToDisk: true);
-			_stream.Dispose();
+			_stream!.Dispose();
 			_stream = null;
 
 			// The caller should call CloseAndDispose and handle potential failure.

--- a/src/BizHawk.Client.Common/FileWriter.cs
+++ b/src/BizHawk.Client.Common/FileWriter.cs
@@ -2,57 +2,69 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 
 using BizHawk.Common.StringExtensions;
 
 namespace BizHawk.Client.Common
 {
+	public class FileWritePaths(string final, string temp)
+	{
+		public readonly string Final = final;
+		public readonly string Temp = temp;
+		public string? Backup;
+	}
+
+	/// <summary>
+	/// Provides a mechanism for safely overwriting files, by using a temporary file that only replaces the original after writing has been completed.
+	/// Optionally makes a backup of the original file.
+	/// </summary>
 	public class FileWriter : IDisposable
 	{
+
 		private FileStream? _stream; // is never null until this.Dispose()
 		public FileStream Stream
 		{
 			get => _stream ?? throw new ObjectDisposedException("Cannot access a disposed FileStream.");
 		}
-		public string FinalPath;
-		public string TempPath;
+		public FileWritePaths Paths;
 
-		public bool UsingTempFile => TempPath != FinalPath;
+		public bool UsingTempFile => Paths.Temp != Paths.Final;
 
 		private bool _finished = false;
 
-		private FileWriter(string final, string temp, FileStream stream)
+		private FileWriter(FileWritePaths paths, FileStream stream)
 		{
-			FinalPath = final;
-			TempPath = temp;
+			Paths = paths;
 			_stream = stream;
 		}
 
-		// There is no public constructor. This is the only way to create an instance.
+
+		/// <summary>
+		/// Create a FileWriter instance, or return an error if unable to access the file.
+		/// </summary>
 		public static FileWriteResult<FileWriter> Create(string path)
 		{
 			string writePath = path;
+			// If the file already exists, we will write to a temporary location first and preserve the old one until we're done.
+			if (File.Exists(path))
+			{
+				writePath = path.InsertBeforeLast('.', ".saving", out bool inserted);
+				if (!inserted) writePath = $"{path}.saving";
+
+				// The file might already exist, if a prior file write failed.
+				// Maybe the user should have dealt with this on the previously failed save.
+				// But we want to support plain old "try again", so let's ignore that.
+			}
+			FileWritePaths paths = new(path, writePath);
 			try
 			{
-				// If the file already exists, we will write to a temporary location first and preserve the old one until we're done.
-				if (File.Exists(path))
-				{
-					writePath = path.InsertBeforeLast('.', ".saving", out bool inserted);
-					if (!inserted) writePath = $"{path}.saving";
-
-					if (File.Exists(writePath))
-					{
-						// The user should probably have dealt with this on the previously failed save.
-						// But maybe we should support plain old "try again", so let's delete it.
-						File.Delete(writePath);
-					}
-				}
 				FileStream fs = new(writePath, FileMode.Create, FileAccess.Write);
-				return new(new FileWriter(path, writePath, fs), writePath);
+				return new(new FileWriter(paths, fs), paths);
 			}
 			catch (Exception ex) // There are many exception types that file operations might raise.
 			{
-				return new(FileWriteEnum.FailedToOpen, writePath, ex);
+				return new(FileWriteEnum.FailedToOpen, paths, ex);
 			}
 		}
 
@@ -60,8 +72,9 @@ namespace BizHawk.Client.Common
 		/// This method must be called after writing has finished and must not be called twice.
 		/// Dispose will be called regardless of the result.
 		/// </summary>
+		/// <param name="backupPath">If not null, renames the original file to this path.</param>
 		/// <exception cref="InvalidOperationException">If called twice.</exception>
-		public FileWriteResult CloseAndDispose()
+		public FileWriteResult CloseAndDispose(string? backupPath = null)
 		{
 			// In theory it might make sense to allow the user to try again if we fail inside this method.
 			// If we implement that, it is probably best to make a static method that takes a FileWriteResult.
@@ -71,29 +84,63 @@ namespace BizHawk.Client.Common
 			_finished = true;
 			Dispose();
 
-			if (!UsingTempFile) return new(FileWriteEnum.Success, FinalPath, null);
-
-			if (File.Exists(FinalPath))
+			Paths.Backup = backupPath;
+			if (!UsingTempFile)
 			{
-				try
-				{
-					File.Delete(FinalPath);
-				}
-				catch (Exception ex)
-				{
-					return new(FileWriteEnum.FailedToDeleteOldFile, TempPath, ex);
-				}
+				// The chosen file did not already exist, so there is nothing to back up and nothing to rename.
+				return new(FileWriteEnum.Success, Paths, null);
 			}
+
 			try
 			{
-				File.Move(TempPath, FinalPath);
+				// When everything goes right, this is all we need.
+				File.Replace(Paths.Temp, Paths.Final, backupPath);
+				return new(FileWriteEnum.Success, Paths, null);
 			}
-			catch (Exception ex)
+			catch
 			{
-				return new(FileWriteEnum.FailedToRename, TempPath, ex);
+				// When things go wrong, we have to do a lot of work in order to
+				// figure out what went wrong and tell the user.
+				return FindTheError();
+			}
+		}
+
+		private FileWriteResult FindTheError()
+		{
+			// It is an unfortunate reality that .NET provides horrible exception messages
+			// when using File.Replace(source, destination, backup). They are not only
+			// unhelpful by not telling which file operation failed, but can also be a lie.
+			// File.Move isn't great either.
+			// So, we will split this into multiple parts and subparts.
+
+			// 1) Handle backup file, if necessary
+			//    a) Delete the old backup, if it exists. We check existence here to avoid DirectoryNotFound errors.
+			//       If this fails, return that failure.
+			//       If it succeeded but the file somehow still exists, report that error.
+			//    b) Ensure the target directory exists.
+			//       Rename the original file, and similarly report any errors.
+			// 2) Handle renaming of temp file, the same way renaming of original for backup was done.
+
+			if (Paths.Backup != null)
+			{
+				try { DeleteIfExists(Paths.Backup); }
+				catch (Exception ex) { return new(FileWriteEnum.FailedToDeleteOldBackup, Paths, ex); }
+				if (!TryWaitForFileToVanish(Paths.Backup)) return new(FileWriteEnum.FailedToDeleteOldBackup, Paths, new Exception("The file was supposedly deleted but is still there."));
+
+				try { MoveFile(Paths.Final, Paths.Backup); }
+				catch (Exception ex) { return new(FileWriteEnum.FailedToMakeBackup, Paths, ex); }
+				if (!TryWaitForFileToVanish(Paths.Final)) return new(FileWriteEnum.FailedToMakeBackup, Paths, new Exception("The file was supposedly moved but is still in the orignal location."));
 			}
 
-			return new(FileWriteEnum.Success, FinalPath, null);
+			try { DeleteIfExists(Paths.Final); }
+			catch (Exception ex) { return new(FileWriteEnum.FailedToDeleteOldFile, Paths, ex); }
+			if (!TryWaitForFileToVanish(Paths.Final)) return new(FileWriteEnum.FailedToDeleteOldFile, Paths, new Exception("The file was supposedly deleted but is still there."));
+
+			try { MoveFile(Paths.Temp, Paths.Final); }
+			catch (Exception ex) { return new(FileWriteEnum.FailedToRename, Paths, ex); }
+			if (!TryWaitForFileToVanish(Paths.Temp)) return new(FileWriteEnum.FailedToRename, Paths, new Exception("The file was supposedly moved but is still in the orignal location."));
+
+			return new(FileWriteEnum.Success, Paths, null);
 		}
 
 		/// <summary>
@@ -109,7 +156,7 @@ namespace BizHawk.Client.Common
 			try
 			{
 				// Delete because the file is almost certainly useless and just clutter.
-				File.Delete(TempPath);
+				File.Delete(Paths.Temp);
 			}
 			catch { /* eat? this is probably not very important */ }
 		}
@@ -126,6 +173,36 @@ namespace BizHawk.Client.Common
 
 			// The caller should call CloseAndDispose and handle potential failure.
 			Debug.Assert(_finished, $"{nameof(FileWriteResult)} should not be disposed before calling {nameof(CloseAndDispose)}");
+		}
+
+
+		private static void DeleteIfExists(string path)
+		{
+			if (File.Exists(path))
+			{
+				File.Delete(path);
+			}
+		}
+
+		private static void MoveFile(string source, string destination)
+		{
+			FileInfo file = new(destination);
+			file.Directory.Create();
+			File.Move(source, destination);
+		}
+
+		/// <summary>
+		/// Supposedly it is possible for File.Delete to return before the file has actually been deleted.
+		/// And File.Move too, I guess.
+		/// </summary>
+		private static bool TryWaitForFileToVanish(string path)
+		{
+			for (var i = 25; i != 0; i--)
+			{
+				if (!File.Exists(path)) return true;
+				Thread.Sleep(10);
+			}
+			return false;
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/FileWriter.cs
+++ b/src/BizHawk.Client.Common/FileWriter.cs
@@ -1,0 +1,131 @@
+﻿#nullable enable
+
+using System.Diagnostics;
+using System.IO;
+
+using BizHawk.Common.StringExtensions;
+
+namespace BizHawk.Client.Common
+{
+	public class FileWriter : IDisposable
+	{
+		private FileStream? _stream; // is never null until this.Dispose()
+		public FileStream Stream
+		{
+			get => _stream ?? throw new ObjectDisposedException("Cannot access a disposed FileStream.");
+		}
+		public string FinalPath;
+		public string TempPath;
+
+		public bool UsingTempFile => TempPath != FinalPath;
+
+		private bool _finished = false;
+
+		private FileWriter(string final, string temp, FileStream stream)
+		{
+			FinalPath = final;
+			TempPath = temp;
+			_stream = stream;
+		}
+
+		// There is no public constructor. This is the only way to create an instance.
+		public static FileWriteResult<FileWriter> Create(string path)
+		{
+			string writePath = path;
+			try
+			{
+				// If the file already exists, we will write to a temporary location first and preserve the old one until we're done.
+				if (File.Exists(path))
+				{
+					writePath = path.InsertBeforeLast('.', ".saving", out bool inserted);
+					if (!inserted) writePath = $"{path}.saving";
+
+					if (File.Exists(writePath))
+					{
+						// The user should probably have dealt with this on the previously failed save.
+						// But maybe we should support plain old "try again", so let's delete it.
+						File.Delete(writePath);
+					}
+				}
+				FileStream fs = new(writePath, FileMode.Create, FileAccess.Write);
+				return new(new FileWriter(path, writePath, fs), writePath);
+			}
+			catch (Exception ex) // There are many exception types that file operations might raise.
+			{
+				return new(FileWriteEnum.FailedToOpen, writePath, ex);
+			}
+		}
+
+		/// <summary>
+		/// This method must be called after writing has finished and must not be called twice.
+		/// Dispose will be called regardless of the result.
+		/// </summary>
+		/// <exception cref="InvalidOperationException">If called twice.</exception>
+		public FileWriteResult CloseAndDispose()
+		{
+			// In theory it might make sense to allow the user to try again if we fail inside this method.
+			// If we implement that, it is probably best to make a static method that takes a FileWriteResult.
+			// So even then, this method should not ever be called twice.
+			if (_finished) throw new InvalidOperationException("Cannot close twice.");
+
+			_finished = true;
+			Dispose();
+
+			if (!UsingTempFile) return new(FileWriteEnum.Success, FinalPath, null);
+
+			if (File.Exists(FinalPath))
+			{
+				try
+				{
+					File.Delete(FinalPath);
+				}
+				catch (Exception ex)
+				{
+					return new(FileWriteEnum.FailedToDeleteOldFile, TempPath, ex);
+				}
+			}
+			try
+			{
+				File.Move(TempPath, FinalPath);
+			}
+			catch (Exception ex)
+			{
+				return new(FileWriteEnum.FailedToRename, TempPath, ex);
+			}
+
+			return new(FileWriteEnum.Success, FinalPath, null);
+		}
+
+		/// <summary>
+		/// Closes and deletes the file. Use if there was an error while writing.
+		/// Do not call <see cref="CloseAndDispose"/> after this.
+		/// </summary>
+		public void Abort()
+		{
+			if (_dispoed) throw new ObjectDisposedException("Cannot use a disposed file stream.");
+			_finished = true;
+			Dispose();
+
+			try
+			{
+				// Delete because the file is almost certainly useless and just clutter.
+				File.Delete(TempPath);
+			}
+			catch { /* eat? this is probably not very important */ }
+		}
+
+		private bool _dispoed;
+		public void Dispose()
+		{
+			if (_dispoed) return;
+			_dispoed = true;
+
+			_stream!.Flush(flushToDisk: true);
+			_stream.Dispose();
+			_stream = null;
+
+			// The caller should call CloseAndDispose and handle potential failure.
+			Debug.Assert(_finished, $"{nameof(FileWriteResult)} should not be disposed before calling {nameof(CloseAndDispose)}");
+		}
+	}
+}

--- a/src/BizHawk.Client.Common/FileWriter.cs
+++ b/src/BizHawk.Client.Common/FileWriter.cs
@@ -56,6 +56,22 @@ namespace BizHawk.Client.Common
 			return createResult.Value.CloseAndDispose(backupPath);
 		}
 
+		public static FileWriteResult Write(string path, Action<Stream> writeCallback, string? backupPath = null)
+		{
+			FileWriteResult<FileWriter> createResult = Create(path);
+			if (createResult.IsError) return createResult;
+
+			try
+			{
+				writeCallback(createResult.Value!.Stream);
+			}
+			catch (Exception ex)
+			{
+				return new(FileWriteEnum.FailedDuringWrite, createResult.Value!.Paths, ex);
+			}
+
+			return createResult.Value.CloseAndDispose(backupPath);
+		}
 
 		/// <summary>
 		/// Create a FileWriter instance, or return an error if unable to access the file.
@@ -76,6 +92,7 @@ namespace BizHawk.Client.Common
 			FileWritePaths paths = new(path, writePath);
 			try
 			{
+				Directory.CreateDirectory(Path.GetDirectoryName(path));
 				FileStream fs = new(writePath, FileMode.Create, FileAccess.Write);
 				return new(new FileWriter(paths, fs), paths);
 			}

--- a/src/BizHawk.Client.Common/FrameworkZipWriter.cs
+++ b/src/BizHawk.Client.Common/FrameworkZipWriter.cs
@@ -47,7 +47,7 @@ namespace BizHawk.Client.Common
 			return fs.Convert(ret);
 		}
 
-		public FileWriteResult CloseAndDispose()
+		public FileWriteResult CloseAndDispose(string? backupPath = null)
 		{
 			if (_archive == null || _fs == null) throw new ObjectDisposedException("Cannot use disposed ZipWriter.");
 
@@ -58,11 +58,11 @@ namespace BizHawk.Client.Common
 			FileWriteResult ret;
 			if (_writeException == null)
 			{
-				ret = _fs.CloseAndDispose();
+				ret = _fs.CloseAndDispose(backupPath);
 			}
 			else
 			{
-				ret = new(FileWriteEnum.FailedDuringWrite, _fs.TempPath, _writeException);
+				ret = new(FileWriteEnum.FailedDuringWrite, _fs.Paths, _writeException);
 				_fs.Abort();
 			}
 

--- a/src/BizHawk.Client.Common/FrameworkZipWriter.cs
+++ b/src/BizHawk.Client.Common/FrameworkZipWriter.cs
@@ -11,16 +11,17 @@ namespace BizHawk.Client.Common
 	{
 		private ZipArchive? _archive;
 
-		private FileStream? _fs;
+		private FileWriter? _fs;
 
 		private Zstd? _zstd;
 		private readonly CompressionLevel _level;
 		private readonly int _zstdCompressionLevel;
 
-		public FrameworkZipWriter(string path, int compressionLevel)
+		private Exception? _writeException = null;
+		private bool _disposed;
+
+		private FrameworkZipWriter(int compressionLevel)
 		{
-			_fs = new(path, FileMode.Create, FileAccess.Write);
-			_archive = new(_fs, ZipArchiveMode.Create, leaveOpen: true);
 			if (compressionLevel == 0)
 				_level = CompressionLevel.NoCompression;
 			else if (compressionLevel < 5)
@@ -34,32 +35,95 @@ namespace BizHawk.Client.Common
 			_zstdCompressionLevel = compressionLevel * 2 + 1;
 		}
 
-		public void WriteItem(string name, Action<Stream> callback, bool zstdCompress)
+		public static FileWriteResult<FrameworkZipWriter> Create(string path, int compressionLevel)
 		{
-			// don't compress with deflate if we're already compressing with zstd
-			// this won't produce meaningful compression, and would just be a timesink
-			using var stream = _archive!.CreateEntry(name, zstdCompress ? CompressionLevel.NoCompression : _level).Open();
+			FileWriteResult<FileWriter> fs = FileWriter.Create(path);
+			if (fs.IsError) return new(fs);
 
-			if (zstdCompress)
+			FrameworkZipWriter ret = new(compressionLevel);
+			ret._fs = fs.Value!;
+			ret._archive = new(ret._fs.Stream, ZipArchiveMode.Create, leaveOpen: true);
+
+			return fs.Convert(ret);
+		}
+
+		public FileWriteResult CloseAndDispose()
+		{
+			if (_archive == null || _fs == null) throw new ObjectDisposedException("Cannot use disposed ZipWriter.");
+
+			// We actually have to do this here since it has to be done before the file stream is closed.
+			_archive.Dispose();
+			_archive = null;
+
+			FileWriteResult ret;
+			if (_writeException == null)
 			{
-				using var z = _zstd!.CreateZstdCompressionStream(stream, _zstdCompressionLevel);
-				callback(z);
+				ret = _fs.CloseAndDispose();
 			}
 			else
 			{
-				callback(stream);
+				ret = new(FileWriteEnum.FailedDuringWrite, _fs.TempPath, _writeException);
+				_fs.Abort();
+			}
+
+			// And since we have to close stuff, there's really no point in not disposing here.
+			Dispose();
+			return ret;
+		}
+
+		public void Abort()
+		{
+			if (_archive == null || _fs == null) throw new ObjectDisposedException("Cannot use disposed ZipWriter.");
+
+			_archive.Dispose();
+			_archive = null;
+
+			_fs.Abort();
+
+			Dispose();
+		}
+
+		public void WriteItem(string name, Action<Stream> callback, bool zstdCompress)
+		{
+			if (_archive == null || _zstd == null) throw new ObjectDisposedException("Cannot use disposed ZipWriter.");
+			if (_writeException != null) return;
+
+			try
+			{
+				// don't compress with deflate if we're already compressing with zstd
+				// this won't produce meaningful compression, and would just be a timesink
+				using var stream = _archive.CreateEntry(name, zstdCompress ? CompressionLevel.NoCompression : _level).Open();
+
+				if (zstdCompress)
+				{
+					using var z = _zstd.CreateZstdCompressionStream(stream, _zstdCompressionLevel);
+					callback(z);
+				}
+				else
+				{
+					callback(stream);
+				}
+			}
+			catch (Exception ex)
+			{
+				_writeException = ex;
+				// We aren't returning the failure until closing. Should we? I don't want to refactor that much calling code without a good reason.
 			}
 		}
 
 		public void Dispose()
 		{
+			if (_disposed) return;
+			_disposed = true;
+
+			// _archive should already be disposed by CloseAndDispose, but just in case
 			_archive?.Dispose();
 			_archive = null;
-			_fs?.Flush(flushToDisk: true);
-			_fs?.Dispose();
-			_fs = null;
-			_zstd?.Dispose();
+			_zstd!.Dispose();
 			_zstd = null;
+
+			_fs!.Dispose();
+			_fs = null;
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/IMainFormForApi.cs
+++ b/src/BizHawk.Client.Common/IMainFormForApi.cs
@@ -53,7 +53,7 @@ namespace BizHawk.Client.Common
 		void EnableRewind(bool enabled);
 
 		/// <remarks>only referenced from <see cref="EmuClientApi"/></remarks>
-		bool FlushSaveRAM(bool autosave = false);
+		FileWriteResult FlushSaveRAM(bool autosave = false);
 
 		/// <remarks>only referenced from <see cref="EmuClientApi"/></remarks>
 		void FrameAdvance(bool discardApiHawkSurfaces = true);

--- a/src/BizHawk.Client.Common/IMainFormForApi.cs
+++ b/src/BizHawk.Client.Common/IMainFormForApi.cs
@@ -44,7 +44,7 @@ namespace BizHawk.Client.Common
 		void CloseEmulator(int? exitCode = null);
 
 		/// <remarks>only referenced from <see cref="EmuClientApi"/></remarks>
-		void CloseRom(bool clearSram = false);
+		void LoadNullRom(bool clearSram = false);
 
 		/// <remarks>only referenced from <see cref="ClientLuaLibrary"/></remarks>
 		IDecodeResult DecodeCheatForAPI(string code, out MemoryDomain/*?*/ domain);

--- a/src/BizHawk.Client.Common/IMainFormForApi.cs
+++ b/src/BizHawk.Client.Common/IMainFormForApi.cs
@@ -97,11 +97,17 @@ namespace BizHawk.Client.Common
 		/// <remarks>only referenced from <see cref="MovieApi"/></remarks>
 		bool RestartMovie();
 
-		/// <remarks>only referenced from <see cref="SaveStateApi"/></remarks>
-		void SaveQuickSave(int slot, bool suppressOSD = false, bool fromLua = false);
+		FileWriteResult SaveQuickSave(int slot, bool suppressOSD = false);
 
+		/// <summary>
+		/// Creates a savestate and writes it to a file.
+		/// </summary>
+		/// <param name="path">The path of the file to write.</param>
+		/// <param name="userFriendlyStateName">The name to use for the state on the client's on-screen display.</param>
+		/// <param name="suppressOSD">If true, the client will not show a success message.</param>
+		/// <returns>Returns a value indicating if there was an error and (if there was) why.</returns>
 		/// <remarks>referenced from <see cref="EmuClientApi"/> and <see cref="SaveStateApi"/></remarks>
-		void SaveState(string path, string userFriendlyStateName, bool fromLua = false, bool suppressOSD = false);
+		FileWriteResult SaveState(string path, string userFriendlyStateName, bool suppressOSD = false);
 
 		/// <remarks>only referenced from <see cref="EmuClientApi"/></remarks>
 		void SeekFrameAdvance();

--- a/src/BizHawk.Client.Common/IZipWriter.cs
+++ b/src/BizHawk.Client.Common/IZipWriter.cs
@@ -7,5 +7,17 @@ namespace BizHawk.Client.Common
 	public interface IZipWriter : IDisposable
 	{
 		void WriteItem(string name, Action<Stream> callback, bool zstdCompress);
+
+		/// <summary>
+		/// This method must be called after writing has finished and must not be called twice.
+		/// Dispose will be called regardless of the result.
+		/// </summary>
+		FileWriteResult CloseAndDispose();
+
+		/// <summary>
+		/// Closes and deletes the file. Use if there was an error while writing.
+		/// Do not call <see cref="CloseAndDispose"/> after this.
+		/// </summary>
+		void Abort();
 	}
 }

--- a/src/BizHawk.Client.Common/IZipWriter.cs
+++ b/src/BizHawk.Client.Common/IZipWriter.cs
@@ -12,7 +12,8 @@ namespace BizHawk.Client.Common
 		/// This method must be called after writing has finished and must not be called twice.
 		/// Dispose will be called regardless of the result.
 		/// </summary>
-		FileWriteResult CloseAndDispose();
+		/// <param name="backupPath">If not null, renames the original file to this path.</param>
+		FileWriteResult CloseAndDispose(string? backupPath = null);
 
 		/// <summary>
 		/// Closes and deletes the file. Use if there was an error while writing.

--- a/src/BizHawk.Client.Common/config/ConfigService.cs
+++ b/src/BizHawk.Client.Common/config/ConfigService.cs
@@ -104,19 +104,14 @@ namespace BizHawk.Client.Common
 			return config ?? new T();
 		}
 
-		public static void Save(string filepath, object config)
+		public static FileWriteResult Save(string filepath, object config)
 		{
-			var file = new FileInfo(filepath);
-			try
+			return FileWriter.Write(filepath, (fs) =>
 			{
-				using var writer = file.CreateText();
+				using var writer = new StreamWriter(fs);
 				var w = new JsonTextWriter(writer) { Formatting = Formatting.Indented };
 				Serializer.Serialize(w, config);
-			}
-			catch
-			{
-				/* Eat it */
-			}
+			});
 		}
 
 		// movie 1.0 header stuff

--- a/src/BizHawk.Client.Common/lua/LuaFileList.cs
+++ b/src/BizHawk.Client.Common/lua/LuaFileList.cs
@@ -102,9 +102,8 @@ namespace BizHawk.Client.Common
 			return true;
 		}
 
-		public void Save(string path)
+		public FileWriteResult Save(string path)
 		{
-			using var sw = new StreamWriter(path);
 			var sb = new StringBuilder();
 			var saveDirectory = Path.GetDirectoryName(Path.GetFullPath(path));
 			foreach (var file in this)
@@ -123,10 +122,19 @@ namespace BizHawk.Client.Common
 				}
 			}
 
-			sw.Write(sb.ToString());
+			FileWriteResult result = FileWriter.Write(path, (fs) =>
+			{
+				using var sw = new StreamWriter(fs);
+				sw.Write(sb.ToString());
+			});
 
-			Filename = path;
-			Changes = false;
+			if (!result.IsError)
+			{
+				Filename = path;
+				Changes = false;
+			}
+
+			return result;
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
+++ b/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
@@ -71,7 +71,7 @@ namespace BizHawk.Client.Common
 			return bk2;
 		}
 
-		public static ITasMovie ConvertToSavestateAnchoredMovie(this ITasMovie old, int frame, byte[] savestate)
+		public static FileWriteResult<ITasMovie> ConvertToSavestateAnchoredMovie(this ITasMovie old, int frame, byte[] savestate)
 		{
 			string newFilename = ConvertFileNameToTasMovie(old.Filename);
 
@@ -115,11 +115,11 @@ namespace BizHawk.Client.Common
 				}
 			}
 
-			tas.Save();
-			return tas;
+			FileWriteResult saveResult = tas.Save();
+			return saveResult.Convert(tas);
 		}
 
-		public static ITasMovie ConvertToSaveRamAnchoredMovie(this ITasMovie old, byte[] saveRam)
+		public static FileWriteResult<ITasMovie> ConvertToSaveRamAnchoredMovie(this ITasMovie old, byte[] saveRam)
 		{
 			string newFilename = ConvertFileNameToTasMovie(old.Filename);
 
@@ -146,8 +146,8 @@ namespace BizHawk.Client.Common
 				tas.Subtitles.Add(sub);
 			}
 
-			tas.Save();
-			return tas;
+			FileWriteResult saveResult = tas.Save();
+			return saveResult.Convert(tas);
 		}
 
 #pragma warning disable RCS1224 // private but for unit test

--- a/src/BizHawk.Client.Common/movie/MovieSession.cs
+++ b/src/BizHawk.Client.Common/movie/MovieSession.cs
@@ -290,7 +290,7 @@ namespace BizHawk.Client.Common
 
 			Movie = null;
 
-			return result ?? new(FileWriteEnum.Success, "", null);
+			return result ?? new();
 		}
 
 		public IMovie Get(string path, bool loadMovie)

--- a/src/BizHawk.Client.Common/movie/MovieSession.cs
+++ b/src/BizHawk.Client.Common/movie/MovieSession.cs
@@ -385,6 +385,8 @@ namespace BizHawk.Client.Common
 			switch (Settings.MovieEndAction)
 			{
 				case MovieEndAction.Stop:
+					// Technically this can save the movie, but it'd be weird to be in that situation.
+					// Do we want that?
 					StopMovie();
 					break;
 				case MovieEndAction.Record:

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.IO.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.IO.cs
@@ -23,7 +23,7 @@ namespace BizHawk.Client.Common
 		{
 			if (string.IsNullOrWhiteSpace(Filename))
 			{
-				return new(FileWriteEnum.Success, "", null);
+				return new();
 			}
 
 			string backupName = Filename.InsertBeforeLast('.', insert: $".{DateTime.Now:yyyy-MM-dd HH.mm.ss}", out _);
@@ -54,7 +54,7 @@ namespace BizHawk.Client.Common
 			catch (Exception ex)
 			{
 				saver.Abort();
-				return new(FileWriteEnum.FailedDuringWrite, createResult.WritePath, ex);
+				return new(FileWriteEnum.FailedDuringWrite, createResult.Paths, ex);
 			}
 
 			FileWriteResult result = saver.CloseAndDispose();

--- a/src/BizHawk.Client.Common/movie/import/IMovieImport.cs
+++ b/src/BizHawk.Client.Common/movie/import/IMovieImport.cs
@@ -67,7 +67,11 @@ namespace BizHawk.Client.Common
 						Result.Movie.Hash = hash;
 				}
 
-				Result.Movie.Save();
+				if (Result.Movie.Save().IsError)
+				{
+					Result.Errors.Add($"Could not write the file {newFileName}");
+					return Result;
+				}
 			}
 
 			return Result;

--- a/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
+++ b/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
@@ -74,12 +74,12 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Forces the creation of a backup file of the current movie state
 		/// </summary>
-		void SaveBackup();
+		FileWriteResult SaveBackup();
 
 		/// <summary>
 		/// Instructs the movie to save the current contents to Filename
 		/// </summary>
-		void Save();
+		FileWriteResult Save();
 
 		/// <summary>updates the <see cref="HeaderKeys.CycleCount"/> and <see cref="HeaderKeys.ClockRate"/> headers from the currently loaded core</summary>
 		void SetCycleValues();

--- a/src/BizHawk.Client.Common/movie/interfaces/IMovieSession.cs
+++ b/src/BizHawk.Client.Common/movie/interfaces/IMovieSession.cs
@@ -83,7 +83,7 @@ namespace BizHawk.Client.Common
 		/// <summary>clears the queued movie</summary>
 		void AbortQueuedMovie();
 
-		void StopMovie(bool saveChanges = true);
+		FileWriteResult StopMovie(bool saveChanges = true);
 
 		/// <summary>
 		/// Create a new (Tas)Movie with the given path as filename. If <paramref name="loadMovie"/> is true,

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
@@ -210,7 +210,9 @@ namespace BizHawk.Client.Common
 			// We are in record mode so replace the movie log with the one from the savestate
 			if (Session.Settings.EnableBackupMovies && MakeBackup && Log.Count != 0)
 			{
-				SaveBackup();
+				// TODO: This isn't ideal, but making it ideal would mean a big refactor.
+				FileWriteResult saveResult = SaveBackup();
+				if (saveResult.Exception != null) throw saveResult.Exception;
 				MakeBackup = false;
 			}
 

--- a/src/BizHawk.Client.Common/savestates/SavestateFile.cs
+++ b/src/BizHawk.Client.Common/savestates/SavestateFile.cs
@@ -58,7 +58,7 @@ namespace BizHawk.Client.Common
 			_userBag = userBag;
 		}
 
-		public FileWriteResult Create(string filename, SaveStateConfig config)
+		public FileWriteResult Create(string filename, SaveStateConfig config, bool makeBackup)
 		{
 			FileWriteResult<ZipStateSaver> createResult = ZipStateSaver.Create(filename, config.CompressionLevelNormal);
 			if (createResult.IsError) return createResult;
@@ -132,7 +132,8 @@ namespace BizHawk.Client.Common
 				bs.PutLump(BinaryStateLump.LagLog, tw => tasMovie.LagLog.Save(tw), zstdCompress: true);
 			}
 
-			return bs.CloseAndDispose();
+			makeBackup = makeBackup && config.MakeBackups;
+			return bs.CloseAndDispose(makeBackup ? $"{filename}.bak" : null);
 		}
 
 		public bool Load(string path, IDialogParent dialogParent)

--- a/src/BizHawk.Client.Common/savestates/ZipStateSaver.cs
+++ b/src/BizHawk.Client.Common/savestates/ZipStateSaver.cs
@@ -48,9 +48,10 @@ namespace BizHawk.Client.Common
 		/// This method must be called after writing has finished and must not be called twice.
 		/// Dispose will be called regardless of the result.
 		/// </summary>
-		public FileWriteResult CloseAndDispose()
+		/// <param name="backupPath">If not null, renames the original file to this path.</param>
+		public FileWriteResult CloseAndDispose(string? backupPath = null)
 		{
-			FileWriteResult result = _zip.CloseAndDispose();
+			FileWriteResult result = _zip.CloseAndDispose(backupPath);
 			Dispose();
 			return result;
 		}

--- a/src/BizHawk.Client.Common/tools/CheatList.cs
+++ b/src/BizHawk.Client.Common/tools/CheatList.cs
@@ -88,19 +88,9 @@ namespace BizHawk.Client.Common
 			return file.Exists && Load(domains, file.FullName, false);
 		}
 
-		public void NewList(string defaultFileName, bool autosave = false)
+		public void NewList(string defaultFileName)
 		{
 			_defaultFileName = defaultFileName;
-
-			if (autosave && _changes && _cheatList.Count is not 0)
-			{
-				if (string.IsNullOrEmpty(CurrentFileName))
-				{
-					CurrentFileName = _defaultFileName;
-				}
-
-				Save();
-			}
 
 			_cheatList.Clear();
 			CurrentFileName = "";

--- a/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
+++ b/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
@@ -18,9 +18,6 @@ namespace BizHawk.Client.EmuHawk
 		/// <remarks>only referenced from <see cref="TAStudio"/></remarks>
 		bool EmulatorPaused { get; }
 
-		/// <remarks>only referenced from <see cref="TAStudio"/></remarks>
-		bool GameIsClosing { get; }
-
 		/// <remarks>only referenced from <see cref="PlaybackBox"/></remarks>
 		bool HoldFrameAdvance { get; set; }
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -269,7 +269,7 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		private void QuickSavestateMenuItem_Click(object sender, EventArgs e)
-			=> SaveQuickSave(int.Parse(((ToolStripMenuItem) sender).Text));
+			=> SaveQuickSaveAndShowError(int.Parse(((ToolStripMenuItem) sender).Text));
 
 		private void SaveNamedStateMenuItem_Click(object sender, EventArgs e) => SaveStateAs();
 
@@ -305,7 +305,7 @@ namespace BizHawk.Client.EmuHawk
 			=> SavestateCurrentSlot();
 
 		private void SavestateCurrentSlot()
-			=> SaveQuickSave(Config.SaveSlot);
+			=> SaveQuickSaveAndShowError(Config.SaveSlot);
 
 		private void LoadCurrentSlotMenuItem_Click(object sender, EventArgs e)
 			=> LoadstateCurrentSlot();
@@ -1383,8 +1383,15 @@ namespace BizHawk.Client.EmuHawk
 		private void UndoSavestateContextMenuItem_Click(object sender, EventArgs e)
 		{
 			var slot = Config.SaveSlot;
-			_stateSlots.SwapBackupSavestate(MovieSession.Movie, $"{SaveStatePrefix()}.QuickSave{slot % 10}.State", slot);
-			AddOnScreenMessage($"Save slot {slot} restored.");
+			FileWriteResult swapResult = _stateSlots.SwapBackupSavestate(MovieSession.Movie, $"{SaveStatePrefix()}.QuickSave{slot % 10}.State", slot);
+			if (swapResult.IsError)
+			{
+				this.ErrorMessageBox(swapResult, "Failed to swap state files.");
+			}
+			else
+			{
+				AddOnScreenMessage($"Save slot {slot} restored.");
+			}
 		}
 
 		private void ClearSramContextMenuItem_Click(object sender, EventArgs e)
@@ -1454,7 +1461,7 @@ namespace BizHawk.Client.EmuHawk
 			if (sender == Slot9StatusButton) slot = 9;
 			if (sender == Slot0StatusButton) slot = 10;
 
-			if (e.Button is MouseButtons.Right) SaveQuickSave(slot);
+			if (e.Button is MouseButtons.Right) SaveQuickSaveAndShowError(slot);
 			else if (e.Button is MouseButtons.Left && HasSlot(slot)) _ = LoadQuickSave(slot);
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -264,7 +264,7 @@ namespace BizHawk.Client.EmuHawk
 		private void CloseRomMenuItem_Click(object sender, EventArgs e)
 		{
 			Console.WriteLine($"Closing rom clicked Frame: {Emulator.Frame} Emulator: {Emulator.GetType().Name}");
-			CloseRom();
+			LoadNullRom();
 			Console.WriteLine($"Closing rom clicked DONE Frame: {Emulator.Frame} Emulator: {Emulator.GetType().Name}");
 		}
 
@@ -1396,7 +1396,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void ClearSramContextMenuItem_Click(object sender, EventArgs e)
 		{
-			CloseRom(clearSram: true);
+			LoadNullRom(clearSram: true);
 		}
 
 		private void ShowMenuContextMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -315,7 +315,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void FlushSaveRAMMenuItem_Click(object sender, EventArgs e)
 		{
-			FlushSaveRAM();
+			ShowMessageIfError(() => FlushSaveRAM(), "Failed to flush saveram!");
 		}
 
 		private void ReadonlyMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -983,8 +983,15 @@ namespace BizHawk.Client.EmuHawk
 
 		private void SaveConfigMenuItem_Click(object sender, EventArgs e)
 		{
-			SaveConfig();
-			AddOnScreenMessage("Saved settings");
+			FileWriteResult result = SaveConfig();
+			if (result.IsError)
+			{
+				this.ErrorMessageBox(result);
+			}
+			else
+			{
+				AddOnScreenMessage("Saved settings");
+			}
 		}
 
 		private void SaveConfigAsMenuItem_Click(object sender, EventArgs e)
@@ -996,8 +1003,15 @@ namespace BizHawk.Client.EmuHawk
 				initFileName: file);
 			if (result is not null)
 			{
-				SaveConfig(result);
-				AddOnScreenMessage("Copied settings");
+				FileWriteResult saveResult = SaveConfig(result);
+				if (saveResult.IsError)
+				{
+					this.ErrorMessageBox(saveResult);
+				}
+				else
+				{
+					AddOnScreenMessage("Copied settings");
+				}
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Hotkey.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Hotkey.cs
@@ -120,7 +120,7 @@ namespace BizHawk.Client.EmuHawk
 					OpenRom();
 					break;
 				case "Close ROM":
-					CloseRom();
+					LoadNullRom();
 					break;
 				case "Load Last ROM":
 					LoadMostRecentROM();

--- a/src/BizHawk.Client.EmuHawk/MainForm.Hotkey.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Hotkey.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			void SelectAndSaveToSlot(int slot)
 			{
-				SaveQuickSave(slot);
+				SaveQuickSaveAndShowError(slot);
 				Config.SaveSlot = slot;
 				UpdateStatusSlots();
 			}

--- a/src/BizHawk.Client.EmuHawk/MainForm.Hotkey.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Hotkey.cs
@@ -126,7 +126,7 @@ namespace BizHawk.Client.EmuHawk
 					LoadMostRecentROM();
 					break;
 				case "Flush SaveRAM":
-					FlushSaveRAM();
+					FlushSaveRAMMenuItem_Click(null, EventArgs.Empty);
 					break;
 				case "Display FPS":
 					ToggleFps();

--- a/src/BizHawk.Client.EmuHawk/MainForm.Movie.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Movie.cs
@@ -125,7 +125,14 @@ namespace BizHawk.Client.EmuHawk
 			}
 			else
 			{
-				MovieSession.StopMovie(saveChanges);
+				FileWriteResult saveResult = MovieSession.StopMovie(saveChanges);
+				if (saveResult.IsError)
+				{
+					this.ShowMessageBox(
+						$"Failed to save movie.\n{saveResult.UserFriendlyErrorMessage()}\n{saveResult.Exception.Message}",
+						"Error",
+						EMsgBoxIcon.Error);
+				}
 				SetMainformMovieInfo();
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3800,7 +3800,7 @@ namespace BizHawk.Client.EmuHawk
 
 					if (previousRom != CurrentlyOpenRom)
 					{
-						CheatList.NewList(Tools.GenerateDefaultCheatFilename(), autosave: true);
+						CheatList.NewList(Tools.GenerateDefaultCheatFilename());
 						if (Config.Cheats.LoadFileByGame && Emulator.HasMemoryDomains())
 						{
 							if (CheatList.AttemptToLoadCheatFile(Emulator.AsMemoryDomains()))
@@ -3817,7 +3817,7 @@ namespace BizHawk.Client.EmuHawk
 						}
 						else
 						{
-							CheatList.NewList(Tools.GenerateDefaultCheatFilename(), autosave: true);
+							CheatList.NewList(Tools.GenerateDefaultCheatFilename());
 						}
 					}
 
@@ -3860,7 +3860,7 @@ namespace BizHawk.Client.EmuHawk
 					DisplayManager.UpdateGlobals(Config, Emulator);
 					DisplayManager.Blank();
 					ExtToolManager.BuildToolStrip();
-					CheatList.NewList("", autosave: true);
+					CheatList.NewList("");
 					OnRomChanged();
 					return false;
 				}
@@ -4020,7 +4020,7 @@ namespace BizHawk.Client.EmuHawk
 				PauseOnFrame = null;
 				CurrentlyOpenRom = null;
 				CurrentlyOpenRomArgs = null;
-				CheatList.NewList("", autosave: true);
+				CheatList.NewList("");
 				OnRomChanged();
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
@@ -470,7 +470,11 @@ namespace BizHawk.Client.EmuHawk
 
 				SaveToDefaults(cd);
 
-				ConfigService.Save(Config.ControlDefaultPath, cd);
+				FileWriteResult saveResult = ConfigService.Save(Config.ControlDefaultPath, cd);
+				if (saveResult.IsError)
+				{
+					this.ErrorMessageBox(saveResult);
+				}
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/movie/EditCommentsForm.cs
+++ b/src/BizHawk.Client.EmuHawk/movie/EditCommentsForm.cs
@@ -55,7 +55,8 @@ namespace BizHawk.Client.EmuHawk
 				_movie.Comments.Add(c.Value.ToString());
 			}
 
-			_movie.Save();
+			FileWriteResult result = _movie.Save();
+			if (result.IsError) throw result.Exception!;
 		}
 
 		private void Cancel_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.cs
@@ -142,7 +142,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private bool SaveAs()
+		private FileWriteResult SaveAs()
 		{
 			var fileName = MainForm.CheatList.CurrentFileName;
 			if (string.IsNullOrWhiteSpace(fileName))
@@ -156,7 +156,8 @@ namespace BizHawk.Client.EmuHawk
 				CheatsFSFilterSet,
 				this);
 
-			return file != null && MainForm.CheatList.SaveFile(file.FullName);
+			if (file == null) return new();
+			else return MainForm.CheatList.SaveFile(file.FullName);
 		}
 
 		private void Cheats_Load(object sender, EventArgs e)
@@ -361,7 +362,12 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (MainForm.CheatList.Changes)
 			{
-				if (MainForm.CheatList.Save())
+				FileWriteResult result = MainForm.CheatList.Save();
+				if (result.IsError)
+				{
+					this.ErrorMessageBox(result);
+				}
+				else
 				{
 					UpdateMessageLabel(saved: true);
 				}
@@ -374,7 +380,12 @@ namespace BizHawk.Client.EmuHawk
 
 		private void SaveAsMenuItem_Click(object sender, EventArgs e)
 		{
-			if (SaveAs())
+			FileWriteResult result = SaveAs();
+			if (result.IsError)
+			{
+				this.ErrorMessageBox(result);
+			}
+			else
 			{
 				UpdateMessageLabel(saved: true);
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.cs
@@ -112,6 +112,7 @@ namespace BizHawk.Client.EmuHawk
 				return true;
 			}
 
+			// Intentionally not updating this to use FileWriter because this tool is going to be removed later.
 			foreach (var zone in _unsavedZones)
 			{
 				SaveMacroAs(_zones[zone]);

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.cs
@@ -289,7 +289,7 @@ namespace BizHawk.Client.EmuHawk
 				return false;
 			}
 
-			macro.Save(result);
+			macro.Save(result); // ignore errors: This tool is going to be removed.
 			Config!.RecentMacros.Add(result);
 
 			return true;

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
@@ -198,19 +198,25 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		public void Save(string fileName)
+		public FileWriteResult Save(string fileName)
 		{
 			// Save the controller definition/LogKey
 			// Save the controller name and player count. (Only for the user.)
 			// Save whether or not the macro should use overlay input, and/or replace
-			string[] header = new string[4];
-			header[0] = InputKey;
-			header[1] = _emulator.ControllerDefinition.Name;
-			header[2] = _emulator.ControllerDefinition.PlayerCount.ToString();
-			header[3] = $"{Overlay},{Replace}";
 
-			File.WriteAllLines(fileName, header);
-			File.AppendAllLines(fileName, _log);
+			return FileWriter.Write(fileName, (fs) =>
+			{
+				using var writer = new StreamWriter(fs);
+				writer.WriteLine(InputKey);
+				writer.WriteLine(_emulator.ControllerDefinition.Name);
+				writer.WriteLine(_emulator.ControllerDefinition.PlayerCount.ToString());
+				writer.WriteLine($"{Overlay},{Replace}");
+
+				foreach (string line in _log)
+				{
+					writer.WriteLine(line);
+				}
+			});
 		}
 
 		public MovieZone(string fileName, IDialogController dialogController, IEmulator emulator, IMovieSession movieSession, ToolManager tools)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
@@ -59,13 +59,10 @@
 
 		public void StopMovie(bool suppressSave)
 		{
-			if (!MainForm.GameIsClosing)
-			{
-				Activate();
-				_suppressAskSave = suppressSave;
-				StartNewTasMovie();
-				_suppressAskSave = false;
-			}
+			Activate();
+			_suppressAskSave = suppressSave;
+			StartNewTasMovie();
+			_suppressAskSave = false;
 		}
 
 		public bool WantsToControlRewind { get; private set; } = true;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
@@ -157,12 +157,23 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			if (CurrentTasMovie?.Changes is not true) return true;
-			var result = DialogController.DoWithTempMute(() => this.ModalMessageBox3(
+			var shouldSaveResult = DialogController.DoWithTempMute(() => this.ModalMessageBox3(
 				caption: "Closing with Unsaved Changes",
 				icon: EMsgBoxIcon.Question,
 				text: $"Save {WindowTitleStatic} project?"));
-			if (result is null) return false;
-			if (result.Value) SaveTas();
+			if (shouldSaveResult == true)
+			{
+				FileWriteResult saveResult = SaveTas();
+				while (saveResult.IsError && shouldSaveResult != true)
+				{
+					shouldSaveResult = this.ModalMessageBox3(
+						$"Failed to save movie. {saveResult.UserFriendlyErrorMessage()}\n{saveResult.Exception.Message}\n\nTry again?",
+						"Error",
+						EMsgBoxIcon.Error);
+					if (shouldSaveResult == true) saveResult = SaveTas();
+				}
+			}
+			if (shouldSaveResult is null) return false;
 			else CurrentTasMovie.ClearChanges();
 			return true;
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
@@ -163,15 +163,8 @@ namespace BizHawk.Client.EmuHawk
 				text: $"Save {WindowTitleStatic} project?"));
 			if (shouldSaveResult == true)
 			{
-				FileWriteResult saveResult = SaveTas();
-				while (saveResult.IsError && shouldSaveResult != true)
-				{
-					shouldSaveResult = this.ModalMessageBox3(
-						$"Failed to save movie. {saveResult.UserFriendlyErrorMessage()}\n{saveResult.Exception.Message}\n\nTry again?",
-						"Error",
-						EMsgBoxIcon.Error);
-					if (shouldSaveResult == true) saveResult = SaveTas();
-				}
+				TryAgainResult saveResult = this.DoWithTryAgainBox(() => SaveTas(), "Failed to save movie.");
+				return saveResult != TryAgainResult.Canceled;
 			}
 			if (shouldSaveResult is null) return false;
 			else CurrentTasMovie.ClearChanges();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -172,15 +172,25 @@ namespace BizHawk.Client.EmuHawk
 			if (file != null)
 			{
 				var selectionStart = TasView.SelectionStartIndex!.Value;
-				new MovieZone(
+				MovieZone macro = new(
 					Emulator,
 					Tools,
 					MovieSession,
 					start: selectionStart,
-					length: TasView.SelectionEndIndex!.Value - selectionStart + 1)
-					.Save(file.FullName);
+					length: TasView.SelectionEndIndex!.Value - selectionStart + 1);
+				FileWriteResult saveResult = macro.Save(file.FullName);
 
-				Config.RecentMacros.Add(file.FullName);
+				if (saveResult.IsError)
+				{
+					DialogController.ShowMessageBox(
+						$"Failed to save macro.\n{saveResult.UserFriendlyErrorMessage()}\n{saveResult.Exception.Message}",
+						"Error",
+						EMsgBoxIcon.Error);
+				}
+				else
+				{
+					Config.RecentMacros.Add(file.FullName);
+				}
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -974,7 +974,7 @@ namespace BizHawk.Client.EmuHawk
 			MainForm.UpdateWindowTitle();
 
 			if (fileInfo != null) return saveResult;
-			else return new(FileWriteEnum.Success, "", null); // user cancelled, so we were successful in not saving
+			else return new(); // user cancelled, so we were successful in not saving
 		}
 
 		protected override string WindowTitle

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
@@ -1008,7 +1008,13 @@ namespace BizHawk.Client.EmuHawk
 
 				if (!string.IsNullOrWhiteSpace(watches.CurrentFileName))
 				{
-					if (watches.Save())
+					FileWriteResult saveResult = watches.Save();
+					if (saveResult.IsError)
+					{
+						this.ErrorMessageBox(saveResult);
+						MessageLabel.Text = $"Failed to save {Path.GetFileName(_currentFileName)}";
+					}
+					else
 					{
 						_currentFileName = watches.CurrentFileName;
 						MessageLabel.Text = $"{Path.GetFileName(_currentFileName)} saved";
@@ -1017,11 +1023,20 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					var result = watches.SaveAs(GetWatchSaveFileFromUser(CurrentFileName()));
-					if (result)
+					FileInfo/*?*/ file = GetWatchSaveFileFromUser(CurrentFileName());
+					if (file != null)
 					{
-						MessageLabel.Text = $"{Path.GetFileName(_currentFileName)} saved";
-						Settings.RecentSearches.Add(watches.CurrentFileName);
+						var result = watches.SaveAs(file);
+						if (result.IsError)
+						{
+							this.ErrorMessageBox(result);
+							MessageLabel.Text = $"Failed to save {Path.GetFileName(_currentFileName)}";
+						}
+						else
+						{
+							MessageLabel.Text = $"{Path.GetFileName(_currentFileName)} saved";
+							Settings.RecentSearches.Add(watches.CurrentFileName);
+						}
 					}
 				}
 			}
@@ -1035,7 +1050,15 @@ namespace BizHawk.Client.EmuHawk
 				watches.Add(_searches[i]);
 			}
 
-			if (watches.SaveAs(GetWatchSaveFileFromUser(CurrentFileName())))
+			FileInfo/*?*/ file = GetWatchSaveFileFromUser(CurrentFileName());
+			if (file == null) return;
+			FileWriteResult result = watches.SaveAs(file);
+			if (result.IsError)
+			{
+				this.ErrorMessageBox(result);
+				MessageLabel.Text = $"Failed to save {Path.GetFileName(_currentFileName)}";
+			}
+			else
 			{
 				_currentFileName = watches.CurrentFileName;
 				MessageLabel.Text = $"{Path.GetFileName(_currentFileName)} saved";

--- a/src/BizHawk.Tests.Client.Common/Movie/FakeMovieSession.cs
+++ b/src/BizHawk.Tests.Client.Common/Movie/FakeMovieSession.cs
@@ -70,6 +70,10 @@ namespace BizHawk.Tests.Client.Common.Movie
 		public void PopupMessage(string message) => throw new NotImplementedException();
 		public void QueueNewMovie(IMovie movie, string systemId, string loadedRomHash, PathEntryCollection pathEntries, IDictionary<string, string> preferredCores) => throw new NotImplementedException();
 		public void RunQueuedMovie(bool recordMode, IEmulator emulator) => throw new NotImplementedException();
-		public void StopMovie(bool saveChanges = true) => Movie?.Stop();
+		public FileWriteResult StopMovie(bool saveChanges = true)
+		{
+			Movie?.Stop();
+			return new(FileWriteEnum.Success, "", null);
+		}
 	}
 }

--- a/src/BizHawk.Tests.Client.Common/Movie/FakeMovieSession.cs
+++ b/src/BizHawk.Tests.Client.Common/Movie/FakeMovieSession.cs
@@ -73,7 +73,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 		public FileWriteResult StopMovie(bool saveChanges = true)
 		{
 			Movie?.Stop();
-			return new(FileWriteEnum.Success, "", null);
+			return new();
 		}
 	}
 }


### PR DESCRIPTION
Most file writes now use a new system that allows for error detection and handling. (includes movies, config file, and all tools)
When an exception occurs, a message box appears alerting the user. If there is an exception while doing a save-on-close, the user is given the option to try again, skip saving, or cancel closing. (Includes a bug fix where an existing dialog offering the cancel option did not actually cancel.)

Addresses #4258.

Fixes an issue where the CheatList was being forcibly autosaved when closing a game, ignoring the autosave config option.

Changes behavior when saving the config file fails. Previously it would silently fail (and report success if "saved" via the menu item), now it has the same error handling as other updated file writes. The silent fail seems to have been intended to allow using a read-only config file. If we want to bring this back, I suggest making a config option to not save on close instead. As-is, a read-only file will still work you just have to click "No" after closing EmuHawk when it tells you it can't save the config file.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
