### PR TITLE
Fix input/hotkey bugs

### DIFF
--- a/src/BizHawk.Client.Common/Controller.cs
+++ b/src/BizHawk.Client.Common/Controller.cs
@@ -59,11 +59,20 @@ namespace BizHawk.Client.Common
 		public List<string> SearchBindings(string button)
 			=> _bindings.Where(b => b.Value.Contains(button)).Select(static b => b.Key).ToList();
 
-		// Searches bindings for the controller and returns true if this binding is mapped somewhere in this controller
-		public bool HasBinding(string button) =>
-			_bindings
+		/// <summary>
+		/// Checks if the given button combination would be a controller input.
+		/// This means Shift+A will return true if an input is bound to either A or Shift+A.
+		/// </summary>
+		public bool HasBinding(string button)
+		{
+			string[] buttons = button.Split('+');
+			return _bindings
 				.SelectMany(kvp => kvp.Value)
-				.Any(boundButton => boundButton == button);
+				.Any((boundCombination) => {
+					string[] boundButtons = boundCombination.Split('+');
+					return boundButtons.All((b) => buttons.Contains(b));
+				});
+		}
 
 		/// <summary>
 		/// uses the bindings to latch our own logical button state from the source controller's button state (which are assumed to be the physical side of the binding).

--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -106,7 +106,14 @@ namespace BizHawk.Client.Common
 		public Dictionary<string, string> FirmwareUserSpecifications { get; set; } = new Dictionary<string, string>();
 
 		// General Client Settings
-		public int InputHotkeyOverrideOptions { get; set; }
+		public enum InputPriority
+		{
+			BOTH,
+			INPUT,
+			HOTKEY,
+		}
+
+		public InputPriority InputHotkeyOverrideOptions { get; set; }
 		public bool NoMixedInputHokeyOverride { get; set; }
 
 		public bool StackOSDMessages { get; set; } = true;

--- a/src/BizHawk.Client.Common/controllers/StickyControllers.cs
+++ b/src/BizHawk.Client.Common/controllers/StickyControllers.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 using BizHawk.Common.CollectionExtensions;
 using BizHawk.Emulation.Common;
@@ -60,16 +59,12 @@ namespace BizHawk.Client.Common
 			_axisHolds.Clear();
 		}
 
-		private List<string> _justPressed = [ ];
-
 		public void MassToggleStickyState(List<string> buttons)
 		{
-			foreach (var button in buttons.Where(button => !_justPressed.Contains(button)))
+			foreach (var button in buttons)
 			{
 				_ = _buttonHolds.ToggleMembership(button);
 			}
-
-			_justPressed = buttons;
 		}
 	}
 
@@ -158,16 +153,12 @@ namespace BizHawk.Client.Common
 			foreach (var v in _axisPatterns.Values) v.GetNextValue(lagged);
 		}
 
-		private List<string> _justPressed = [ ];
-
 		public void MassToggleStickyState(List<string> buttons)
 		{
-			foreach (var button in buttons.Where(button => !_justPressed.Contains(button)))
+			foreach (var button in buttons)
 			{
 				SetButtonAutofire(button, !_boolPatterns.ContainsKey(button));
 			}
-
-			_justPressed = buttons;
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/input/IPhysicalInputSource.cs
+++ b/src/BizHawk.Client.Common/input/IPhysicalInputSource.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+
+using System.Collections.Generic;
+
+namespace BizHawk.Client.Common
+{
+	public interface IPhysicalInputSource
+	{
+		InputEvent? DequeueEvent();
+
+		KeyValuePair<string, int>[] GetAxisValues();
+	}
+}

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -152,6 +152,9 @@ namespace BizHawk.Client.Common
 		// input state which has been destined for client hotkey consumption are colesced here
 		private readonly InputCoalescer _hotkeyCoalescer = new InputCoalescer();
 
+		/// <summary>
+		/// Processes queued inputs and triggers input evets (i.e. hotkeys), but does not update output controllers.<br/>
+		/// </summary>
 		/// <param name="processUnboundInput">Events that did not do anything are forwarded out here.
 		/// This allows things like Windows' standard alt hotkeys (for menu items) to be handled by the
 		/// caller if the input didn't alrady do something else.</param>
@@ -262,8 +265,17 @@ namespace BizHawk.Client.Common
 				ControllerInputCoalescer.AcceptNewAxis("RMouse X", (int)(x * 10000));
 				ControllerInputCoalescer.AcceptNewAxis("RMouse Y", (int)(y * 10000));
 			}
+		}
 
+		/// <summary>
+		/// Update output controllers. Call <see cref="ProcessInput(IPhysicalInputSource, Func{string, bool}, Config, Action{InputEvent}, Func{string, bool})"/> shortly before this.
+		/// </summary>
+		public void RunControllerChain(Config config)
+		{
+			// client, only one step
 			ClientControls.LatchFromPhysical(_hotkeyCoalescer);
+
+			// controller, which actually has a chain
 			ActiveController.LatchFromPhysical(ControllerInputCoalescer);
 			ActiveController.OR_FromLogical(ClickyVirtualPadController);
 			AutoFireController.LatchFromPhysical(ControllerInputCoalescer);

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -161,8 +161,8 @@ namespace BizHawk.Client.Common
 				var hotkeyTriggers = ClientControls.SearchBindings(ie.LogicalButton.ToString());
 				bool isEmuInput = ActiveController.HasBinding(ie.LogicalButton.ToString());
 
-				bool shouldDoHotkey = config.InputHotkeyOverrideOptions != 1;
-				bool shouldDoEmuInput = config.InputHotkeyOverrideOptions != 2;
+				bool shouldDoHotkey = config.InputHotkeyOverrideOptions != Config.InputPriority.INPUT;
+				bool shouldDoEmuInput = config.InputHotkeyOverrideOptions != Config.InputPriority.HOTKEY;
 				if (shouldDoEmuInput && !isEmuInput) shouldDoHotkey = true;
 
 				bool didHotkey = false;

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -170,7 +170,7 @@ namespace BizHawk.Client.Common
 				// TODO - wonder what happens if we pop up something interactive as a response to one of these hotkeys? may need to purge further processing
 
 				var hotkeyTriggers = ClientControls.SearchBindings(ie.LogicalButton.ToString());
-				bool isEmuInput = ie.LogicalButton.ToString().Split('+').Any(ActiveController.HasBinding);
+				bool isEmuInput = ActiveController.HasBinding(ie.LogicalButton.ToString());
 
 				bool shouldDoHotkey = config.InputHotkeyOverrideOptions != 1;
 				bool shouldDoEmuInput = config.InputHotkeyOverrideOptions != 2;

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -44,7 +44,7 @@ namespace BizHawk.Client.Common
 
 		// Input state for game controller inputs are coalesced here
 		// This relies on a client specific implementation!
-		public ControllerInputCoalescer ControllerInputCoalescer { get; set; }
+		public ControllerInputCoalescer ControllerInputCoalescer { get; set; } = new();
 
 		public Controller ClientControls { get; set; }
 

--- a/src/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/src/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -9,7 +9,7 @@ using BizHawk.Common.CollectionExtensions;
 
 namespace BizHawk.Client.EmuHawk
 {
-	public class Input
+	public class Input : IPhysicalInputSource
 	{
 		/// <summary>
 		/// If your form needs this kind of input focus, be sure to say so.
@@ -30,7 +30,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private readonly Thread _updateThread;
 
-		public readonly IHostInputAdapter Adapter;
+		public IHostInputAdapter Adapter { get; }
 
 		private Config _currentConfig;
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -726,13 +726,13 @@ namespace BizHawk.Client.EmuHawk
 			switch (Config.InputHotkeyOverrideOptions)
 			{
 				default:
-				case 0:
+				case Config.InputPriority.BOTH:
 					BothHkAndControllerMenuItem.Checked = true;
 					break;
-				case 1:
+				case Config.InputPriority.INPUT:
 					InputOverHkMenuItem.Checked = true;
 					break;
-				case 2:
+				case Config.InputPriority.HOTKEY:
 					HkOverInputMenuItem.Checked = true;
 					break;
 			}
@@ -961,19 +961,19 @@ namespace BizHawk.Client.EmuHawk
 
 		private void BothHkAndControllerMenuItem_Click(object sender, EventArgs e)
 		{
-			Config.InputHotkeyOverrideOptions = 0;
+			Config.InputHotkeyOverrideOptions = Config.InputPriority.BOTH;
 			UpdateKeyPriorityIcon();
 		}
 
 		private void InputOverHkMenuItem_Click(object sender, EventArgs e)
 		{
-			Config.InputHotkeyOverrideOptions = 1;
+			Config.InputHotkeyOverrideOptions = Config.InputPriority.INPUT;
 			UpdateKeyPriorityIcon();
 		}
 
 		private void HkOverInputMenuItem_Click(object sender, EventArgs e)
 		{
-			Config.InputHotkeyOverrideOptions = 2;
+			Config.InputHotkeyOverrideOptions = Config.InputPriority.HOTKEY;
 			UpdateKeyPriorityIcon();
 		}
 
@@ -1457,9 +1457,9 @@ namespace BizHawk.Client.EmuHawk
 		{
 			Config.InputHotkeyOverrideOptions = Config.InputHotkeyOverrideOptions switch
 			{
-				1 => 2,
-				2 => Config.NoMixedInputHokeyOverride ? 1 : 0,
-				_ => 1,
+				Config.InputPriority.INPUT => Config.InputPriority.HOTKEY,
+				Config.InputPriority.HOTKEY => Config.NoMixedInputHokeyOverride ? Config.InputPriority.INPUT : Config.InputPriority.BOTH,
+				_ => Config.InputPriority.INPUT,
 			};
 			UpdateKeyPriorityIcon();
 		}

--- a/src/BizHawk.Client.EmuHawk/MainForm.Hotkey.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Hotkey.cs
@@ -26,6 +26,25 @@ namespace BizHawk.Client.EmuHawk
 				default:
 					return false;
 
+				// Hotkeys handled elsewhere, via the hotkey controller
+				case "Autohold":
+				case "Autofire":
+				case "Frame Advance":
+				case "Turbo":
+				case "Rewind":
+				case "Fast Forward":
+				case "Open RA Overlay":
+					break;
+				case "RA Up":
+				case "RA Down":
+				case "RA Left":
+				case "RA Right":
+				case "RA Confirm":
+				case "RA Cancel":
+				case "RA Quit":
+					// don't consider these keys outside of RAIntegration overlay being active
+					return RA is RAIntegration { OverlayActive: true };
+
 				// General
 				case "Pause":
 					TogglePause();
@@ -33,7 +52,7 @@ namespace BizHawk.Client.EmuHawk
 				case "Frame Inch":
 					//special! allow this key to get handled as Frame Advance, too
 					FrameInch = true;
-					return false;
+					break;
 				case "Toggle Throttle":
 					ToggleUnthrottled();
 					break;
@@ -548,33 +567,6 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			return true;
-		}
-
-		// Determines if the value is a hotkey  that would be handled outside of the CheckHotkey method
-		private bool IsInternalHotkey(string trigger)
-		{
-			switch (trigger)
-			{
-				default:
-					return false;
-				case "Autohold":
-				case "Autofire":
-				case "Frame Advance":
-				case "Turbo":
-				case "Rewind":
-				case "Fast Forward":
-				case "Open RA Overlay":
-					return true;
-				case "RA Up":
-				case "RA Down":
-				case "RA Left":
-				case "RA Right":
-				case "RA Confirm":
-				case "RA Cancel":
-				case "RA Quit":
-					// don't consider these keys outside of RAIntegration overlay being active
-					return RA is RAIntegration { OverlayActive: true };
-			}
 		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2751,15 +2751,15 @@ namespace BizHawk.Client.EmuHawk
 			switch (Config.InputHotkeyOverrideOptions)
 			{
 				default:
-				case 0:
+				case Config.InputPriority.BOTH:
 					KeyPriorityStatusLabel.Image = Properties.Resources.Both;
 					KeyPriorityStatusLabel.ToolTipText = "Key priority: Allow both hotkeys and controller buttons";
 					break;
-				case 1:
+				case Config.InputPriority.INPUT:
 					KeyPriorityStatusLabel.Image = Properties.Resources.GameController;
 					KeyPriorityStatusLabel.ToolTipText = "Key priority: Controller buttons will override hotkeys";
 					break;
-				case 2:
+				case Config.InputPriority.HOTKEY:
 					KeyPriorityStatusLabel.Image = Properties.Resources.HotKeys;
 					KeyPriorityStatusLabel.ToolTipText = "Key priority: Hotkeys will override controller buttons";
 					break;
@@ -2859,28 +2859,30 @@ namespace BizHawk.Client.EmuHawk
 
 		private void ToggleKeyPriority()
 		{
-			Config.InputHotkeyOverrideOptions++;
-			if (Config.InputHotkeyOverrideOptions > 2)
+			int priority = (int)Config.InputHotkeyOverrideOptions;
+			priority++;
+			if (priority > 2)
 			{
-				Config.InputHotkeyOverrideOptions = 0;
+				priority = 0;
 			}
 
-			if (Config.NoMixedInputHokeyOverride && Config.InputHotkeyOverrideOptions == 0)
+			if (Config.NoMixedInputHokeyOverride && priority == 0)
 			{
-				Config.InputHotkeyOverrideOptions = 1;
+				priority = 1;
 			}
 
+			Config.InputHotkeyOverrideOptions = (Config.InputPriority)priority;
 			UpdateKeyPriorityIcon();
 			switch (Config.InputHotkeyOverrideOptions)
 			{
-				case 0:
+				case Config.InputPriority.BOTH:
 					AddOnScreenMessage("Key priority set to Both Hotkey and Input");
 					break;
-				case 1:
+				case Config.InputPriority.INPUT:
 					AddOnScreenMessage("Key priority set to Input over Hotkey");
 					break;
-				case 2:
-					AddOnScreenMessage("Key priority set to Input");
+				case Config.InputPriority.HOTKEY:
+					AddOnScreenMessage("Key priority set to Hotkey over Input");
 					break;
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -945,7 +945,7 @@ namespace BizHawk.Client.EmuHawk
 					{
 						MainFormContextMenu.Show(PointToScreen(new(0, MainformMenu.Height)));
 					}
-				}, IsInternalHotkey);
+				});
 
 				// translate mouse coordinates
 				// NOTE: these must go together, because in the case of screen rotation, X and Y are transformed together
@@ -2104,7 +2104,7 @@ namespace BizHawk.Client.EmuHawk
 			foreach (var (k, v) in Config.HotkeyBindings) controls.BindMulti(k, v);
 
 			InputManager.ClientControls = controls;
-			InputManager.ControllerInputCoalescer = new(); // ctor initialises values for host haptics
+			InputManager.ControllerInputCoalescer = new();
 		}
 
 		private void LoadMoviesFromRecent(string path)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -959,6 +959,8 @@ namespace BizHawk.Client.EmuHawk
 					finalHostController.AcceptNewAxis("WMouse Y", (int)((y * 20000) - 10000));
 				}
 
+				InputManager.RunControllerChain(Config);
+
 				// emu.yield()'ing scripts
 				if (Tools.Has<LuaConsole>())
 				{

--- a/src/BizHawk.Tests.Client.Common/InputManagerTests.cs
+++ b/src/BizHawk.Tests.Client.Common/InputManagerTests.cs
@@ -40,10 +40,6 @@ namespace BizHawk.Tests.Client.Common
 
 		private static readonly IReadOnlyList<string> _modifierKeys = new[] { "Super", "Ctrl", "Alt", "Shift" };
 
-		private static readonly int PRIORITY_BOTH = 0;
-		private static readonly int PRIORITY_INPUT = 1;
-		private static readonly int PRIORITY_HOTKEY = 2;
-
 		private InputEvent MakePressEvent(string keyboardButton, uint modifiers = 0)
 		{
 			return new()
@@ -284,7 +280,7 @@ namespace BizHawk.Tests.Client.Common
 			Context context = MakeContext();
 			InputManager manager = context.manager;
 			FakeInputSource source = context.source;
-			context.config.InputHotkeyOverrideOptions = PRIORITY_BOTH;
+			context.config.InputHotkeyOverrideOptions = Config.InputPriority.BOTH;
 
 			manager.ClientControls.BindMulti(_hotkeys[0], "Z");
 			manager.ActiveController.BindMulti("A", "Z");
@@ -303,7 +299,7 @@ namespace BizHawk.Tests.Client.Common
 			Context context = MakeContext();
 			InputManager manager = context.manager;
 			FakeInputSource source = context.source;
-			context.config.InputHotkeyOverrideOptions = PRIORITY_HOTKEY;
+			context.config.InputHotkeyOverrideOptions = Config.InputPriority.HOTKEY;
 
 			manager.ClientControls.BindMulti(_hotkeys[0], "Z");
 			manager.ActiveController.BindMulti("A", "Z");
@@ -322,7 +318,7 @@ namespace BizHawk.Tests.Client.Common
 			Context context = MakeContext();
 			InputManager manager = context.manager;
 			FakeInputSource source = context.source;
-			context.config.InputHotkeyOverrideOptions = PRIORITY_INPUT;
+			context.config.InputHotkeyOverrideOptions = Config.InputPriority.INPUT;
 
 			manager.ClientControls.BindMulti(_hotkeys[0], "Z");
 			manager.ActiveController.BindMulti("A", "Z");
@@ -340,7 +336,7 @@ namespace BizHawk.Tests.Client.Common
 			Context context = MakeContext();
 			InputManager manager = context.manager;
 			FakeInputSource source = context.source;
-			context.config.InputHotkeyOverrideOptions = PRIORITY_HOTKEY;
+			context.config.InputHotkeyOverrideOptions = Config.InputPriority.HOTKEY;
 
 			manager.ClientControls.BindMulti(_hotkeys[0], "Shift+Z");
 			manager.ActiveController.BindMulti("A", "Shift+Z");
@@ -360,7 +356,7 @@ namespace BizHawk.Tests.Client.Common
 			Context context = MakeContext();
 			InputManager manager = context.manager;
 			FakeInputSource source = context.source;
-			context.config.InputHotkeyOverrideOptions = PRIORITY_INPUT;
+			context.config.InputHotkeyOverrideOptions = Config.InputPriority.INPUT;
 
 			manager.ClientControls.BindMulti(_hotkeys[0], "Shift+Z");
 			manager.ActiveController.BindMulti("A", "Shift+Z");
@@ -379,7 +375,7 @@ namespace BizHawk.Tests.Client.Common
 			Context context = MakeContext();
 			InputManager manager = context.manager;
 			FakeInputSource source = context.source;
-			context.config.InputHotkeyOverrideOptions = PRIORITY_HOTKEY;
+			context.config.InputHotkeyOverrideOptions = Config.InputPriority.HOTKEY;
 
 			manager.ClientControls.BindMulti(_hotkeys[0], "Z");
 			manager.ActiveController.BindMulti("A", "Shift+Z");

--- a/src/BizHawk.Tests.Client.Common/InputManagerTests.cs
+++ b/src/BizHawk.Tests.Client.Common/InputManagerTests.cs
@@ -31,13 +31,12 @@ namespace BizHawk.Tests.Client.Common
 
 			public void BasicInputProcessing()
 			{
-				manager.ProcessInput(source, processHotkey, config, (_) => { }, (_) => false);
+				manager.ProcessInput(source, processHotkey, config, (_) => { });
 				manager.RunControllerChain(config);
-
 			}
 		}
 
-		private static readonly string[] _hotkeys = [ "Hotkey 1" ];
+		private static readonly string[] _hotkeys = [ "Hotkey 1", "Autofire", "Autohold" ];
 
 		private static readonly IReadOnlyList<string> _modifierKeys = new[] { "Super", "Ctrl", "Alt", "Shift" };
 
@@ -393,8 +392,7 @@ namespace BizHawk.Tests.Client.Common
 			Assert.AreEqual(0, context.triggeredHotkeys.Count);
 
 			source.AddInputEvent(MakeReleaseEvent("Z"));
-			manager.ProcessInput(source, context.processHotkey, context.config, (_) => { }, (_) => true); // true: releasing internal hotkey
-			manager.RunControllerChain(context.config);
+			context.BasicInputProcessing();
 
 			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
 		}
@@ -492,7 +490,7 @@ namespace BizHawk.Tests.Client.Common
 			manager.ClientControls.BindMulti(_hotkeys[0], "Q");
 
 			source.AddInputEvent(MakePressEvent("Q"));
-			manager.ProcessInput(source, context.processHotkey, context.config, (_) => Assert.Fail("Bound key was seen as unbound."), (_) => false);
+			manager.ProcessInput(source, context.processHotkey, context.config, (_) => Assert.Fail("Bound key was seen as unbound."));
 		}
 
 		[TestMethod]
@@ -504,7 +502,7 @@ namespace BizHawk.Tests.Client.Common
 			manager.ActiveController.BindMulti("A", "Q");
 
 			source.AddInputEvent(MakePressEvent("Q"));
-			manager.ProcessInput(source, context.processHotkey, context.config, (_) => Assert.Fail("Bound key was seen as unbound."), (_) => false);
+			manager.ProcessInput(source, context.processHotkey, context.config, (_) => Assert.Fail("Bound key was seen as unbound."));
 		}
 	}
 }

--- a/src/BizHawk.Tests.Client.Common/InputManagerTests.cs
+++ b/src/BizHawk.Tests.Client.Common/InputManagerTests.cs
@@ -1,0 +1,510 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using BizHawk.Client.Common;
+using BizHawk.Emulation.Common;
+using BizHawk.Tests.Client.Common.input;
+using BizHawk.Tests.Client.Common.Movie;
+
+namespace BizHawk.Tests.Client.Common
+{
+	[TestClass]
+	public class InputManagerTests
+	{
+		private class Context
+		{
+			public required InputManager manager;
+			public required Config config;
+			public required List<string> triggeredHotkeys = new();
+			public required Func<string, bool> processHotkey;
+			public required IEmulator emulator;
+			public required FakeInputSource source = new();
+
+			public void EmulateFrameAdvance(bool lag = false)
+			{
+				emulator.FrameAdvance(manager.ControllerOutput, false);
+				BasicInputProcessing();
+
+				if (lag) manager.AutoFireController.IncrementStarts();
+				manager.StickyAutofireController.IncrementLoops(lag);
+			}
+
+			public void BasicInputProcessing()
+			{
+				manager.ProcessInput(source, processHotkey, config, (_) => { }, (_) => false);
+				manager.RunControllerChain(config);
+
+			}
+		}
+
+		private static readonly string[] _hotkeys = [ "Hotkey 1" ];
+
+		private static readonly IReadOnlyList<string> _modifierKeys = new[] { "Super", "Ctrl", "Alt", "Shift" };
+
+		private static readonly int PRIORITY_BOTH = 0;
+		private static readonly int PRIORITY_INPUT = 1;
+		private static readonly int PRIORITY_HOTKEY = 2;
+
+		private InputEvent MakePressEvent(string keyboardButton, uint modifiers = 0)
+		{
+			return new()
+			{
+				EventType = InputEventType.Press,
+				LogicalButton = new(keyboardButton, modifiers, () => _modifierKeys),
+				Source = Bizware.Input.HostInputType.Keyboard,
+			};
+		}
+
+		private InputEvent MakeReleaseEvent(string keyboardButton, uint modifiers = 0)
+		{
+			return new()
+			{
+				EventType = InputEventType.Release,
+				LogicalButton = new(keyboardButton, modifiers, () => _modifierKeys),
+				Source = Bizware.Input.HostInputType.Keyboard,
+			};
+		}
+
+		private Context MakeContext()
+		{
+			InputManager manager = new();
+			FakeEmulator emu = new();
+			Config config = new();
+			manager.SyncControls(emu, new FakeMovieSession(emu), config);
+
+			ControllerDefinition cd = new("fake")
+			{
+				BoolButtons = _hotkeys.ToList(),
+			};
+			manager.ClientControls = new Controller(cd.MakeImmutable());
+
+			List<string> triggeredHotkeys = new();
+			bool FakeProcessHotkey(string trigger)
+			{
+				triggeredHotkeys.Add(trigger);
+				return _hotkeys.Contains(trigger);
+			}
+			Context context = new()
+			{
+				config = config,
+				manager = manager,
+				triggeredHotkeys = triggeredHotkeys,
+				processHotkey = FakeProcessHotkey,
+				emulator = emu,
+				source = new FakeInputSource(),
+			};
+
+			return context;
+		}
+
+		[TestMethod]
+		public void BasicControllerInput()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindMulti("A", "Q");
+
+			source.AddInputEvent(MakePressEvent("Q"));
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("B"));
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("C"));
+
+			source.AddInputEvent(MakeReleaseEvent("Q"));
+			context.BasicInputProcessing();
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void ControllerInputWithOneModifier()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindMulti("A", "Shift+Q");
+
+			source.AddInputEvent(MakePressEvent("Shift"));
+			source.AddInputEvent(MakePressEvent("Shift+Q"));
+
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+
+			source.AddInputEvent(MakeReleaseEvent("Shift"));
+			context.BasicInputProcessing();
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void ControllerInputWithMultipleModifiers()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindMulti("A", "Ctrl+Shift+Q");
+
+			source.AddInputEvent(MakePressEvent("Ctrl"));
+			source.AddInputEvent(MakePressEvent("Ctrl+Shift"));
+			source.AddInputEvent(MakePressEvent("Ctrl+Shift+Q"));
+
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+
+			source.AddInputEvent(MakeReleaseEvent("Shift"));
+			context.BasicInputProcessing();
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void ControllerInputAcceptsOutOfOrderModifier()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindMulti("A", "Shift+Q");
+
+			source.AddInputEvent(MakePressEvent("Q"));
+			context.BasicInputProcessing();
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+
+			source.AddInputEvent(MakePressEvent("Shift"));
+			context.BasicInputProcessing();
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void ControllerInputIgnoresExtraModifier()
+		{
+			// Extra modifiers are ignored so that we can do inputs while doing another input that's bound to a modifier.
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindMulti("A", "Q");
+			manager.ActiveController.BindMulti("B", "Ctrl+Q");
+
+			source.AddInputEvent(MakePressEvent("Shift"));
+			source.AddInputEvent(MakePressEvent("Shift+Q"));
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+
+			source.AddInputEvent(MakeReleaseEvent("Q"));
+			context.BasicInputProcessing();
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+
+			source.AddInputEvent(MakePressEvent("Shift+Ctrl")); // "Shift+Ctrl" not "Ctrl+Shift"
+			source.AddInputEvent(MakePressEvent("Ctrl+Shift+Q"));
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("B"));
+		}
+
+		[TestMethod]
+		public void BasicHotkeyInput()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ClientControls.BindMulti(_hotkeys[0], "Q");
+
+			source.AddInputEvent(MakePressEvent("Q"));
+			context.BasicInputProcessing();
+
+			Assert.AreEqual(1, context.triggeredHotkeys.Count);
+			Assert.AreEqual(_hotkeys[0], context.triggeredHotkeys[0]);
+		}
+
+		[TestMethod]
+		public void HotkeyInputWithOneModifier()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ClientControls.BindMulti(_hotkeys[0], "Shift+Q");
+
+			source.AddInputEvent(MakePressEvent("Shift+Q"));
+			context.BasicInputProcessing();
+
+			Assert.AreEqual(1, context.triggeredHotkeys.Count);
+			Assert.AreEqual(_hotkeys[0], context.triggeredHotkeys[0]);
+		}
+
+		[TestMethod]
+		public void HotkeyInputWithMultipleModifiers()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ClientControls.BindMulti(_hotkeys[0], "Ctrl+Shift+Q");
+
+			source.AddInputEvent(MakePressEvent("Ctrl+Shift+Q"));
+			context.BasicInputProcessing();
+
+			Assert.AreEqual(1, context.triggeredHotkeys.Count);
+			Assert.AreEqual(_hotkeys[0], context.triggeredHotkeys[0]);
+		}
+
+		[TestMethod]
+		public void HotkeyInputDoesNotTriggerWithOutOfOrderModifier()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ClientControls.BindMulti(_hotkeys[0], "Shift+Q");
+
+			source.AddInputEvent(MakePressEvent("Q"));
+			context.BasicInputProcessing();
+			Assert.AreEqual(0, context.triggeredHotkeys.Count);
+
+			source.AddInputEvent(MakePressEvent("Shift"));
+			context.BasicInputProcessing();
+			Assert.AreEqual(0, context.triggeredHotkeys.Count);
+		}
+
+		[TestMethod]
+		public void HotkeyInputDoesNotTriggerWithExtraModifier()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ClientControls.BindMulti(_hotkeys[0], "Q");
+
+			source.AddInputEvent(MakePressEvent("Shift"));
+			source.AddInputEvent(MakePressEvent("Shift+Q"));
+			context.BasicInputProcessing();
+
+			Assert.AreEqual(0, context.triggeredHotkeys.Count);
+		}
+
+		[TestMethod]
+		public void SinglePressCanDoControllerAndHotkeyInput()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			context.config.InputHotkeyOverrideOptions = PRIORITY_BOTH;
+
+			manager.ClientControls.BindMulti(_hotkeys[0], "Z");
+			manager.ActiveController.BindMulti("A", "Z");
+
+			source.AddInputEvent(MakePressEvent("Z"));
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+			Assert.AreEqual(1, context.triggeredHotkeys.Count);
+			Assert.AreEqual(_hotkeys[0], context.triggeredHotkeys[0]);
+		}
+
+		[TestMethod]
+		public void HotkeyPriority()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			context.config.InputHotkeyOverrideOptions = PRIORITY_HOTKEY;
+
+			manager.ClientControls.BindMulti(_hotkeys[0], "Z");
+			manager.ActiveController.BindMulti("A", "Z");
+
+			source.AddInputEvent(MakePressEvent("Z"));
+			context.BasicInputProcessing();
+
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+			Assert.AreEqual(1, context.triggeredHotkeys.Count);
+			Assert.AreEqual(_hotkeys[0], context.triggeredHotkeys[0]);
+		}
+
+		[TestMethod]
+		public void ControllerPriority()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			context.config.InputHotkeyOverrideOptions = PRIORITY_INPUT;
+
+			manager.ClientControls.BindMulti(_hotkeys[0], "Z");
+			manager.ActiveController.BindMulti("A", "Z");
+
+			source.AddInputEvent(MakePressEvent("Z"));
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+			Assert.AreEqual(0, context.triggeredHotkeys.Count);
+		}
+
+		[TestMethod]
+		public void HotkeyPriorityWithModifier()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			context.config.InputHotkeyOverrideOptions = PRIORITY_HOTKEY;
+
+			manager.ClientControls.BindMulti(_hotkeys[0], "Shift+Z");
+			manager.ActiveController.BindMulti("A", "Shift+Z");
+
+			source.AddInputEvent(MakePressEvent("Shift"));
+			source.AddInputEvent(MakePressEvent("Shift+Z"));
+			context.BasicInputProcessing();
+
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+			Assert.AreEqual(1, context.triggeredHotkeys.Count);
+			Assert.AreEqual(_hotkeys[0], context.triggeredHotkeys[0]);
+		}
+
+		[TestMethod]
+		public void ControllerPriorityWithModifier()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			context.config.InputHotkeyOverrideOptions = PRIORITY_INPUT;
+
+			manager.ClientControls.BindMulti(_hotkeys[0], "Shift+Z");
+			manager.ActiveController.BindMulti("A", "Shift+Z");
+
+			source.AddInputEvent(MakePressEvent("Shift"));
+			source.AddInputEvent(MakePressEvent("Shift+Z"));
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+			Assert.AreEqual(0, context.triggeredHotkeys.Count);
+		}
+
+		[TestMethod]
+		public void HotkeyOverrideDoesNotEatReleaseEvents()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			context.config.InputHotkeyOverrideOptions = PRIORITY_HOTKEY;
+
+			manager.ClientControls.BindMulti(_hotkeys[0], "Z");
+			manager.ActiveController.BindMulti("A", "Shift+Z");
+
+			source.AddInputEvent(MakePressEvent("Shift"));
+			source.AddInputEvent(MakePressEvent("Shift+Z"));
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+			Assert.AreEqual(0, context.triggeredHotkeys.Count);
+
+			source.AddInputEvent(MakeReleaseEvent("Z"));
+			manager.ProcessInput(source, context.processHotkey, context.config, (_) => { }, (_) => true); // true: releasing internal hotkey
+			manager.RunControllerChain(context.config);
+
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void AutofireController()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.AutoFireController.BindMulti("A", "Q");
+
+			source.AddInputEvent(MakePressEvent("Q"));
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+
+			context.EmulateFrameAdvance();
+
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void AutofireHotkey()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindMulti("A", "Q");
+			manager.ClientControls.BindMulti("Autofire", "W");
+
+			source.AddInputEvent(MakePressEvent("W"));
+			source.AddInputEvent(MakePressEvent("Q"));
+			context.BasicInputProcessing();
+			source.AddInputEvent(MakeReleaseEvent("Q"));
+			source.AddInputEvent(MakeReleaseEvent("W"));
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+
+			context.EmulateFrameAdvance();
+
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void AutoholdHotkey()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindMulti("A", "Q");
+			manager.ClientControls.BindMulti("Autohold", "W");
+
+			source.AddInputEvent(MakePressEvent("W"));
+			source.AddInputEvent(MakePressEvent("Q"));
+			context.BasicInputProcessing();
+			source.AddInputEvent(MakeReleaseEvent("Q"));
+			source.AddInputEvent(MakeReleaseEvent("W"));
+			context.BasicInputProcessing();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+
+			context.EmulateFrameAdvance();
+
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void AutofireHotkeyDoesNotRespondToAlreadyHeldButton()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindMulti("A", "Q");
+			manager.ClientControls.BindMulti("Autofire", "W");
+
+			source.AddInputEvent(MakePressEvent("Q"));
+			context.BasicInputProcessing();
+			source.AddInputEvent(MakePressEvent("W"));
+			context.BasicInputProcessing();
+			source.AddInputEvent(MakeReleaseEvent("Q"));
+			source.AddInputEvent(MakeReleaseEvent("W"));
+			context.BasicInputProcessing();
+
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void HotkeyIsNotSeenAsUnbound()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ClientControls.BindMulti(_hotkeys[0], "Q");
+
+			source.AddInputEvent(MakePressEvent("Q"));
+			manager.ProcessInput(source, context.processHotkey, context.config, (_) => Assert.Fail("Bound key was seen as unbound."), (_) => false);
+		}
+
+		[TestMethod]
+		public void InputIsNotSeenAsUnbound()
+		{
+			Context context = MakeContext();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindMulti("A", "Q");
+
+			source.AddInputEvent(MakePressEvent("Q"));
+			manager.ProcessInput(source, context.processHotkey, context.config, (_) => Assert.Fail("Bound key was seen as unbound."), (_) => false);
+		}
+	}
+}

--- a/src/BizHawk.Tests.Client.Common/Movie/FakeMovieSession.cs
+++ b/src/BizHawk.Tests.Client.Common/Movie/FakeMovieSession.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 	{
 		public IMovieConfig Settings { get; set; }
 
-		public required IMovie Movie { get; set; }
+		public IMovie? Movie { get; set; }
 
 		public bool ReadOnly { get => false; set { } }
 
@@ -28,9 +28,24 @@ namespace BizHawk.Tests.Client.Common.Movie
 		public IMovieController MovieController { get; }
 
 		public IController StickySource { get; set; }
-		public IController MovieIn { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+		public IController MovieIn { get; set; } = NullController.Instance;
 
-		public IInputAdapter MovieOut => throw new NotImplementedException();
+		private IInputAdapter _out = new CopyControllerAdapter();
+		public IInputAdapter MovieOut
+		{
+			get
+			{
+				if (Movie?.IsActive() == true && !Movie.IsRecording())
+				{
+					_out.Source = MovieController;
+				}
+				else
+				{
+					_out.Source = MovieIn;
+				}
+				return _out;
+			}
+		}
 
 		public string BackupDirectory { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
@@ -52,6 +67,6 @@ namespace BizHawk.Tests.Client.Common.Movie
 		public void PopupMessage(string message) => throw new NotImplementedException();
 		public void QueueNewMovie(IMovie movie, string systemId, string loadedRomHash, PathEntryCollection pathEntries, IDictionary<string, string> preferredCores) => throw new NotImplementedException();
 		public void RunQueuedMovie(bool recordMode, IEmulator emulator) => throw new NotImplementedException();
-		public void StopMovie(bool saveChanges = true) => Movie.Stop();
+		public void StopMovie(bool saveChanges = true) => Movie?.Stop();
 	}
 }

--- a/src/BizHawk.Tests.Client.Common/Movie/TasMovieTests.cs
+++ b/src/BizHawk.Tests.Client.Common/Movie/TasMovieTests.cs
@@ -8,7 +8,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 		internal static TasMovie MakeMovie(int numberOfFrames)
 		{
 			FakeEmulator emu = new FakeEmulator();
-			FakeMovieSession session = new(emu) { Movie = null! };
+			FakeMovieSession session = new(emu);
 			TasMovie movie = new(session, "/fake/path");
 			session.Movie = movie;
 

--- a/src/BizHawk.Tests.Client.Common/input/FakeInputSource.cs
+++ b/src/BizHawk.Tests.Client.Common/input/FakeInputSource.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+using BizHawk.Client.Common;
+
+namespace BizHawk.Tests.Client.Common.input
+{
+	internal class FakeInputSource : IPhysicalInputSource
+	{
+		private List<InputEvent> _events = new();
+		private int _nextEventId;
+		public InputEvent? DequeueEvent() => _nextEventId < _events.Count ? _events[_nextEventId++] : null;
+
+		private KeyValuePair<string, int>[] _axisValues = [ ];
+		public KeyValuePair<string, int>[] GetAxisValues() => _axisValues;
+
+		public void AddInputEvent(InputEvent ie) => _events.Add(ie);
+	}
+}


### PR DESCRIPTION
Fix: Hotkey overrides input would cause an input to continue after a button was released if the input is bound to a combination such as Shift+A and an "internal hotkey" is bound to a single button (such as A). Also input bound to Alt would not have the alt ignored by menus.

Fix: Input overrides hotkeys did not work if both input and hotkey were bound to a combination such as Shift+A.

Fix: Controller inputs bound to a modifier key combination would not be triggered if additional modifier keys were also pressed.

Fix: autofire/autohold hotkeys would sometimes activate buttons that were already being held when the hotkey was pressed.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
