### PR TITLE
Fixed DMC DMA bus conflicts with controllers

### DIFF
--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
@@ -949,7 +949,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			public void Fetch()
 			{
 				if (sample_length != 0)
-				{			
+				{
 					sample_buffer = apu.nes.ReadMemory((ushort)sample_address);
 					sample_buffer_filled = true;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/APU.cs
@@ -949,8 +949,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			public void Fetch()
 			{
 				if (sample_length != 0)
-				{
-					
+				{			
 					sample_buffer = apu.nes.ReadMemory((ushort)sample_address);
 					sample_buffer_filled = true;
 
@@ -1040,7 +1039,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 		public void RunDMCFetch()
 		{
-			dmc.Fetch();			
+			dmc.Fetch();
 		}
 
 		public void RunDMCHaltFetch()

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -87,6 +87,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		public ushort double_controller_read_address = 0;
 		public byte previous_controller1_read = 0;
 		public byte previous_controller2_read = 0;
+		public bool dmc_dma_controller_conflict;
 		public bool joypadStrobed;
 		public byte joypadStrobeValue;
 
@@ -826,6 +827,10 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				}
 				double_controller_read_address = (ushort) addr;
 				double_controller_read = TotalExecutedCycles + 1; // The shift register in the controller is only updated if the previous CPU cycle did not read from the controller port.
+				if (dmc_dma_controller_conflict)
+				{
+					double_controller_read++; // since the DMC DMA fetch routine occurs before cpu.ExecuteOne() which updates TotalExecutedCycles, we need to increment this value.
+				}
 			}
 
 			ret &= 0x1f;


### PR DESCRIPTION
In a previous PR I modified how controller strobing was done, and also made changes to controller clocking. After those changes, I added more tests to my test ROM, which (unbeknownst to me) was now failing due to my aforementioned changes. Here is what broke:

When the DMC DMA has a bus conflict with the controller ports, the controller does not get clocked an additional time, unlike the situation where the dummy read cycles of a DMC DMA read from the controller port.

Apparently, the TAS of Tiny Toons desynced after my previous changes. After fixing it, it once again completes the game:

<img width="1357" height="580" alt="TinyToonTAS" src="https://github.com/user-attachments/assets/27df0509-8d7a-4cf5-bb2d-dd0b0045a534" />

In addition to fixing how the DMC DMA bus conflict does or does not clock the controller, I also implemented the way the DMC DMA Bus conflict affects the data bus:

<img width="512" height="554" alt="Conflcit" src="https://github.com/user-attachments/assets/accd0d09-a7b6-4bb9-a0fa-b02bed2bc6f0" />

Keep in mind, this bus conflict can read the controllers, and read from $4015, but reading from address $4015 does not update the data bus, so the conflict really only affects the data bus if reading from the controller ports.