### PR TITLE
Fix some items not appearing in Lua form dropdowns

### DIFF
--- a/src/BizHawk.Client.Common/lua/NLuaTableHelper.cs
+++ b/src/BizHawk.Client.Common/lua/NLuaTableHelper.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
+using System.Linq;
 
 using NLua;
 
@@ -28,6 +29,18 @@ namespace BizHawk.Client.Common
 			return table;
 		}
 
+		/// <summary>
+		/// Enumerates all values in <paramref name="table"/>, regardless of what their keys are.
+		/// </summary>
+		/// <returns>
+		/// An unordered sequence of values.
+		/// </returns>
+		public IEnumerable<T> EnumerateAllValues<T>(LuaTable table) => table.Values.Cast<T>();
+
+		/// <summary>
+		/// Enumerates values in a Lua-style array, starting with table[1], table[2], ... up to the first absent index.
+		/// Ignores all non-sequential and non-numeric keys.
+		/// </summary>
 		public ArraySegment<T> EnumerateValues<T>(LuaTable table)
 		{
 			var n = table.Count;

--- a/src/BizHawk.Client.Common/lua/NLuaTableHelper.cs
+++ b/src/BizHawk.Client.Common/lua/NLuaTableHelper.cs
@@ -2,7 +2,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
-using System.Linq;
 
 using NLua;
 
@@ -28,14 +27,6 @@ namespace BizHawk.Client.Common
 			foreach (var (k, v) in dictionary) table[k] = v;
 			return table;
 		}
-
-		/// <summary>
-		/// Enumerates all values in <paramref name="table"/>, regardless of what their keys are.
-		/// </summary>
-		/// <returns>
-		/// An unordered sequence of values.
-		/// </returns>
-		public IEnumerable<T> EnumerateAllValues<T>(LuaTable table) => table.Values.Cast<T>();
 
 		/// <summary>
 		/// Enumerates values in a Lua-style array, starting with table[1], table[2], ... up to the first absent index.

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/FormsLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/FormsLuaLibrary.cs
@@ -179,7 +179,7 @@ namespace BizHawk.Client.EmuHawk
 				return 0;
 			}
 
-			var dropdownItems = _th.EnumerateValues<string>(items).ToList();
+			var dropdownItems = _th.EnumerateAllValues<string>(items).ToList();
 			dropdownItems.Sort();
 
 			var dropdown = new LuaDropDown(dropdownItems);
@@ -1158,7 +1158,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				if (FindControlWithHandle(handle) is LuaDropDown ldd)
 				{
-					var dropdownItems = _th.EnumerateValues<string>(items).ToList();
+					var dropdownItems = _th.EnumerateAllValues<string>(items).ToList();
 					if (alphabetize) dropdownItems.Sort();
 					ldd.SetItems(dropdownItems);
 				}

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/FormsLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/FormsLuaLibrary.cs
@@ -179,7 +179,8 @@ namespace BizHawk.Client.EmuHawk
 				return 0;
 			}
 
-			var dropdownItems = _th.EnumerateAllValues<string>(items).ToList();
+			// Include non-numeric, unordered keys for backwards compatibility
+			var dropdownItems = items.Values.Cast<string>().ToList();
 			dropdownItems.Sort();
 
 			var dropdown = new LuaDropDown(dropdownItems);
@@ -1158,9 +1159,13 @@ namespace BizHawk.Client.EmuHawk
 			{
 				if (FindControlWithHandle(handle) is LuaDropDown ldd)
 				{
-					var dropdownItems = _th.EnumerateAllValues<string>(items).ToList();
-					if (alphabetize) dropdownItems.Sort();
-					ldd.SetItems(dropdownItems);
+					// Include non-numeric, unordered keys for backwards compatibility
+					// Sort numeric keys to maintain order of sequential {"Foo", "Bar"} tables when values are not alphabetized
+					// Order of non-numeric keys is undetermined
+					var dropdownItems = alphabetize
+						? items.Values.Cast<string>().Order()
+						: items.OrderBy(kvp => kvp.Key as long? ?? long.MaxValue).Select(kvp => (string)kvp.Value);
+					ldd.SetItems(dropdownItems.ToList());
 				}
 			}
 			catch (Exception ex)


### PR DESCRIPTION
- Add `NLuaTableHelper.EnumerateAllValues` which works like the old `EnumerateValues` implementation before 7bd9e218
- Add doc comments to both methods to clarify the difference
- Use this new (old) method in `FormsLuaLibrary.Dropdown` and `SetDropdownItems` to restore old behavior

7bd9e218 changed the behavior of `NLuaTableHelper.EnumerateValues` to enumerate keys sequentially and ignore non-sequential/non-numeric keys, the way Lua's `ipairs` does it. This makes sense for most uses of `EnumerateValues`, but `forms.dropdown` is explicitly documented as not requiring numeric/sequential keys, and some scripts* rely on this behavior. `forms.setdropdownitems` doesn't document what the table should look like, but can be assumed to work the same.

\* I ran into this issue while testing the bizhawk-shuffler-2 script on a dev build, a quick [search](https://github.com/search?q=%22forms.dropdown%22+OR+%22forms.setdropdownitems%22+language%3ALua+&type=code) shows other scripts that are likely affected, but I didn't test those.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
