### PR TITLE
Fix libretro "no game" loading

### DIFF
--- a/src/BizHawk.Client.Common/RomLoader.cs
+++ b/src/BizHawk.Client.Common/RomLoader.cs
@@ -832,14 +832,21 @@ namespace BizHawk.Client.Common
 				{
 					// must be done before LoadNoGame (which triggers retro_init and the paths to be consumed by the core)
 					// game name == name of core
-					game = Disc.IsValidExtension(file.Extension)
-						? MakeGameFromDisc(
-							InstantiateDiscFor(path),
-							ext: file.Extension,
-							name: Path.GetFileNameWithoutExtension(file.Name),
-							fastFailUnsupportedSystems: false)
-						: new RomGame(file).GameInfo;
-					game.Name = $"{game.Name} [{Path.GetFileNameWithoutExtension(launchLibretroCore)}]";
+					if (OpenAdvanced is not OpenAdvanced_LibretroNoGame)
+					{
+						game = Disc.IsValidExtension(file.Extension)
+							? MakeGameFromDisc(
+								InstantiateDiscFor(path),
+								ext: file.Extension,
+								name: Path.GetFileNameWithoutExtension(file.Name),
+								fastFailUnsupportedSystems: false)
+							: new RomGame(file).GameInfo;
+						game.Name = $"{game.Name} [{Path.GetFileNameWithoutExtension(launchLibretroCore)}]";
+					}
+					else
+					{
+						game = new GameInfo { Name = Path.GetFileNameWithoutExtension(launchLibretroCore) };
+					}
 					game.System = VSystemID.Raw.Libretro;
 					var retro = new LibretroHost(nextComm, game, launchLibretroCore);
 					nextEmulator = retro;


### PR DESCRIPTION
Fix "The file needs to exist, yo." exception when loading a libretro core with the "no game" option after 0681dd2590ffe8e68e3383d273566118e557c6bb.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
