### PR TITLE
Remove the button for loading macro tool.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -203,7 +203,6 @@ namespace BizHawk.Client.EmuHawk
 			this.TraceLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CodeDataLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.MacroToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.VirtualPadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.BasicBotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator11 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
@@ -1358,7 +1357,6 @@ namespace BizHawk.Client.EmuHawk
             this.TraceLoggerMenuItem,
             this.DebuggerMenuItem,
             this.CodeDataLoggerMenuItem,
-            this.MacroToolMenuItem,
             this.VirtualPadMenuItem,
             this.BasicBotMenuItem,
             this.toolStripSeparator11,
@@ -1416,11 +1414,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.CodeDataLoggerMenuItem.Text = "Code-Data Logger";
 			this.CodeDataLoggerMenuItem.Click += new System.EventHandler(this.CodeDataLoggerMenuItem_Click);
-			// 
-			// MacroToolMenuItem
-			// 
-			this.MacroToolMenuItem.Text = "&Macro Tool";
-			this.MacroToolMenuItem.Click += new System.EventHandler(this.MacroToolMenuItem_Click);
 			// 
 			// VirtualPadMenuItem
 			// 
@@ -2721,7 +2714,6 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXDiscControlsMenuItem;
 		private BizHawk.WinForms.Controls.StatusLabelEx UpdateNotification;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXControllerSettingsMenuItem;
-		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MacroToolMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppleSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppleDisksSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator31;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1037,7 +1037,6 @@ namespace BizHawk.Client.EmuHawk
 			BasicBotMenuItem.Enabled = Tools.IsAvailable<BasicBot>();
 
 			GameSharkConverterMenuItem.Enabled = Tools.IsAvailable<GameShark>();
-			MacroToolMenuItem.Enabled = MovieSession.Movie.IsActive() && Tools.IsAvailable<MacroInputTool>();
 			VirtualPadMenuItem.Enabled = Emulator.ControllerDefinition.Any();
 		}
 
@@ -1117,11 +1116,6 @@ namespace BizHawk.Client.EmuHawk
 		private void CodeDataLoggerMenuItem_Click(object sender, EventArgs e)
 		{
 			Tools.Load<CDL>();
-		}
-
-		private void MacroToolMenuItem_Click(object sender, EventArgs e)
-		{
-			Tools.Load<MacroInputTool>();
 		}
 
 		private void VirtualPadMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
It is still possible to open via the toolbox but only when VersionInfo.DeveloperBuild is true.
It will eventually be removed entirely, since it's very broken and it seems nobody wants it. That will take a little more effort since some of its stuff is tied into TAStudio, but I figured it might be good to do this before release.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant