### PR TITLE
Fix InputApi

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/InputApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/InputApi.cs
@@ -18,7 +18,7 @@ namespace BizHawk.Client.Common
 		public Dictionary<string, bool> Get()
 		{
 			var buttons = new Dictionary<string, bool>();
-			foreach (var (button, _) in _inputManager.ControllerInputCoalescer.BoolButtons().Where(kvp => kvp.Value)) buttons[button] = true;
+			foreach (var (button, _) in _inputManager.HostInputCoalescer.BoolButtons().Where(kvp => kvp.Value)) buttons[button] = true;
 			return buttons;
 		}
 
@@ -44,7 +44,7 @@ namespace BizHawk.Client.Common
 			=> _inputManager.ControllerInputCoalescer.AxisValues().ToDictionary();
 
 		public IReadOnlyList<string> GetPressedButtons()
-			=> _inputManager.ControllerInputCoalescer.BoolButtons().Where(static kvp => kvp.Value)
+			=> _inputManager.HostInputCoalescer.BoolButtons().Where(static kvp => kvp.Value)
 				.Select(static kvp => kvp.Key).ToList();
 	}
 }

--- a/src/BizHawk.Client.Common/Api/Interfaces/IInputApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IInputApi.cs
@@ -44,8 +44,9 @@ namespace BizHawk.Client.Common
 		IReadOnlyDictionary<string, int> GetPressedAxes();
 
 		/// <returns>
-		/// List of (host) key/button names which are pressed
+		/// List of (host) key/button names which are pressed, including modifier combinations.
 		/// (i.e. were pressed when EmuHawk last polled; this is distinct from virtual gamepad polling/latching).
+		/// <br/>For example, if the user presses Shift+A this will return 3 values: "Shift", "A", and "Shift+A".
 		/// Unpressed buttons are omitted.
 		/// </returns>
 		/// <remarks>

--- a/src/BizHawk.Client.Common/input/InputCoalescerControllers.cs
+++ b/src/BizHawk.Client.Common/input/InputCoalescerControllers.cs
@@ -45,4 +45,15 @@ namespace BizHawk.Client.Common
 			return buttons.All(Buttons.GetValueOrDefault);
 		}
 	}
+
+	public sealed class ApiInputCoalescer : InputCoalescer
+	{
+		protected override void ProcessInput(string button, bool state)
+		{
+			// For controller input, we want Shift+X to register as both Shift and X
+			foreach (var s in button.Split('+')) Buttons[s] = state;
+			// AND as the combination
+			base.ProcessInput(button, state);
+		}
+	}
 }

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -46,6 +46,11 @@ namespace BizHawk.Client.Common
 		// This relies on a client specific implementation!
 		public ControllerInputCoalescer ControllerInputCoalescer { get; set; } = new();
 
+		/// <summary>
+		/// Created for <see cref="IInputApi"/>. Receives only buttons, and receives them regardless of input priority setting.
+		/// </summary>
+		public ApiInputCoalescer HostInputCoalescer { get; } = new();
+
 		public Controller ClientControls { get; set; }
 
 		public Func<(Point Pos, long Scroll, bool LMB, bool MMB, bool RMB, bool X1MB, bool X2MB)> GetMainFormMouseInfo { get; set; }
@@ -157,6 +162,8 @@ namespace BizHawk.Client.Common
 				// Console.WriteLine(ie);
 
 				// TODO - wonder what happens if we pop up something interactive as a response to one of these hotkeys? may need to purge further processing
+
+				HostInputCoalescer.Receive(ie);
 
 				var hotkeyTriggers = ClientControls.SearchBindings(ie.LogicalButton.ToString());
 				bool isEmuInput = ActiveController.HasBinding(ie.LogicalButton.ToString());

--- a/src/BizHawk.Tests.Client.Common/Api/InputApiTests.cs
+++ b/src/BizHawk.Tests.Client.Common/Api/InputApiTests.cs
@@ -1,0 +1,289 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BizHawk.Client.Common;
+
+namespace BizHawk.Tests.Client.Common.Api
+{
+	// Please note that these tests create press events as seen by the input manager.
+	// Sending incorrect press events can make a test incorrect.
+	// Example of correct events:
+	// context.MakePressEvent("Shift");
+	// context.MakePressEvent("Shift+A");
+	// context.MakeRleaseEvent("A");
+	// context.MakeRleaseEvent("Shift");
+	//
+	// There is no press event for just "A", and there are never release events for combinations.
+	[TestClass]
+	public class InputApiTests
+	{
+		private class Context
+		{
+			public InputManagerTests.Context inputContext;
+			public InputApi api;
+
+			public Context(string[]? hotkeys = null)
+			{
+				inputContext = new(hotkeys);
+				// null DisplayManagerBase: We don't have one and it isn't used for anything other than GetMouse, which we aren't testing.
+				api = new(null, inputContext.manager);
+			}
+
+			public void MakePressEvent(string keyboardButton, uint modifiers = 0)
+			{
+				inputContext.source.MakePressEvent(keyboardButton, modifiers);
+				inputContext.BasicInputProcessing();
+			}
+
+			public void MakeReleaseEvent(string keyboardButton, uint modifiers = 0)
+			{
+				inputContext.source.MakeReleaseEvent(keyboardButton, modifiers);
+				inputContext.BasicInputProcessing();
+			}
+		}
+
+		[TestMethod]
+		public void TestNoPressedButtons()
+		{
+			// arrange
+			Context context = new();
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.AreEqual(0, buttons.Count);
+		}
+
+		[TestMethod]
+		public void TestPressPlainButton()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("A");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsTrue(buttons.Contains("A"));
+			Assert.AreEqual(1, buttons.Count);
+		}
+
+		[TestMethod]
+		public void TestReleasePlainButton()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("A");
+			context.MakeReleaseEvent("A");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsFalse(buttons.Contains("A"));
+			Assert.AreEqual(0, buttons.Count);
+		}
+
+		[TestMethod]
+		public void TestMultipleButtons()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("A");
+			context.MakePressEvent("B");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsTrue(buttons.Contains("A"));
+			Assert.IsTrue(buttons.Contains("B"));
+			Assert.AreEqual(2, buttons.Count);
+		}
+
+		[TestMethod]
+		public void TestModifierAlone()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("Shift");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsTrue(buttons.Contains("Shift"));
+			Assert.AreEqual(1, buttons.Count);
+		}
+
+		[TestMethod]
+		public void TestModifierCombinationShowsBothIndividualButtons()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("Shift");
+			context.MakePressEvent("Shift+A");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsTrue(buttons.Contains("Shift"));
+			Assert.IsTrue(buttons.Contains("A"));
+		}
+
+		[TestMethod]
+		public void TestModifierCombinationAsSingleButton()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("Shift");
+			context.MakePressEvent("Shift+A");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsTrue(buttons.Contains("Shift+A"));
+		}
+
+		[TestMethod]
+		public void TestReleaseRegularButtonReleasesCombination()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("Shift");
+			context.MakePressEvent("Shift+A");
+			context.MakeReleaseEvent("A");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsFalse(buttons.Contains("Shift+A"));
+			Assert.AreEqual(1, buttons.Count);
+		}
+
+		[TestMethod]
+		public void TestOutOfOrderModifierCombinationIsNotCombined()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("A");
+			context.MakePressEvent("Shift");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsFalse(buttons.Contains("Shift+A"));
+			Assert.AreEqual(2, buttons.Count);
+		}
+
+		[TestMethod]
+		public void TestReleaseModifierButtonReleasesCombination()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("Shift");
+			context.MakePressEvent("Shift+A");
+			context.MakeReleaseEvent("Shift");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsFalse(buttons.Contains("Shift+A"));
+			Assert.AreEqual(1, buttons.Count);
+		}
+
+		[TestMethod]
+		public void TestButtonIsVisibleWithControllerPriority()
+		{
+			// arrange
+			Context context = new([ "hotkey 1" ]);
+			context.inputContext.manager.ClientControls.BindMulti("hotkey 1", "A");
+			context.inputContext.manager.ActiveController.BindMulti("A", "A");
+			context.inputContext.config.InputHotkeyOverrideOptions = Config.InputPriority.INPUT;
+			context.MakePressEvent("A");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsTrue(buttons.Contains("A"));
+		}
+
+		[TestMethod]
+		public void TestButtonIsVisibleWithHotkeyPriority()
+		{
+			// arrange
+			Context context = new([ "hotkey 1" ]);
+			context.inputContext.manager.ClientControls.BindMulti("hotkey 1", "A");
+			context.inputContext.manager.ActiveController.BindMulti("A", "A");
+			context.inputContext.config.InputHotkeyOverrideOptions = Config.InputPriority.HOTKEY;
+			context.MakePressEvent("A");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			Assert.IsTrue(buttons.Contains("A"));
+		}
+
+		[TestMethod]
+		public void TestMultipleModifiersBeforeKey()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("Shift");
+			context.MakePressEvent("Shift+Ctrl");
+			context.MakePressEvent("Ctrl+Shift+A");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			CollectionAssert.AreEquivalent(
+				new[] { "Shift", "Ctrl", "Shift+Ctrl", "A", "Ctrl+Shift+A" },
+				buttons.ToArray());
+		}
+
+		[TestMethod]
+		public void TestMultipleModifiersAfterKey()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("A");
+			context.MakePressEvent("Shift");
+			context.MakePressEvent("Shift+Ctrl");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			CollectionAssert.AreEquivalent(
+				new[] { "A", "Shift", "Ctrl", "Shift+Ctrl" },
+				buttons.ToArray());
+		}
+
+		[TestMethod]
+		public void TestModifierAfterCombination()
+		{
+			// arrange
+			Context context = new();
+			context.MakePressEvent("Shift");
+			context.MakePressEvent("Shift+A");
+			context.MakePressEvent("Shift+Ctrl");
+
+			// act
+			IReadOnlyList<string> buttons = context.api.GetPressedButtons();
+
+			// assert
+			CollectionAssert.AreEquivalent(
+				new[] { "A", "Shift", "Ctrl", "Shift+Ctrl", "Shift+A" },
+				buttons.ToArray());
+		}
+	}
+}

--- a/src/BizHawk.Tests.Client.Common/input/FakeInputSource.cs
+++ b/src/BizHawk.Tests.Client.Common/input/FakeInputSource.cs
@@ -14,5 +14,27 @@ namespace BizHawk.Tests.Client.Common.input
 		public KeyValuePair<string, int>[] GetAxisValues() => _axisValues;
 
 		public void AddInputEvent(InputEvent ie) => _events.Add(ie);
+
+		private static readonly IReadOnlyList<string> _modifierKeys = new[] { "Super", "Ctrl", "Alt", "Shift" };
+
+		public void MakePressEvent(string keyboardButton, uint modifiers = 0)
+		{
+			AddInputEvent(new()
+			{
+				EventType = InputEventType.Press,
+				LogicalButton = new(keyboardButton, modifiers, () => _modifierKeys),
+				Source = Bizware.Input.HostInputType.Keyboard,
+			});
+		}
+
+		public void MakeReleaseEvent(string keyboardButton, uint modifiers = 0)
+		{
+			AddInputEvent(new()
+			{
+				EventType = InputEventType.Release,
+				LogicalButton = new(keyboardButton, modifiers, () => _modifierKeys),
+				Source = Bizware.Input.HostInputType.Keyboard,
+			});
+		}
 	}
 }


### PR DESCRIPTION
See issue #4449 

It is questionable if the accidental change to the API behavior is good. This PR restores the old behavior and updates the API documentation to clarify behavior. (with the caveat that hotkey priority can no longer hide inputs from the API)

Note that the new `ApiInputCoalescer` class would not be necessary if we do not want controllers to see holding A and pressing Shift as Shift+A.

If there is consensus that we want to do this, I will update the comments in the test code and merge.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
