### PR TITLE
Fix Windows jump list entries for libretro

### DIFF
--- a/src/BizHawk.Client.EmuHawk/JumpLists.cs
+++ b/src/BizHawk.Client.EmuHawk/JumpLists.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Shell;
 
@@ -28,10 +29,32 @@ namespace BizHawk.Client.EmuHawk
 			var ji = new JumpTask
 			{
 				ApplicationPath = exepath,
-				Arguments = $"\"{fullPath}\"",
+				Arguments = QuoteAndEscapeArgument(fullPath),
 				Title = title,
 			};
 			JumpList.AddToRecentCategory(ji);
+		}
+
+		/// <summary>
+		/// Wrap a single command line argument in double quotes and escape characters
+		/// so that it correctly roundtrips back to <c>args[]</c> as a single argument.
+		/// </summary>
+		private static string QuoteAndEscapeArgument(string argument)
+		{
+			if (!string.IsNullOrEmpty(argument) && argument.IndexOfAny([ ' ', '"', '\t', '\n' ]) == -1)
+				return argument;
+
+			// Windows/.NET command line mangling
+			// see https://learn.microsoft.com/en-us/dotnet/api/system.environment.getcommandlineargs#remarks
+
+			// any double quote needs to be escaped with a backslash
+			// any series of backslashes *directly preceding* a double quote also need to be escaped
+			// so basically: insert \ before ", double any existing \ before a "
+			// special case: backslashes at the end of the string also need to be escaped (so the wrapping double quote isn't)
+			return '"' + Regex.Replace(argument ?? "",
+				@"(\\*)(""|\\\z)", // group $1: 0 or more backslashes; group $2: double quote, or backslash at end of string
+				"$1$1\\$2" // repeat group $1 twice, then backslash and group $2
+			) + '"';
 		}
 	}
 }


### PR DESCRIPTION
- Escape double quotes in command line argument stored in the Windows jump list entry, to let serialized `OpenAdvanced_Libretro` values roundtrip properly

---

`OpenAdvanced_Libretro` objects are serialized like this:

    *Libretro*{"Path":"F:\\Emulation\\GBC\\rom.gb","CorePath":"F:\\Emulation\\BizHawk\\Libretro\\Cores\\sameboy_libretro.dll"}

.NET command line parsing strips out the double quotes, which either causes JSON deserialization errors or breaks the argument into multiple parts if the paths contain spaces. This is unrelated to BizHawk code or `System.CommandLine`, the arguments are already mangled in `Main(string args[])`.

Double quotes need to be escaped in [a particular way](https://learn.microsoft.com/en-us/dotnet/api/system.environment.getcommandlineargs#remarks). I think this is a MS/Windows thing and I'm not sure if .NET parses arguments the same on Linux, but the jump list stuff only works on Windows anyway.

(Realistically speaking a simple `string.Replace("\"", "\\\"")` probably would have worked fine in this case, since none of the json values should ever end in a backslash that could cause incorrect escape sequences)

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
