### PR TITLE
Update the ISaveRam interface for clarity.

### DIFF
--- a/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
+++ b/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
@@ -133,7 +133,6 @@ namespace BizHawk.Client.Common
 
 			foreach (var (k, v) in old.HeaderEntries) tas.HeaderEntries[k] = v;
 
-			tas.StartsFromSaveRam = true;
 			tas.SyncSettingsJson = old.SyncSettingsJson;
 
 			foreach (string comment in old.Comments)

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.HeaderApi.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.HeaderApi.cs
@@ -51,26 +51,7 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		public bool StartsFromSaveRam
-		{
-			// ReSharper disable SimplifyConditionalTernaryExpression
-			get => Header.TryGetValue(HeaderKeys.StartsFromSaveram, out var s) ? bool.Parse(s) : false;
-			// ReSharper restore SimplifyConditionalTernaryExpression
-			set
-			{
-				if (value)
-				{
-					if (!Header.ContainsKey(HeaderKeys.StartsFromSaveram))
-					{
-						Header.Add(HeaderKeys.StartsFromSaveram, "True");
-					}
-				}
-				else
-				{
-					Header.Remove(HeaderKeys.StartsFromSaveram);
-				}
-			}
-		}
+		public bool StartsFromSaveRam => SaveRam != null;
 
 		public override string GameName
 		{

--- a/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
+++ b/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
@@ -67,7 +67,7 @@ namespace BizHawk.Client.Common
 		byte[] SaveRam { get; set; }
 
 		bool StartsFromSavestate { get; set; }
-		bool StartsFromSaveRam { get; set; }
+		bool StartsFromSaveRam { get; }
 
 		string LogKey { get; set; }
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -27,12 +27,8 @@ using BizHawk.Client.Common.cheats;
 
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores;
-using BizHawk.Emulation.Cores.Computers.AppleII;
-using BizHawk.Emulation.Cores.Computers.Commodore64;
 using BizHawk.Emulation.Cores.Computers.DOS;
 using BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES;
-using BizHawk.Emulation.Cores.Consoles.SNK;
-using BizHawk.Emulation.Cores.Nintendo.GBA;
 using BizHawk.Emulation.Cores.Nintendo.NES;
 using BizHawk.Emulation.Cores.Nintendo.SNES;
 
@@ -1921,36 +1917,24 @@ namespace BizHawk.Client.EmuHawk
 					return;
 				}
 
+				byte[] sram = null;
 				try
 				{
-					byte[] sram;
-
-					// some cores might not know how big the saveram ought to be, so just send it the whole file
-					if (Emulator is AppleII or C64 or DOSBox or MGBAHawk or NeoGeoPort or NES { BoardName: "FDS" })
-					{
-						sram = File.ReadAllBytes(saveramToLoad.FullName);
-					}
-					else
-					{
-						var oldRam = Emulator.AsSaveRam().CloneSaveRam();
-						if (oldRam is null)
-						{
-							// we have a SaveRAM file, but the current core does not have save ram.
-							// just skip loading the saveram file in that case
-							return;
-						}
-
-						// why do we silently truncate\pad here instead of warning\erroring?
-						sram = new byte[oldRam.Length];
-						using var fs = saveramToLoad.OpenRead();
-						_ = fs.Read(sram, 0, sram.Length);
-					}
-
-					Emulator.AsSaveRam().StoreSaveRam(sram);
+					sram = File.ReadAllBytes(saveramToLoad.FullName);
 				}
-				catch (IOException e)
+				catch (Exception e)
 				{
-					AddOnScreenMessage("An error occurred while loading Sram");
+					AddOnScreenMessage("An IO error occurred while loading Sram");
+					Console.Error.WriteLine(e);
+				}
+
+				try
+				{
+					if (sram != null) Emulator.AsSaveRam().StoreSaveRam(sram);
+				}
+				catch (Exception e)
+				{
+					AddOnScreenMessage("The core threw an error while loading Sram");
 					Console.Error.WriteLine(e);
 				}
 			}
@@ -1976,9 +1960,7 @@ namespace BizHawk.Client.EmuHawk
 				var backupPath = $"{path}.bak";
 				var backupFile = new FileInfo(backupPath);
 
-				var saveram = Emulator.AsSaveRam().CloneSaveRam();
-				if (saveram == null)
-					return true;
+				var saveram = Emulator.AsSaveRam().CloneSaveRam()!;
 
 				try
 				{

--- a/src/BizHawk.Client.EmuHawk/movie/RecordMovie.cs
+++ b/src/BizHawk.Client.EmuHawk/movie/RecordMovie.cs
@@ -103,7 +103,7 @@ namespace BizHawk.Client.EmuHawk
 				MaxDropDownItems = 32,
 				Size = new(152, 21),
 			};
-			if (_emulator.HasSaveRam() && _emulator.AsSaveRam().CloneSaveRam(clearDirty: false) is not null) StartFromCombo.Items.Add(START_FROM_SAVERAM);
+			if (_emulator.HasSaveRam()) StartFromCombo.Items.Add(START_FROM_SAVERAM);
 			if (_emulator.HasSavestates()) StartFromCombo.Items.Add(START_FROM_SAVESTATE);
 
 			DefaultAuthorCheckBox = new()
@@ -242,7 +242,6 @@ namespace BizHawk.Client.EmuHawk
 				else if (selectedStartFromValue is START_FROM_SAVERAM && _emulator.HasSaveRam())
 				{
 					var core = _emulator.AsSaveRam();
-					movieToRecord.StartsFromSaveRam = true;
 					movieToRecord.SaveRam = core.CloneSaveRam(clearDirty: false);
 				}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -55,7 +55,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (AskSaveChanges())
 			{
-				var saveRam = SaveRamEmulator?.CloneSaveRam(clearDirty: false) ?? throw new Exception("No SaveRam");
+				var saveRam = SaveRamEmulator?.CloneSaveRam(clearDirty: false) ?? throw new Exception("No SaveRam; this button should have been disabled.");
 				GoToFrame(TasView.AnyRowsSelected ? TasView.FirstSelectedRowIndex : 0);
 				var newProject = CurrentTasMovie.ConvertToSaveRamAnchoredMovie(saveRam);
 				MainForm.PauseEmulator();

--- a/src/BizHawk.Emulation.Common/Base Implementations/LinkedSaveRam.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/LinkedSaveRam.cs
@@ -23,7 +23,7 @@ namespace BizHawk.Emulation.Common
 		{
 			for (int i = 0; i < _numCores; i++)
 			{
-				if (_linkedCores[i].AsSaveRam().SaveRamModified)
+				if (_linkedCores[i].AsSaveRam()?.SaveRamModified == true)
 				{
 					return true;
 				}
@@ -37,7 +37,7 @@ namespace BizHawk.Emulation.Common
 			int len = 0;
 			for (int i = 0; i < _numCores; i++)
 			{
-				linkedBuffers.Add(_linkedCores[i].AsSaveRam().CloneSaveRam(clearDirty) ?? Array.Empty<byte>());
+				linkedBuffers.Add(_linkedCores[i].AsSaveRam()?.CloneSaveRam(clearDirty) ?? Array.Empty<byte>());
 				len += linkedBuffers[i].Length;
 			}
 			byte[] ret = new byte[len];
@@ -55,13 +55,15 @@ namespace BizHawk.Emulation.Common
 			int pos = 0;
 			for (int i = 0; i < _numCores; i++)
 			{
-				var toCopy = _linkedCores[i].AsSaveRam().CloneSaveRam(); // wait CloneSaveRam is already a copy, why are we copying it again
-				if (toCopy is null) continue;
-				var b = new byte[toCopy.Length];
+				var numberBytesToCopy = _linkedCores[i].AsSaveRam()?.CloneSaveRam().Length;
+				if (numberBytesToCopy is null) continue;
+				var b = new byte[numberBytesToCopy.Value];
 				Buffer.BlockCopy(data, pos, b, 0, b.Length);
 				pos += b.Length;
 				_linkedCores[i].AsSaveRam().StoreSaveRam(b);
 			}
+
+			if (data.Length != pos) throw new InvalidOperationException("Incorrect sram size.");
 		}
 	}
 }

--- a/src/BizHawk.Emulation.Common/Interfaces/Services/ISaveRam.cs
+++ b/src/BizHawk.Emulation.Common/Interfaces/Services/ISaveRam.cs
@@ -10,16 +10,14 @@
 	{
 		/// <summary>
 		/// Returns a copy of the SaveRAM. Editing it won't do you any good unless you later call StoreSaveRam()
-		/// This IS allowed to return null.
-		/// Unfortunately, the core may think differently of a nonexisting (null) saveram vs a 0 size saveram.
-		/// Frontend users of the ISaveRam should treat null as nonexisting (and thus not even write the file, so that the "does not exist" condition can be roundtripped and not confused with an empty file)
 		/// </summary>
 		/// <param name="clearDirty">Whether the saveram should be considered in a clean state after this call for purposes of <see cref="SaveRamModified"/></param>
-		byte[]? CloneSaveRam(bool clearDirty = true);
+		byte[] CloneSaveRam(bool clearDirty = true);
 
 		/// <summary>
-		/// store new SaveRAM to the emu core. the data should be the same size as the return from ReadSaveRam()
+		/// Store new SaveRAM to the emu core.
 		/// </summary>
+		/// <exception cref="Exception">The core may throw an exception if the given data is invalid.</exception>
 		void StoreSaveRam(byte[] data);
 
 		/// <summary>

--- a/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.IEmulator.cs
@@ -8,7 +8,10 @@ namespace BizHawk.Emulation.Cores.Arcades.MAME
 		public string SystemId => VSystemID.Raw.Arcade;
 		public bool DeterministicEmulation { get; }
 		public int Frame { get; private set; }
-		public IEmulatorServiceProvider ServiceProvider { get; }
+
+		private BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
+
 		public ControllerDefinition ControllerDefinition => MAMEController;
 
 		/// <summary>

--- a/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.ISaveRam.cs
@@ -22,7 +22,7 @@ namespace BizHawk.Emulation.Cores.Arcades.MAME
 		{
 			if (_nvramFilenames.Count == 0)
 			{
-				return null;
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			for (int i = 0; i < _nvramFilenames.Count; i++)
@@ -53,7 +53,7 @@ namespace BizHawk.Emulation.Cores.Arcades.MAME
 		{
 			if (_nvramFilenames.Count == 0)
 			{
-				return;
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			using var ms = new MemoryStream(data, false);

--- a/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.MemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.MemoryDomains.cs
@@ -107,7 +107,7 @@ namespace BizHawk.Emulation.Cores.Arcades.MAME
 				_memoryDomains.SystemBus = _memoryDomains[deviceName + " : System Bus"]!;
 			}
 
-			((BasicServiceProvider)ServiceProvider).Register<IMemoryDomains>(_memoryDomains);
+			_serviceProvider.Register<IMemoryDomains>(_memoryDomains);
 		}
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.cs
+++ b/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.cs
@@ -25,13 +25,17 @@ namespace BizHawk.Emulation.Cores.Arcades.MAME
 			_gameFileName = Path.GetFileName(lp.Roms[0].RomPath.SubstringAfter('|')).ToLowerInvariant();
 			_syncSettings = lp.SyncSettings ?? new();
 
-			ServiceProvider = new BasicServiceProvider(this);
+			_serviceProvider = new BasicServiceProvider(this);
+			_serviceProvider.Unregister<ISaveRam>();
 			DeterministicEmulation = !_syncSettings.RTCSettings.UseRealTime || lp.DeterministicEmulationRequested;
 
 			_logCallback = MAMELogCallback;
 			_baseTimeCallback = MAMEBaseTimeCallback;
 			_inputPollCallback = InputCallbacks.Call;
-			_filenameCallback = name => _nvramFilenames.Add(name);
+			_filenameCallback = name => {
+				_nvramFilenames.Add(name);
+				_serviceProvider.Register<ISaveRam>(this);
+			};
 			_infoCallback = info =>
 			{
 				var text = info.Replace(". ", "\n").Replace("\n\n", "\n");

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0020.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0020.cs
@@ -302,6 +302,8 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 			var deltaBSize = reader.ReadInt32();
 			_deltaB = reader.ReadBytes(deltaBSize);
 
+			if (reader.BaseStream.Position != deltaASize + deltaBSize + 8) throw new InvalidOperationException("Incorrect sram size.");
+
 			DeltaSerializer.ApplyDelta(_originalMediaA, _chipA.Data, _deltaA);
 			DeltaSerializer.ApplyDelta(_originalMediaB, _chipB.Data, _deltaB);
 			_saveRamDirty = false;

--- a/src/BizHawk.Emulation.Cores/Computers/MSX/MSX.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/MSX/MSX.IEmulator.cs
@@ -4,7 +4,8 @@ namespace BizHawk.Emulation.Cores.Computers.MSX
 {
 	public partial class MSX : IEmulator, ISoundProvider, IVideoProvider
 	{
-		public IEmulatorServiceProvider ServiceProvider { get; }
+		private BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		public ControllerDefinition ControllerDefinition => current_controller;
 

--- a/src/BizHawk.Emulation.Cores/Computers/MSX/MSX.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/MSX/MSX.IMemoryDomains.cs
@@ -49,7 +49,7 @@ namespace BizHawk.Emulation.Cores.Computers.MSX
 			SyncAllByteArrayDomains();
 
 			MemoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList());
-			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
+			_serviceProvider.Register<IMemoryDomains>(MemoryDomains);
 
 			_memoryDomainsInit = true;
 		}

--- a/src/BizHawk.Emulation.Cores/Computers/MSX/MSX.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/MSX/MSX.ISaveRam.cs
@@ -6,20 +6,26 @@ namespace BizHawk.Emulation.Cores.Computers.MSX
 	{
 		public byte[] CloneSaveRam(bool clearDirty)
 		{
-			return (byte[]) SaveRAM?.Clone();
+			if (SaveRAM == null)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+			else
+				return (byte[]) SaveRAM.Clone();
 		}
 
 		public void StoreSaveRam(byte[] data)
 		{
-			if (SaveRAM != null)
+			if (SaveRAM == null)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+			else
 			{
+				if (data.Length != SaveRAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 				Array.Copy(data, SaveRAM, data.Length);
 			}
 		}
 
 		public bool SaveRamModified { get; private set; }
 
-		public byte[] SaveRAM;
+		private byte[] SaveRAM;
 		private byte SaveRamBank;
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Computers/MSX/MSX.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/MSX/MSX.cs
@@ -14,7 +14,8 @@ namespace BizHawk.Emulation.Cores.Computers.MSX
 		[CoreConstructor(VSystemID.Raw.MSX)]
 		public MSX(CoreLoadParameters<MSXSettings, MSXSyncSettings> lp)
 		{
-			ServiceProvider = new BasicServiceProvider(this);
+			_serviceProvider = new BasicServiceProvider(this);
+			_serviceProvider.Unregister<ISaveRam>();
 			Settings = lp.Settings ?? new MSXSettings();
 			SyncSettings = lp.SyncSettings ?? new MSXSyncSettings();
 
@@ -141,7 +142,7 @@ namespace BizHawk.Emulation.Cores.Computers.MSX
 
 			blip.SetRates(3579545, 44100);
 
-			(ServiceProvider as BasicServiceProvider).Register<ISoundProvider>(this);
+			_serviceProvider.Register<ISoundProvider>(this);
 
 			SetupMemoryDomains();
 
@@ -156,9 +157,8 @@ namespace BizHawk.Emulation.Cores.Computers.MSX
 
 			Tracer = new TraceBuffer(newHeader.ToString());
 
-			var serviceProvider = ServiceProvider as BasicServiceProvider;
-			serviceProvider.Register<ITraceable>(Tracer);
-			serviceProvider.Register<IStatable>(new StateSerializer(SyncState));
+			_serviceProvider.Register<ITraceable>(Tracer);
+			_serviceProvider.Register<IStatable>(new StateSerializer(SyncState));
 
 			current_controller = SyncSettings.Contr_Setting == MSXSyncSettings.ContrType.Keyboard ? MSXControllerKB : MSXControllerJS;
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.ISaveRam.cs
@@ -11,6 +11,7 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 
 		public void StoreSaveRam(byte[] data)
 		{
+			if (data.Length != _hsram.Length) throw new InvalidOperationException("Incorrect sram size.");
 			Buffer.BlockCopy(data, 0, _hsram, 0, data.Length);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/jaguar/VirtualJaguar.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/jaguar/VirtualJaguar.ISaveRam.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Emulation.Cores.Atari.Jaguar
 		{
 			if (_saveRamSize == 0)
 			{
-				return null;
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			byte[] ret = new byte[_saveRamSize];
@@ -22,7 +22,9 @@ namespace BizHawk.Emulation.Cores.Atari.Jaguar
 
 		public new void StoreSaveRam(byte[] data)
 		{
-			if (_saveRamSize > 0)
+			if (_saveRamSize == 0)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+			else
 			{
 				if (data.Length != _saveRamSize)
 				{

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/jaguar/VirtualJaguar.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/jaguar/VirtualJaguar.cs
@@ -113,6 +113,8 @@ namespace BizHawk.Emulation.Cores.Atari.Jaguar
 					}
 				}
 			}
+			if (_saveRamSize == 0)
+				_serviceProvider.Unregister<ISaveRam>();
 
 			_core.SetCdCallbacks(null, null);
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.IMemoryDomains.cs
@@ -23,6 +23,10 @@ namespace BizHawk.Emulation.Cores.Atari.Lynx
 			{
 				mms.Add(new MemoryDomainIntPtr("Save RAM", MemoryDomain.Endian.Little, p, s, true, 2));
 			}
+			else
+			{
+				_serviceProvider.Unregister<ISaveRam>();
+			}
 
 			LibLynx.GetReadOnlyCartPtrs(Core, out var s0, out var p0, out var s1, out var p1);
 			if (s0 > 0 && p0 != IntPtr.Zero)

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.ISaveRam.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Emulation.Cores.Atari.Lynx
 		{
 			if (!LibLynx.GetSaveRamPtr(Core, out var size, out var data))
 			{
-				return null;
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			byte[] ret = new byte[size];
@@ -22,7 +22,7 @@ namespace BizHawk.Emulation.Cores.Atari.Lynx
 		{
 			if (!LibLynx.GetSaveRamPtr(Core, out var size, out var data))
 			{
-				throw new InvalidOperationException();
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			if (srcData.Length != size) throw new ArgumentException(message: "buffer too small", paramName: nameof(srcData));

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.cs
@@ -28,7 +28,7 @@ namespace BizHawk.Emulation.Cores.Atari.Lynx
 		[CoreConstructor(VSystemID.Raw.Lynx)]
 		public Lynx(byte[] file, GameInfo game, CoreComm comm)
 		{
-			ServiceProvider = new BasicServiceProvider(this);
+			_serviceProvider = new BasicServiceProvider(this);
 
 			var bios = comm.CoreFileProvider.GetFirmwareOrThrow(new("Lynx", "Boot"), "Boot rom is required");
 			if (bios.Length != 512)
@@ -131,7 +131,8 @@ namespace BizHawk.Emulation.Cores.Atari.Lynx
 
 		private IntPtr Core;
 
-		public IEmulatorServiceProvider ServiceProvider { get; }
+		private readonly BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		public bool FrameAdvance(IController controller, bool render, bool rendersound = true)
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.ISaveRam.cs
@@ -1,8 +1,8 @@
-﻿using BizHawk.Emulation.Common;
+﻿//using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 {
-	public partial class VectrexHawk : ISaveRam
+	public partial class VectrexHawk// : ISaveRam
 	{
 		public byte[] CloneSaveRam(bool clearDirty)
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IEmulator.cs
@@ -4,7 +4,8 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 {
 	public partial class O2Hawk : IEmulator, IVideoProvider
 	{
-		public IEmulatorServiceProvider ServiceProvider { get; }
+		private readonly BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		public ControllerDefinition ControllerDefinition => _controllerDeck.Definition;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.ISaveRam.cs
@@ -6,13 +6,18 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 	{
 		public byte[] CloneSaveRam(bool clearDirty)
 		{
-			return (byte[])cart_RAM?.Clone();
+			if (cart_RAM == null)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+			return (byte[])cart_RAM.Clone();
 		}
 
 		public void StoreSaveRam(byte[] data)
 		{
-			if (_syncSettings.Use_SRAM)
+			if (cart_RAM == null)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+			else if (_syncSettings.Use_SRAM)
 			{
+				if (data.Length != cart_RAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 				Buffer.BlockCopy(data, 0, cart_RAM, 0, data.Length);
 				Console.WriteLine("loading SRAM here");
 			}

--- a/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.cs
@@ -22,7 +22,7 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 		public readonly byte[] _rom;
 		public readonly byte[] header = new byte[0x50];
 
-		public byte[] cart_RAM;
+		private byte[] cart_RAM;
 		public bool has_bat;
 
 		public int _frame = 0;
@@ -43,6 +43,7 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 		public O2Hawk(CoreComm comm, GameInfo game, byte[] rom, O2Settings settings, O2SyncSettings syncSettings)
 		{
 			var ser = new BasicServiceProvider(this);
+			ser.Unregister<ISaveRam>();
 
 			cpu = new I8048
 			{
@@ -76,7 +77,7 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 			_frameHz = 60;
 
 			ser.Register<IVideoProvider>(this);
-			ServiceProvider = ser;
+			_serviceProvider = ser;
 
 			_tracer = new TraceBuffer(cpu.TraceHeader);
 			ser.Register(_tracer);

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.IEmulator.cs
@@ -6,7 +6,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 {
 	public partial class BsnesCore : IEmulator
 	{
-		public IEmulatorServiceProvider ServiceProvider { get; }
+		private readonly BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		public ControllerDefinition ControllerDefinition => _controllers.Definition;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.IMemoryDomains.cs
@@ -59,10 +59,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 			mm.Add(Api.exe.GetPagesDomain());
 
 			_memoryDomains = new(mm);
-			((BasicServiceProvider) ServiceProvider).Register<IMemoryDomains>(_memoryDomains);
+			_serviceProvider.Register<IMemoryDomains>(_memoryDomains);
 
 			_memoryDomains.MainMemory = _memoryDomains[_isSGB ? "SGB WRAM" : "WRAM"];
 			_memoryDomains.SystemBus = _memoryDomains[_isSGB ? "SGB System Bus" : "System Bus"];
+
+			if (_saveRamSize == 0)
+				_serviceProvider.Unregister<ISaveRam>();
 		}
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.ISaveRam.cs
@@ -13,7 +13,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 
 		public byte[] CloneSaveRam(bool clearDirty)
 		{
-			if (_saveRamSize == 0) return null;
+			if (_saveRamSize == 0)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 
 			byte[] saveRamCopy = new byte[_saveRamSize];
 			using (Api.exe.EnterExit())
@@ -33,7 +34,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 
 		public void StoreSaveRam(byte[] data)
 		{
-			if (_saveRamSize == 0) return;
+			if (_saveRamSize == 0)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 
 			if (data.Length != _saveRamSize)
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.cs
@@ -22,8 +22,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 		public BsnesCore(CoreLoadParameters<SnesSettings, SnesSyncSettings> loadParameters) : this(loadParameters, false) { }
 		public BsnesCore(CoreLoadParameters<SnesSettings, SnesSyncSettings> loadParameters, bool subframe = false)
 		{
-			var ser = new BasicServiceProvider(this);
-			ServiceProvider = ser;
+			_serviceProvider = new BasicServiceProvider(this);
 
 			this._romPath = Path.ChangeExtension(loadParameters.Roms[0].RomPath.SubstringBefore('|'), null);
 			CoreComm = loadParameters.Comm;
@@ -90,7 +89,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 
 			// start up audio resampler
 			InitAudio();
-			ser.Register<ISoundProvider>(_soundProvider);
+			_serviceProvider.Register<ISoundProvider>(_soundProvider);
 
 			if (_isSGB)
 			{
@@ -141,8 +140,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 
 			const string TRACE_HEADER = "65816: PC, mnemonic, operands, registers (A, X, Y, S, D, B, flags (NVMXDIZC), V, H)";
 			_tracer = new TraceBuffer(TRACE_HEADER);
-			ser.Register<IDisassemblable>(new W65816_DisassemblerService());
-			ser.Register(_tracer);
+			_serviceProvider.Register<IDisassemblable>(new W65816_DisassemblerService());
+			_serviceProvider.Register(_tracer);
 
 			Api.Seal();
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/SubBsnesCore.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/SubBsnesCore.cs
@@ -25,7 +25,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 			BasicServiceProvider ser = new(this);
 			ser.Register(_bsnesCore.ServiceProvider.GetService<IDebuggable>());
 			ser.Register(_bsnesCore.ServiceProvider.GetService<IVideoProvider>());
-			ser.Register(_bsnesCore.ServiceProvider.GetService<ISaveRam>());
+			if (_bsnesCore.ServiceProvider.HasService<ISaveRam>())
+				ser.Register(_bsnesCore.ServiceProvider.GetService<ISaveRam>());
 			ser.Register(_bsnesCore.ServiceProvider.GetService<IStatable>());
 			ser.Register(_bsnesCore.ServiceProvider.GetService<IInputPollable>());
 			ser.Register(_bsnesCore.ServiceProvider.GetService<IRegionable>());

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.ISaveRam.cs
@@ -21,7 +21,10 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 
 			if (len == 0)
 			{
-				return null;
+				// mGBA does not know a game's save type (and as a result actual savedata size) on startup.
+				// Consequently, it cannot conditionally provide the ISaveRam service.
+				// Unfortunately this means the frontend will create empty save files for games with no savedata.
+				return Array.Empty<byte>();
 			}
 
 			var ret = new byte[len];

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IEmulator.cs
@@ -5,7 +5,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 {
 	public partial class GBHawk : IEmulator, IVideoProvider
 	{
-		public IEmulatorServiceProvider ServiceProvider { get; }
+		private readonly BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		public ControllerDefinition ControllerDefinition => _controllerDeck.Definition;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IMemoryDomains.cs
@@ -68,7 +68,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 			}
 
 			MemoryDomains = new MemoryDomainList(domains);
-			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
+			_serviceProvider.Register<IMemoryDomains>(MemoryDomains);
 		}
 
 		private byte PeekRAM(long addr)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.ISaveRam.cs
@@ -6,13 +6,18 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 	{
 		public byte[] CloneSaveRam(bool clearDirty)
 		{
-			return (byte[])cart_RAM?.Clone();
+			if (cart_RAM == null)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+			return (byte[])cart_RAM.Clone();
 		}
 
 		public void StoreSaveRam(byte[] data)
 		{
-			if (_syncSettings.Use_SRAM)
+			if (cart_RAM == null)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+			else if (_syncSettings.Use_SRAM)
 			{
+				if (data.Length != cart_RAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 				Buffer.BlockCopy(data, 0, cart_RAM, 0, data.Length);
 				Console.WriteLine("loading SRAM here");
 			}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IEmulator.cs
@@ -4,7 +4,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 {
 	public partial class GBHawkLink : IEmulator, IVideoProvider, ISoundProvider
 	{
-		public IEmulatorServiceProvider ServiceProvider { get; }
+		private readonly BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		public ControllerDefinition ControllerDefinition => _controllerDeck.Definition;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IMemoryDomains.cs
@@ -96,8 +96,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 				domains.Add(cartRamR);
 			}
 
+			if (L.cart_RAM == null && R.cart_RAM == null)
+			{
+				_serviceProvider.Unregister<ISaveRam>();
+			}
+
 			MemoryDomains = new MemoryDomainList(domains);
-			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
+			_serviceProvider.Register<IMemoryDomains>(MemoryDomains);
 		}
 
 		private byte PeekSystemBusL(long addr)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.ISaveRam.cs
@@ -45,7 +45,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 				return temp;
 			}
 
-			return null;
+			throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 		}
 
 		public void StoreSaveRam(byte[] data)
@@ -54,16 +54,23 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 			{
 				if (L.cart_RAM != null && R.cart_RAM == null)
 				{
+					if (data.Length != L.cart_RAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 					Buffer.BlockCopy(data, 0, L.cart_RAM, 0, L.cart_RAM.Length);
 				}
 				else if (R.cart_RAM != null && L.cart_RAM == null)
 				{
+					if (data.Length != R.cart_RAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 					Buffer.BlockCopy(data, 0, R.cart_RAM, 0, R.cart_RAM.Length);
 				}
 				else if (R.cart_RAM != null && L.cart_RAM != null)
 				{
+					if (data.Length != L.cart_RAM.Length + R.cart_RAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 					Buffer.BlockCopy(data, 0, L.cart_RAM, 0, L.cart_RAM.Length);
 					Buffer.BlockCopy(data, L.cart_RAM.Length, R.cart_RAM, 0, R.cart_RAM.Length);
+				}
+				else
+				{
+					throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 				}
 
 				Console.WriteLine("loading SRAM here");

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.cs
@@ -37,8 +37,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 			if (lp.Roms.Count != 2)
 				throw new InvalidOperationException("Wrong number of roms");
 
-			var ser = new BasicServiceProvider(this);
-			ServiceProvider = ser;
+			_serviceProvider = new BasicServiceProvider(this);
 
 			linkSettings = lp.Settings ?? new GBLinkSettings();
 			linkSyncSettings = lp.SyncSettings ?? new GBLinkSyncSettings();
@@ -66,11 +65,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 			L = new GBHawk.GBHawk(lp.Comm, lp.Roms[0].Game, lp.Roms[0].RomData, temp_set_L, temp_sync_L);
 			R = new GBHawk.GBHawk(lp.Comm, lp.Roms[1].Game, lp.Roms[1].RomData, temp_set_R, temp_sync_R);
 
-			ser.Register<IVideoProvider>(this);
-			ser.Register<ISoundProvider>(this);
+			_serviceProvider.Register<IVideoProvider>(this);
+			_serviceProvider.Register<ISoundProvider>(this);
 
 			_tracer = new TraceBuffer(L.cpu.TraceHeader);
-			ser.Register<ITraceable>(_tracer);
+			_serviceProvider.Register<ITraceable>(_tracer);
 
 			_lStates = L.ServiceProvider.GetService<IStatable>();
 			_rStates = R.ServiceProvider.GetService<IStatable>();

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IEmulator.cs
@@ -4,7 +4,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 {
 	public partial class GBHawkLink3x : IEmulator, IVideoProvider, ISoundProvider
 	{
-		public IEmulatorServiceProvider ServiceProvider { get; }
+		private readonly BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		public ControllerDefinition ControllerDefinition => _controllerDeck.Definition;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IMemoryDomains.cs
@@ -137,8 +137,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 				domains.Add(cartRamR);
 			}
 
+			if (L.cart_RAM == null && C.cart_RAM == null && R.cart_RAM == null)
+			{
+				_serviceProvider.Unregister<ISaveRam>();
+			}
+
 			MemoryDomains = new MemoryDomainList(domains);
-			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
+			_serviceProvider.Register<IMemoryDomains>(MemoryDomains);
 		}
 
 		private byte PeekSystemBusL(long addr)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.ISaveRam.cs
@@ -60,7 +60,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 				return temp;
 			}
 
-			return null;
+			throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 		}
 
 		public void StoreSaveRam(byte[] data)
@@ -84,7 +84,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 				if (R.cart_RAM != null)
 				{
 					Buffer.BlockCopy(data, temp, R.cart_RAM, 0, R.cart_RAM.Length);
+					temp += R.cart_RAM.Length;
 				}
+
+				if (temp == 0) throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+				if (data.Length != temp) throw new InvalidOperationException("Incorrect sram size.");
 
 				Console.WriteLine("loading SRAM here");
 			}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.cs
@@ -37,8 +37,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 			if (lp.Roms.Count != 3)
 				throw new InvalidOperationException("Wrong number of roms");
 
-			var ser = new BasicServiceProvider(this);
-			ServiceProvider = ser;
+			_serviceProvider = new BasicServiceProvider(this);
 
 			Link3xSettings = lp.Settings ?? new GBLink3xSettings();
 			Link3xSyncSettings = lp.SyncSettings ?? new GBLink3xSyncSettings();
@@ -74,11 +73,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 			C = new GBHawk.GBHawk(lp.Comm, lp.Roms[1].Game, lp.Roms[1].RomData, tempSetC, tempSyncC);
 			R = new GBHawk.GBHawk(lp.Comm, lp.Roms[2].Game, lp.Roms[2].RomData, tempSetR, tempSyncR);
 
-			ser.Register<IVideoProvider>(this);
-			ser.Register<ISoundProvider>(this);
+			_serviceProvider.Register<IVideoProvider>(this);
+			_serviceProvider.Register<ISoundProvider>(this);
 
 			_tracer = new TraceBuffer(L.cpu.TraceHeader);
-			ser.Register(_tracer);
+			_serviceProvider.Register(_tracer);
 
 			_lStates = L.ServiceProvider.GetService<IStatable>();
 			_cStates = C.ServiceProvider.GetService<IStatable>();

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IEmulator.cs
@@ -5,7 +5,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 {
 	public partial class GBHawkLink4x : IEmulator, IVideoProvider, ISoundProvider
 	{
-		public IEmulatorServiceProvider ServiceProvider { get; }
+		private readonly BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		public ControllerDefinition ControllerDefinition => _controllerDeck.Definition;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IMemoryDomains.cs
@@ -178,8 +178,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 				domains.Add(cartRamD);
 			}
 
+			if (A.cart_RAM == null && B.cart_RAM == null && C.cart_RAM == null && D.cart_RAM == null)
+			{
+				_serviceProvider.Unregister<ISaveRam>();
+			}
+
 			MemoryDomains = new MemoryDomainList(domains);
-			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
+			_serviceProvider.Register<IMemoryDomains>(MemoryDomains);
 		}
 
 		private byte PeekSystemBusA(long addr)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.ISaveRam.cs
@@ -75,7 +75,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 				return temp;
 			}
 
-			return null;
+			throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 		}
 
 		public void StoreSaveRam(byte[] data)
@@ -105,7 +105,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 				if (D.cart_RAM != null)
 				{
 					Buffer.BlockCopy(data, temp, D.cart_RAM, 0, D.cart_RAM.Length);
+					temp += D.cart_RAM.Length;
 				}
+
+				if (temp == 0) throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+				if (data.Length != temp) throw new InvalidOperationException("Incorrect sram size.");
 
 				Console.WriteLine("loading SRAM here");
 			}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.cs
@@ -58,7 +58,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 			if (lp.Roms.Count != 4)
 				throw new InvalidOperationException("Wrong number of roms");
 
-			var ser = new BasicServiceProvider(this);
+			_serviceProvider = new BasicServiceProvider(this);
 
 			Link4xSettings = lp.Settings ?? new GBLink4xSettings();
 			Link4xSyncSettings = lp.SyncSettings ?? new GBLink4xSyncSettings();
@@ -102,13 +102,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 			C = new GBHawk.GBHawk(lp.Comm, lp.Roms[2].Game, lp.Roms[2].RomData, tempSetC, tempSyncC);
 			D = new GBHawk.GBHawk(lp.Comm, lp.Roms[3].Game, lp.Roms[3].RomData, tempSetD, tempSyncD);
 
-			ser.Register<IVideoProvider>(this);
-			ser.Register<ISoundProvider>(this);
+			_serviceProvider.Register<IVideoProvider>(this);
+			_serviceProvider.Register<ISoundProvider>(this);
 
 			_tracer = new TraceBuffer(A.cpu.TraceHeader);
-			ser.Register(_tracer);
-
-			ServiceProvider = ser;
+			_serviceProvider.Register(_tracer);
 
 			_aStates = A.ServiceProvider.GetService<IStatable>();
 			_bStates = B.ServiceProvider.GetService<IStatable>();

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.ISaveRam.cs
@@ -18,12 +18,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 				return ret;
 			}
 
-			return null;
+			throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 		}
 
 		public void StoreSaveRam(byte[] data)
 		{
 			var expected = LibGambatte.gambatte_getsavedatalength(GambatteState);
+			if (expected == 0) throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			if (data.Length != expected) throw new ArgumentException(message: "Size of saveram data does not match expected!", paramName: nameof(data));
 
 			LibGambatte.gambatte_loadsavedata(GambatteState, data);

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
@@ -251,6 +251,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 					remote: _syncSettings.EnableRemote);
 
 				NewSaveCoreSetBuff();
+
+				if (LibGambatte.gambatte_getsavedatalength(GambatteState) == 0)
+				{
+					_serviceProvider.Unregister<ISaveRam>();
+				}
 			}
 			catch
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NDS/MelonDS.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NDS/MelonDS.ISaveRam.cs
@@ -15,7 +15,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.NDS
 			{
 				if (DSiWareSaveLength == 0)
 				{
-					return null;
+					throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 				}
 
 				_exe.AddTransientFile([ ], "public.sav");
@@ -47,13 +47,14 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.NDS
 				return ret;
 			}
 
-			return null;
+			throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 		}
 
 		public new void StoreSaveRam(byte[] data)
 		{
 			if (IsDSiWare)
 			{
+				if (DSiWareSaveLength == 0) throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 				if (data.Length == DSiWareSaveLength)
 				{
 					if (PublicSavSize > 0) _exe.AddReadonlyFile(data.AsSpan().Slice(0, PublicSavSize).ToArray(), "public.sav");
@@ -65,6 +66,10 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.NDS
 					if (PublicSavSize > 0) _exe.RemoveReadonlyFile("public.sav");
 					if (PrivateSavSize > 0) _exe.RemoveReadonlyFile("private.sav");
 					if (BannerSavSize > 0) _exe.RemoveReadonlyFile("banner.sav");
+				}
+				else
+				{
+					throw new InvalidOperationException("Incorrect sram size.");
 				}
 			}
 			else if (data.Length > 0)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NDS/MelonDS.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NDS/MelonDS.cs
@@ -618,6 +618,12 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.NDS
 					_serviceProvider.Register<IVideoProvider>(_glTextureProvider);
 					RefreshScreenSettings(_settings);
 				}
+
+				bool supportsSaveRam = IsDSiWare ? DSiWareSaveLength != 0 : _core.GetSaveRamLength(_console) != 0;
+				if (!supportsSaveRam)
+				{
+					_serviceProvider.Unregister<ISaveRam>();
+				}
 			}
 			catch
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.ISaveRam.cs
@@ -15,6 +15,14 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			}
 		}
 
+		private bool HasSaveRam()
+		{
+			if (Board == null) return false;
+			if (Board is FDS) return true;
+			if (Board.SaveRam == null) return false;
+			return true;
+		}
+
 		public byte[] CloneSaveRam(bool clearDirty)
 		{
 			if (Board is FDS fds)
@@ -22,7 +30,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				return fds.ReadSaveRam();
 			}
 
-			return (byte[]) Board?.SaveRam?.Clone();
+			byte[]/*?*/ sram = (byte[])Board?.SaveRam?.Clone();
+			return sram ?? throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 		}
 
 		public void StoreSaveRam(byte[] data)
@@ -30,14 +39,15 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			if (Board is FDS fds)
 			{
 				fds.StoreSaveRam(data);
-				return;
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			if (Board?.SaveRam == null)
 			{
-				return;
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
+			if (data.Length != Board.SaveRam.Length) throw new InvalidOperationException("Incorrect sram size.");
 			Array.Copy(data, Board.SaveRam, data.Length);
 		}
 	}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.cs
@@ -77,6 +77,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			}
 
 			ResetControllerDefinition(subframe);
+
+			if (!HasSaveRam())
+			{
+				ser.Unregister<ISaveRam>();
+			}
 		}
 
 		private static readonly bool USE_DATABASE = true;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.IMemoryDomains.cs
@@ -43,7 +43,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 				}, 1));
 
 			_memoryDomains = new MemoryDomainList(mm);
-			((BasicServiceProvider) ServiceProvider).Register(_memoryDomains);
+			_serviceProvider.Register(_memoryDomains);
 		}
 
 		private IMemoryDomains _memoryDomains;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.ISaveRam.cs
@@ -6,7 +6,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 	{
 		public byte[] CloneSaveRam(bool clearDirty)
 		{
-			if (!QN.qn_has_battery_ram(Context)) return null;
+			if (!QN.qn_has_battery_ram(Context))
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 
 			LibQuickNES.ThrowStringError(QN.qn_battery_ram_save(Context, _saveRamBuff, _saveRamBuff.Length));
 			return (byte[])_saveRamBuff.Clone();
@@ -14,7 +15,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 
 		public void StoreSaveRam(byte[] data)
 		{
-			if (!QN.qn_has_battery_ram(Context)) return;
+			if (!QN.qn_has_battery_ram(Context))
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 
 			LibQuickNES.ThrowStringError(QN.qn_battery_ram_load(Context, data, data.Length));
 		}
@@ -28,6 +30,9 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 			int size = 0;
 			LibQuickNES.ThrowStringError(QN.qn_battery_ram_size(Context, ref size));
 			_saveRamBuff = new byte[size];
+
+			if (!QN.qn_has_battery_ram(Context))
+				_serviceProvider.Unregister<ISaveRam>();
 		}
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.ITraceable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.ITraceable.cs
@@ -40,7 +40,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 		private void ConnectTracer()
 		{
 			Tracer = new TraceBuffer(TraceHeader);
-			((BasicServiceProvider) ServiceProvider).Register<ITraceable>(Tracer);
+			_serviceProvider.Register<ITraceable>(Tracer);
 			_traceCb = MakeTrace;
 		}
 	}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.cs
@@ -30,7 +30,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 		[CoreConstructor(VSystemID.Raw.NES)]
 		public QuickNES(byte[] file, QuickNESSettings settings, QuickNESSyncSettings syncSettings)
 		{
-			ServiceProvider = new BasicServiceProvider(this);
+			_serviceProvider = new BasicServiceProvider(this);
 			Context = QN.qn_new();
 			if (Context == IntPtr.Zero)
 			{
@@ -70,7 +70,9 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 
 		private static readonly LibQuickNES QN;
 
-		public IEmulatorServiceProvider ServiceProvider { get; }
+
+		private readonly BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		int IVideoLogicalOffsets.ScreenX => _settings.ClipLeftAndRight ? 8 : 0;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.ISaveRam.cs
@@ -25,7 +25,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 
 				if (buf == null)
 				{
-					return null;
+					throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 				}
 
 				var ret = new byte[size];
@@ -46,9 +46,9 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 					size = Api.QUERY_get_memory_size(LibsnesApi.SNES_MEMORY.SGB_CARTRAM);
 				}
 
-				if (size == 0)
+				if (size == 0 || buf == null)
 				{
-					return;
+					throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 				}
 
 				if (size != data.Length)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.cs
@@ -193,6 +193,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 			Api.QUERY_set_audio_sample(_soundcb);
 			Api.Seal();
 			RefreshPalette();
+
+			bool hasSaveRam = Api.QUERY_get_memory_data(LibsnesApi.SNES_MEMORY.CARTRIDGE_RAM) != null
+				|| Api.QUERY_get_memory_data(LibsnesApi.SNES_MEMORY.SGB_CARTRAM) != null;
+			if (!hasSaveRam)
+			{
+				ser.Unregister<ISaveRam>();
+			}
 		}
 
 		private readonly LibsnesApi.snes_video_refresh_t _videocb;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SameBoy/SameBoy.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SameBoy/SameBoy.ISaveRam.cs
@@ -10,25 +10,23 @@ namespace BizHawk.Emulation.Cores.Nintendo.Sameboy
 		{
 			int length = LibSameboy.sameboy_sramlen(SameboyState);
 
-			if (length > 0)
+			if (length == 0)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+			else
 			{
 				byte[] ret = new byte[length];
 				LibSameboy.sameboy_savesram(SameboyState, ret);
 				return ret;
 			}
-
-			return null;
 		}
 
 		public void StoreSaveRam(byte[] data)
 		{
 			int expected = LibSameboy.sameboy_sramlen(SameboyState);
+			if (expected == 0) throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			if (data.Length != expected) throw new ArgumentException(message: "Size of saveram data does not match expected!", paramName: nameof(data));
 
-			if (expected > 0)
-			{
-				LibSameboy.sameboy_loadsram(SameboyState, data, data.Length);
-			}
+			LibSameboy.sameboy_loadsram(SameboyState, data, data.Length);
 		}
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SameBoy/SameBoy.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SameBoy/SameBoy.cs
@@ -163,6 +163,10 @@ namespace BizHawk.Emulation.Cores.Nintendo.Sameboy
 
 			InitMemoryDomains();
 			InitMemoryCallbacks();
+			if (LibSameboy.sameboy_sramlen(SameboyState) == 0)
+			{
+				_serviceProvider.Unregister<ISaveRam>();
+			}
 
 			_inputcb = InputCallback;
 			_rumblecb = RumbleCallback;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubGBHawk/SubGBHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubGBHawk/SubGBHawk.cs
@@ -33,7 +33,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubGBHawk
 			ser.Register(_GBCore.ServiceProvider.GetService<ISoundProvider>());
 			ser.Register(_GBCore.ServiceProvider.GetService<ITraceable>());
 			ser.Register(_GBCore.ServiceProvider.GetService<IMemoryDomains>());
-			ser.Register(_GBCore.ServiceProvider.GetService<ISaveRam>());
+			if (_GBCore.ServiceProvider.HasService<ISaveRam>())
+				ser.Register(_GBCore.ServiceProvider.GetService<ISaveRam>());
 			ser.Register(_GBCore.ServiceProvider.GetService<IRegionable>());
 			ser.Register(_GBCore.ServiceProvider.GetService<ICodeDataLogger>());
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.cs
@@ -32,7 +32,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubNESHawk
 			ser.Register(_nesCore.ServiceProvider.GetService<IMemoryDomains>());
 			ser.Register(_nesCore.ServiceProvider.GetService<INESPPUViewable>());
 			ser.Register(_nesCore.ServiceProvider.GetService<IBoardInfo>());
-			ser.Register(_nesCore.ServiceProvider.GetService<ISaveRam>());
+			if (_nesCore.ServiceProvider.HasService<ISaveRam>())
+				ser.Register(_nesCore.ServiceProvider.GetService<ISaveRam>());
 			ser.Register(_nesCore.ServiceProvider.GetService<IDebuggable>());
 			ser.Register(_nesCore.ServiceProvider.GetService<IRegionable>());
 			ser.Register(_nesCore.ServiceProvider.GetService<ICodeDataLogger>());

--- a/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.ISaveRam.cs
@@ -8,15 +8,21 @@ namespace BizHawk.Emulation.Cores.PCEngine
 
 		public byte[] CloneSaveRam(bool clearDirty)
 		{
+			if (BRAM == null) throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			if (clearDirty) SaveRamModified = false;
-			return (byte[]) BRAM?.Clone();
+			return (byte[]) BRAM.Clone();
 		}
 
 		public void StoreSaveRam(byte[] data)
 		{
 			if (BRAM != null)
 			{
+				if (data.Length != BRAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 				Array.Copy(data, BRAM, data.Length);
+			}
+			else
+			{
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			SaveRamModified = false;

--- a/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.cs
@@ -323,6 +323,8 @@ namespace BizHawk.Emulation.Cores.PCEngine
 			ser.Register<ISoundProvider>(_soundProvider);
 			ser.Register<IPCEngineSoundDebuggable>(PSG);
 			ser.Register<IStatable>(new StateSerializer(SyncState));
+			if (BRAM == null)
+				ser.Unregister<ISaveRam>();
 			SetupMemoryDomains();
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.ISaveRam.cs
@@ -45,23 +45,30 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 				return temp;
 			}
 
-			return null;
+			throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 		}
 
 		public void StoreSaveRam(byte[] data)
 		{
 			if (L.SaveRAM != null && R.SaveRAM == null)
 			{
+				if (data.Length != L.SaveRAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 				Buffer.BlockCopy(data, 0, L.SaveRAM, 0, L.SaveRAM.Length);
 			}
 			else if (R.SaveRAM != null && L.SaveRAM == null)
 			{
+				if (data.Length != R.SaveRAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 				Buffer.BlockCopy(data, 0, R.SaveRAM, 0, R.SaveRAM.Length);
 			}
 			else if (R.SaveRAM != null && L.SaveRAM != null)
 			{
+				if (data.Length != L.SaveRAM.Length + R.SaveRAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 				Buffer.BlockCopy(data, 0, L.SaveRAM, 0, L.SaveRAM.Length);
 				Buffer.BlockCopy(data, L.SaveRAM.Length, R.SaveRAM, 0, R.SaveRAM.Length);
+			}
+			else
+			{
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			Console.WriteLine("loading SRAM here");

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.cs
@@ -46,6 +46,8 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 			ser.Register<ICodeDataLogger>(L);
 			ser.Register<IVideoProvider>(this);
 			ser.Register<ISoundProvider>(this);
+			if (L.SaveRAM == null && R.SaveRAM == null)
+				ser.Unregister<ISaveRam>();
 
 			_tracer = new TraceBuffer(L.Cpu.TraceHeader);
 			ser.Register(_tracer);

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
@@ -4,7 +4,8 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 {
 	public partial class SMS : IEmulator
 	{
-		public IEmulatorServiceProvider ServiceProvider { get; }
+		private readonly BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		// not savestated variables
 		private int s_L, s_R;

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IMemoryDomains.cs
@@ -35,11 +35,15 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 					(addr, value) => { SaveRAM[addr] = value; SaveRamModified = true; }, 1);
 				domains.Add(saveRamDomain);
 			}
+			else
+			{
+				_serviceProvider.Unregister<ISaveRam>();
+			}
 
 			SyncAllByteArrayDomains();
 
 			MemoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList());
-			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
+			_serviceProvider.Register<IMemoryDomains>(MemoryDomains);
 
 			_memoryDomainsInit = true;
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.ISaveRam.cs
@@ -6,15 +6,21 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 	{
 		public byte[] CloneSaveRam(bool clearDirty)
 		{
+			if (SaveRAM == null) throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			if (clearDirty) SaveRamModified = false;
-			return (byte[]) SaveRAM?.Clone();
+			return (byte[]) SaveRAM.Clone();
 		}
 
 		public void StoreSaveRam(byte[] data)
 		{
 			if (SaveRAM != null)
 			{
+				if (data.Length != SaveRAM.Length) throw new InvalidOperationException("Incorrect sram size.");
 				Array.Copy(data, SaveRAM, data.Length);
+			}
+			else
+			{
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			SaveRamModified = false;

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.cs
@@ -21,8 +21,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 		[CoreConstructor(VSystemID.Raw.GG)]
 		public SMS(CoreComm comm, GameInfo game, byte[] rom, SmsSettings settings, SmsSyncSettings syncSettings)
 		{
-			var ser = new BasicServiceProvider(this);
-			ServiceProvider = ser;
+			_serviceProvider = new BasicServiceProvider(this);
 			Settings = settings ?? new SmsSettings();
 			SyncSettings = syncSettings ?? new SmsSyncSettings();
 
@@ -94,7 +93,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			SystemId = game.System;
 
 			Vdp = new VDP(this, Cpu, IsGameGear ? VdpMode.GameGear : VdpMode.SMS, Region, sms_reg_compat);
-			ser.Register<IVideoProvider>(Vdp);
+			_serviceProvider.Register<IVideoProvider>(Vdp);
 			PSG = new SN76489sms();
 			YM2413 = new YM2413();
 			//SoundMixer = new SoundMixer(YM2413, PSG);
@@ -106,7 +105,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			BlipL.SetRates(3579545, 44100);
 			BlipR.SetRates(3579545, 44100);
 
-			ser.Register<ISoundProvider>(this);
+			_serviceProvider.Register<ISoundProvider>(this);
 
 			SystemRam = new byte[0x2000];
 
@@ -194,9 +193,9 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 
 			Tracer = new TraceBuffer(Cpu.TraceHeader);
 
-			ser.Register(Tracer);
-			ser.Register<IDisassemblable>(Cpu);
-			ser.Register<IStatable>(new StateSerializer(SyncState));
+			_serviceProvider.Register(Tracer);
+			_serviceProvider.Register<IDisassemblable>(Cpu);
+			_serviceProvider.Register<IStatable>(new StateSerializer(SyncState));
 			Vdp.ProcessOverscan();
 
 			// Z80 SP initialization
@@ -206,7 +205,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 
 			if (!IsSG1000)
 			{
-				ser.Register<ISmsGpuView>(new SmsGpuView(Vdp));
+				_serviceProvider.Register<ISmsGpuView>(new SmsGpuView(Vdp));
 			}
 
 			_controllerDeck = new SMSControllerDeck(SyncSettings.Port1, SyncSettings.Port2, IsGameGear_C, SyncSettings.UseKeyboard);

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IEmulator.cs
@@ -4,7 +4,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 {
 	public partial class GPGX : IEmulator, ISoundProvider
 	{
-		public IEmulatorServiceProvider ServiceProvider { get; }
+		private readonly BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
 		public ControllerDefinition ControllerDefinition { get; private set; }
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IMemoryDomains.cs
@@ -198,7 +198,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 
 				mm.Add(_elf.GetPagesDomain());
 				_memoryDomains = new MemoryDomainList(mm) { SystemBus = systemBus };
-				((BasicServiceProvider) ServiceProvider).Register(_memoryDomains);
+				_serviceProvider.Register(_memoryDomains);
 			}
 		}
 	}

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.ISaveRam.cs
@@ -13,7 +13,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 			var area = Core.gpgx_get_sram(ref size);
 			if (size == 0 || area == IntPtr.Zero)
 			{
-				return null;
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			var ret = new byte[size];
@@ -31,6 +31,13 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 			{
 				// not sure how this is happening, but reject them
 				return;
+			}
+
+			var size = 0;
+			var area = Core.gpgx_get_sram(ref size);
+			if (size == 0 || area == IntPtr.Zero)
+			{
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			}
 
 			if (!Core.gpgx_put_sram(data, data.Length))

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.cs
@@ -30,7 +30,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 			CDCallback = CDCallbackProc;
 			CDReadCallback = CDRead;
 
-			ServiceProvider = new BasicServiceProvider(this);
+			_serviceProvider = new BasicServiceProvider(this);
 			// this can influence some things internally (autodetect romtype, etc)
 
 			// Determining system ID from the rom. If no rom provided, assume Genesis (Sega CD)
@@ -49,7 +49,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 				};
 			}
 			PCRegisterName = SystemId is VSystemID.Raw.GEN ? "M68K PC" : "Z80 pc";
-			if (SystemId is not VSystemID.Raw.GEN) ((BasicServiceProvider) ServiceProvider).Unregister<IDisassemblable>();
+			if (SystemId is not VSystemID.Raw.GEN) _serviceProvider.Unregister<IDisassemblable>();
 
 			// three or six button?
 			// http://www.sega-16.com/forum/showthread.php?4398-Forgotten-Worlds-giving-you-GAME-OVER-immediately-Fix-inside&highlight=forgotten%20worlds
@@ -141,6 +141,12 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 				UpdateVideo();
 
 				SetMemoryDomains();
+				var size = 0;
+				var area = Core.gpgx_get_sram(ref size);
+				if (size == 0 || area == IntPtr.Zero)
+				{
+					_serviceProvider.Unregister<ISaveRam>();
+				}
 
 				Core.gpgx_set_input_callback(_inputCallback);
 
@@ -152,7 +158,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 				if (SystemId == VSystemID.Raw.GEN)
 				{
 					_tracer = new GPGXTraceBuffer(this, _memoryDomains, this);
-					((BasicServiceProvider)ServiceProvider).Register(_tracer);
+					_serviceProvider.Register(_tracer);
 				}
 			}
 

--- a/src/BizHawk.Emulation.Cores/Libretro/Libretro.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Libretro/Libretro.IMemoryDomains.cs
@@ -38,6 +38,9 @@ namespace BizHawk.Emulation.Cores.Libretro
 				}
 			}
 
+			if (_saveramSize == 0)
+				_serviceProvider.Unregister<ISaveRam>();
+
 			// no domains to register...
 			if (md.Count == 0)
 			{

--- a/src/BizHawk.Emulation.Cores/Libretro/Libretro.ISaveRam.cs
+++ b/src/BizHawk.Emulation.Cores/Libretro/Libretro.ISaveRam.cs
@@ -14,7 +14,9 @@ namespace BizHawk.Emulation.Cores.Libretro
 
 		public byte[] CloneSaveRam(bool clearDirty)
 		{
-			if (_saveramSize > 0)
+			if (_saveramSize == 0)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+			else
 			{
 				var buf = new byte[_saveramSize];
 				int index = 0;
@@ -25,13 +27,13 @@ namespace BizHawk.Emulation.Cores.Libretro
 				}
 				return buf;
 			}
-
-			return null;
 		}
 
 		public void StoreSaveRam(byte[] data)
 		{
-			if (_saveramSize > 0)
+			if (_saveramSize == 0)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+			else
 			{
 				int index = 0;
 				foreach (var m in _saveramAreas)
@@ -39,6 +41,8 @@ namespace BizHawk.Emulation.Cores.Libretro
 					Marshal.Copy(data, index, m.Data, (int)m.Size);
 					index += (int)m.Size;
 				}
+
+				if (data.Length != index) throw new InvalidOperationException("Incorrect sram size.");
 			}
 		}
 	}

--- a/src/BizHawk.Emulation.Cores/Waterbox/WaterboxCore.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/WaterboxCore.cs
@@ -88,6 +88,8 @@ namespace BizHawk.Emulation.Cores.Waterbox
 					.Where(md => md.Definition.Flags.HasFlag(LibWaterboxCore.MemoryDomainFlags.Saverammable))
 					.ToArray();
 				_saveramSize = (int)_saveramAreas.Sum(a => a.Size);
+				if (_saveramSize == 0)
+					_serviceProvider.Unregister<ISaveRam>();
 
 				_exe.Seal();
 			}
@@ -161,7 +163,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 		public byte[] CloneSaveRam(bool clearDirty)
 		{
 			if (_saveramSize == 0)
-				return null;
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
 			using (_exe.EnterExit())
 			{
 				var ret = new byte[_saveramSize];
@@ -176,6 +178,9 @@ namespace BizHawk.Emulation.Cores.Waterbox
 
 		public void StoreSaveRam(byte[] data)
 		{
+			if (_saveramSize == 0)
+				throw new InvalidOperationException("Core currently has no SRAM and should not be providing ISaveRam service.");
+
 			// Checking if the size of the SaveRAM provided coincides with that expected. This is important for cores whose SaveRAM size can vary depending on their configuration.
 			if (data.Length != _saveramSize)
 			{


### PR DESCRIPTION
ISaveRam can no longer return null for SaveRam, which used to indicate that the current game has no SaveRam. Instead, cores conditionally provide the ISaveRam service. There is also a behavior change in the frontend, as it no longer silently modifies the .SaveRam file before passing it to the core. This could result in some previously-working saves not working anymore (bad dumps, perhaps?) but should not affect any .SaveRam files generated by EmuHawk.

Several cores have unusual implementations here and should be reviewed by someone who knows more of how they work:
- MSX and O2Hawk: It seems there are no writes to SaveRAM, ever. So they does not ever provide SRAM despite implementing the interface.
- mGBA: According to a code comment, the core does not know the SRAM size at startup. I have made it provide an empty byte array if it doesn't have one, instead of conditionally providing the service. `mGBA does not know a game's save type (and as a result actual savedata size) on startup. Gambatte might be the same, Idk.`
	- see #4242
- MAME: Uses files? Service is registered in a callback.

Multiple other cores also use an API to get SRAM data/size from external code and so might also have mistakes. I've made them unregister the ISaveRam service if `CloneSaveRam` would return null at the end of the constructor.

My original implementation of this, that adds a property `SupportsSaveRam` to the `ISaveRam` interface instead of making cores conditionally provide the service, can be found in my `sram` branch.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
