### PR TITLE
Seek fixes

### DIFF
--- a/src/BizHawk.Client.EmuHawk/IControlMainform.cs
+++ b/src/BizHawk.Client.EmuHawk/IControlMainform.cs
@@ -54,8 +54,8 @@
 		/// <summary>
 		/// Function that is called by Mainform instead of using its own code
 		/// when a Tool sets WantsToControlRewind
-		/// Returns whether or not the rewind action actually occured
 		/// </summary>
+		/// <returns>Returns true if a frame advance is required.</returns>
 		bool Rewind();
 
 		bool WantsToControlRestartMovie { get; }

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -4438,8 +4438,7 @@ namespace BizHawk.Client.EmuHawk
 
 					if (isRewinding)
 					{
-						runFrame = Emulator.Frame > 1; // TODO: the master should be deciding this!
-						rewindTool.Rewind();
+						runFrame = rewindTool.Rewind();
 					}
 				}
 				else

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
@@ -78,8 +78,11 @@
 		public bool Rewind()
 		{
 			int rewindStep = MainForm.IsFastForwarding ? Settings.RewindStepFast : Settings.RewindStep;
+			int frame = Emulator.Frame;
 			WheelSeek(rewindStep);
-			return true;
+			// we need a frame advance if a state was loaded (frame has changed)
+			// and also we are seeking (not already at the target frame)
+			return Emulator.Frame != frame && _seekingTo != -1;
 		}
 
 		public bool WantsToControlRestartMovie { get; }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
@@ -156,7 +156,6 @@ namespace BizHawk.Client.EmuHawk
 				return true;
 			}
 
-			StopSeeking();
 			if (CurrentTasMovie?.Changes is not true) return true;
 			var result = DialogController.DoWithTempMute(() => this.ModalMessageBox3(
 				caption: "Closing with Unsaved Changes",

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
@@ -111,7 +111,9 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (_seekingTo != -1 && Emulator.Frame >= _seekingTo)
 			{
+				bool smga = _shouldMoveGreenArrow;
 				StopSeeking();
+				_shouldMoveGreenArrow = smga;
 			}
 			UpdateProgressBar();
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -944,6 +944,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (_seekingTo != -1)
 			{
+				_shouldMoveGreenArrow = true;
 				_seekingTo -= count;
 
 				if (count > 0 && Emulator.Frame >= _seekingTo)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -966,11 +966,6 @@ namespace BizHawk.Client.EmuHawk
 			{
 				_suppressContextMenu = true;
 				int notch = e.Delta / 120;
-				if (notch > 1)
-				{
-					notch *= 2;
-				}
-
 				WheelSeek(notch);
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -984,10 +984,9 @@ namespace BizHawk.Client.EmuHawk
 			{
 				_seekingTo -= count;
 
-				// that's a weird condition here, but for whatever reason it works best
 				if (count > 0 && Emulator.Frame >= _seekingTo)
 				{
-					GoToFrame(Emulator.Frame - count);
+					GoToFrame(_seekingTo);
 				}
 
 				RefreshDialog();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -1305,7 +1305,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void CancelSeekContextMenuItem_Click(object sender, EventArgs e)
 		{
-			CancelSeek();
+			StopSeeking();
 		}
 
 		private void BranchContextMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
@@ -13,7 +13,7 @@ namespace BizHawk.Client.EmuHawk
 			_lastRecordAction = -1;
 			if (frame == Emulator.Frame)
 			{
-				CancelSeek();
+				StopSeeking();
 				return;
 			}
 
@@ -32,7 +32,18 @@ namespace BizHawk.Client.EmuHawk
 			}
 			closestState.Value.Dispose();
 
-			StartSeeking(frame);
+			_seekStartFrame = Emulator.Frame;
+			_seekingByEdit = false;
+
+			_seekingTo = frame;
+			MainForm.PauseOnFrame = int.MaxValue; // This being set is how MainForm knows we are seeking, and controls TurboSeek.
+			MainForm.UnpauseEmulator();
+
+			if (_seekingTo - _seekStartFrame > 1)
+			{
+				MessageStatusLabel.Text = "Seeking...";
+				ProgressBar.Visible = true;
+			}
 
 			if (!OnLeftMouseDown)
 			{

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
@@ -13,6 +13,7 @@ namespace BizHawk.Client.EmuHawk
 			_lastRecordAction = -1;
 			if (frame == Emulator.Frame)
 			{
+				CancelSeek();
 				return;
 			}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
@@ -84,7 +84,7 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		public void SetVisibleFrame(int? frame = null)
 		{
-			if (TasView.AlwaysScroll && _leftButtonHeld)
+			if (_leftButtonHeld)
 			{
 				return;
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -1156,7 +1156,7 @@ namespace BizHawk.Client.EmuHawk
 				CurrentTasMovie.Truncate(branch.Frame);
 			}
 
-			CancelSeek();
+			StopSeeking();
 			RefreshDialog();
 		}
 	}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -50,7 +50,7 @@ namespace BizHawk.Client.EmuHawk
 		/// Gets a value that separates "restore last position" logic from seeking caused by navigation.
 		/// TASEditor never kills LastPositionFrame, and it only pauses on it, if it hasn't been greenzoned beforehand and middle mouse button was pressed.
 		/// </summary>
-		public int RestorePositionFrame { get; private set; }
+		public int RestorePositionFrame { get; private set; } = -1;
 		private bool _shouldMoveGreenArrow;
 		private bool _seekingByEdit;
 
@@ -171,7 +171,6 @@ namespace BizHawk.Client.EmuHawk
 			TasView.QueryItemIcon += TasView_QueryItemIcon;
 			TasView.QueryFrameLag += TasView_QueryFrameLag;
 			TasView.PointedCellChanged += TasView_PointedCellChanged;
-			RestorePositionFrame = -1;
 
 			TasView.MouseLeave += TAStudio_MouseLeave;
 			TasView.CellHovered += (_, e) =>
@@ -607,6 +606,7 @@ namespace BizHawk.Client.EmuHawk
 			ResumeLayout();
 			if (result)
 			{
+				RestorePositionFrame = -1;
 				_lastRecordAction = -1;
 				BookMarkControl.UpdateTextColumnWidth();
 				MarkerControl.UpdateTextColumnWidth();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -606,8 +606,13 @@ namespace BizHawk.Client.EmuHawk
 			ResumeLayout();
 			if (result)
 			{
+				// Initialize stuff.
 				RestorePositionFrame = -1;
 				_lastRecordAction = -1;
+				_doPause = false;
+
+				StopSeeking();
+
 				BookMarkControl.UpdateTextColumnWidth();
 				MarkerControl.UpdateTextColumnWidth();
 				TastudioPlayMode();


### PR DESCRIPTION
Several fixes to seeking behavior.

This PR introduces a change to how a return value from the API is used: The value of `Rewind` is no longer ignored. What it signifies is also slightly different. It used to say "if the rewind occurred" but now "if a frame advance is required". (In TAStudio, these were usually the same thing.) The ApiHawk [changelog](https://github.com/TASEmulators/BizHawk-ExternalTools/wiki/Partial-changelog-for-ApiHawk) should be updated.

Bugs that affect 2.10:
1. Wheel scroll up behavior was inconsistent, depending on if one or two events are raised for a two-notch scroll.
2. Green arrow was not reset when loading a new movie.
3. Seek would be canceled if user triggers a TAStudio close but cancels when asked if they want to save.
4. Starting a new movie then unpausing could then immediately auto-pause.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
