### PR TITLE
Fix error when creating empty Lua form dropdowns

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaDropDown.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaDropDown.cs
@@ -8,14 +8,14 @@ namespace BizHawk.Client.EmuHawk
 		public LuaDropDown(ICollection<string> items)
 		{
 			this.ReplaceItems(items: items);
-			SelectedIndex = 0;
+			if (items.Count > 0) SelectedIndex = 0;
 			DropDownStyle = ComboBoxStyle.DropDownList;
 		}
 
 		public void SetItems(ICollection<string> items)
 		{
 			this.ReplaceItems(items: items);
-			SelectedIndex = 0;
+			if (items.Count > 0) SelectedIndex = 0;
 		}
 	}
 }


### PR DESCRIPTION
Check if list of items is empty before setting `SelectedIndex`, to avoid an `ArgumentOutOfRangeException`.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
