### PR TITLE
Fix printing Lua tables that contain mixed or non-comparable keys

### DIFF
--- a/src/BizHawk.Client.Common/lua/LuaHelper.cs
+++ b/src/BizHawk.Client.Common/lua/LuaHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -39,7 +40,7 @@ namespace BizHawk.Client.Common
 			static void Append(StringBuilder sb, object value)
 			{
 				if (value is string str) sb.Append('"').Append(str).Append('"');
-				else sb.Append(value);
+				else sb.AppendFormat(CultureInfo.InvariantCulture, "{0}", value);
 			}
 		}
 	}

--- a/src/BizHawk.Client.Common/lua/LuaHelper.cs
+++ b/src/BizHawk.Client.Common/lua/LuaHelper.cs
@@ -12,7 +12,8 @@ namespace BizHawk.Client.Common
 		public static LuaTable EnumerateToLuaTable<T>(this NLuaTableHelper tableHelper, IEnumerable<T> list, int indexFrom = 1)
 			=> tableHelper.ListToTable(list as IReadOnlyList<T> ?? list.ToList(), indexFrom);
 
-		public static string Serialize(this LuaTable lti)
+		/// <remarks>Intended for printing tables to the console</remarks>
+		public static string PrettyPrintShallow(this LuaTable lti)
 		{
 			var sorted = lti
 				.OrderBy(static item => item.Key switch

--- a/src/BizHawk.Client.Common/lua/LuaHelper.cs
+++ b/src/BizHawk.Client.Common/lua/LuaHelper.cs
@@ -28,7 +28,7 @@ namespace BizHawk.Client.Common
 				{
 					double d => d,
 					long i => i,
-					_ => (double?)null
+					_ => (double?)null,
 				})
 				.ThenBy(static item => item.Key as long?) // sort large integers that double can't represent
 				.ThenBy(static item => item.Key is not (long or double) ? item.Key.ToString() : null, StringComparer.InvariantCulture);

--- a/src/BizHawk.Client.Common/lua/LuaHelper.cs
+++ b/src/BizHawk.Client.Common/lua/LuaHelper.cs
@@ -18,13 +18,18 @@ namespace BizHawk.Client.Common
 				.OrderBy(static item => item.Key switch
 				{
 					long => 0,
+					double => 0,
 					string => 1,
-					double => 2,
-					bool => 3,
-					_ => 4, // tables, functions, ...
+					bool => 2,
+					_ => 3, // tables, functions, ...
 				})
-				.ThenBy(static item => item.Key as long?)
-				.ThenBy(static item => item.Key as double?)
+				.ThenBy(static item => item.Key switch
+				{
+					double d => d,
+					long i => i,
+					_ => (double?)null
+				})
+				.ThenBy(static item => item.Key as long?) // sort large integers that double can't represent
 				.ThenBy(static item => item.Key is not (long or double) ? item.Key.ToString() : null, StringComparer.InvariantCulture);
 
 			var sb = new StringBuilder();

--- a/src/BizHawk.Client.Common/lua/LuaHelper.cs
+++ b/src/BizHawk.Client.Common/lua/LuaHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 using NLua;
 
@@ -9,5 +10,37 @@ namespace BizHawk.Client.Common
 	{
 		public static LuaTable EnumerateToLuaTable<T>(this NLuaTableHelper tableHelper, IEnumerable<T> list, int indexFrom = 1)
 			=> tableHelper.ListToTable(list as IReadOnlyList<T> ?? list.ToList(), indexFrom);
+
+		public static string Serialize(this LuaTable lti)
+		{
+			var sorted = lti
+				.OrderBy(static item => item.Key switch
+				{
+					long => 0,
+					string => 1,
+					double => 2,
+					bool => 3,
+					_ => 4, // tables, functions, ...
+				})
+				.ThenBy(static item => item.Key as long?)
+				.ThenBy(static item => item.Key as double?)
+				.ThenBy(static item => item.Key is not (long or double) ? item.Key.ToString() : null, StringComparer.InvariantCulture);
+
+			var sb = new StringBuilder();
+			foreach (var item in sorted)
+			{
+				Append(sb, item.Key);
+				sb.Append(": ");
+				Append(sb, item.Value);
+				sb.Append('\n');
+			}
+			return sb.ToString();
+
+			static void Append(StringBuilder sb, object value)
+			{
+				if (value is string str) sb.Append('"').Append(str).Append('"');
+				else sb.Append(value);
+			}
+		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -82,7 +81,7 @@ namespace BizHawk.Client.EmuHawk
 					Append(sb, item.Value);
 					sb.Append('\n');
 				}
-				return sb.ToString();			
+				return sb.ToString();
 
 				static void Append(StringBuilder sb, object value)
 				{

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
@@ -68,7 +68,7 @@ namespace BizHawk.Client.EmuHawk
 				=> sb.Append(output switch
 				{
 					null => "nil",
-					LuaTable table => table.Serialize(),
+					LuaTable table => table.PrettyPrintShallow(),
 					IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
 					_ => output.ToString(),
 				});

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
@@ -71,7 +71,7 @@ namespace BizHawk.Client.EmuHawk
 					})
 					.ThenBy(static item => item.Key as long?)
 					.ThenBy(static item => item.Key as double?)
-					.ThenBy(static item => item.Key.ToString());
+					.ThenBy(static item => item.Key.ToString(), StringComparer.InvariantCulture);
 
 				var sb = new StringBuilder();
 				foreach (var item in sorted)

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 
 using BizHawk.Client.Common;
@@ -68,6 +69,7 @@ namespace BizHawk.Client.EmuHawk
 				{
 					null => "nil",
 					LuaTable table => table.Serialize(),
+					IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
 					_ => output.ToString(),
 				});
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
@@ -1,8 +1,6 @@
-using System.Linq;
 using System.Text;
 
 using BizHawk.Client.Common;
-using BizHawk.Common.CollectionExtensions;
 
 using NLua;
 
@@ -58,38 +56,6 @@ namespace BizHawk.Client.EmuHawk
 		// Outputs the given object to the output box on the Lua Console dialog. Note: Can accept a LuaTable
 		private void LogWithSeparator(string separator, string terminator, params object[] outputs)
 		{
-			static string SerializeTable(LuaTable lti)
-			{
-				var sorted = lti
-					.OrderBy(static item => item.Key switch
-					{
-						long => 0,
-						string => 1,
-						double => 2,
-						bool => 3,
-						_ => 4, // tables, functions, ...
-					})
-					.ThenBy(static item => item.Key as long?)
-					.ThenBy(static item => item.Key as double?)
-					.ThenBy(static item => item.Key is not (long or double) ? item.Key.ToString() : null, StringComparer.InvariantCulture);
-
-				var sb = new StringBuilder();
-				foreach (var item in sorted)
-				{
-					Append(sb, item.Key);
-					sb.Append(": ");
-					Append(sb, item.Value);
-					sb.Append('\n');
-				}
-				return sb.ToString();
-
-				static void Append(StringBuilder sb, object value)
-				{
-					if (value is string str) sb.Append('"').Append(str).Append('"');
-					else sb.Append(value);
-				}
-			}
-
 			if (!Tools.Has<LuaConsole>())
 			{
 				return;
@@ -101,7 +67,7 @@ namespace BizHawk.Client.EmuHawk
 				=> sb.Append(output switch
 				{
 					null => "nil",
-					LuaTable table => SerializeTable(table),
+					LuaTable table => table.Serialize(),
 					_ => output.ToString(),
 				});
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
@@ -71,7 +71,7 @@ namespace BizHawk.Client.EmuHawk
 					})
 					.ThenBy(static item => item.Key as long?)
 					.ThenBy(static item => item.Key as double?)
-					.ThenBy(static item => item.ToString());
+					.ThenBy(static item => item.Key.ToString());
 
 				var sb = new StringBuilder();
 				foreach (var item in sorted)

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/ConsoleLuaLibrary.cs
@@ -71,7 +71,7 @@ namespace BizHawk.Client.EmuHawk
 					})
 					.ThenBy(static item => item.Key as long?)
 					.ThenBy(static item => item.Key as double?)
-					.ThenBy(static item => item.Key.ToString(), StringComparer.InvariantCulture);
+					.ThenBy(static item => item.Key is not (long or double) ? item.Key.ToString() : null, StringComparer.InvariantCulture);
 
 				var sb = new StringBuilder();
 				foreach (var item in sorted)

--- a/src/BizHawk.Tests.Client.Common/lua/LuaTests.cs
+++ b/src/BizHawk.Tests.Client.Common/lua/LuaTests.cs
@@ -925,15 +925,49 @@ namespace BizHawk.Tests.Client.Common.Lua
 			"3: True\n"
 		)]
 		[DataRow(
-			"""{ [456]="integer", [123]="integer", ["def"]="string", ["abc"]="string", [assert]="function", [false]="boolean", [coroutine.create(assert)]="thread", [{}]="table", }""",
+			"""{ [456.789]="float", [123]="integer", ["def"]="string", ["abc"]="string", [assert]="function", [false]="boolean", [coroutine.create(assert)]="thread", [{}]="table", }""",
 			"123: \"integer\"\n" +
-			"456: \"integer\"\n" +
+			"456.789: \"float\"\n" +
 			"\"abc\": \"string\"\n" +
 			"\"def\": \"string\"\n" +
 			"False: \"boolean\"\n" +
 			"function: \"function\"\n" +
 			"table: \"table\"\n" +
 			"thread: \"thread\"\n"
+		)]
+		[DataRow(
+#pragma warning disable MA0136 // Line endings on the input string don't matter
+			"""
+			{
+				[3.5] = "3.5",
+				[3] = "3",
+				[2.5] = "2.5",
+				[2] = "2",
+				[1.5] = "1.5",
+				[1] = "1",
+				[0] = "0",
+				[-1] = "-1",
+				[9223372036854775807] = "max long",
+				[9223372036854775679] = "max long - 128",
+				[9223372036854775296] = "max long - 511",
+				[9223372036854775551] = "max long - 256",
+				[9223372036854775423] = "max long - 384",
+			}
+			""",
+#pragma warning restore MA0136
+			"-1: \"-1\"\n" +
+			"0: \"0\"\n" +
+			"1: \"1\"\n" +
+			"1.5: \"1.5\"\n" +
+			"2: \"2\"\n" +
+			"2.5: \"2.5\"\n" +
+			"3: \"3\"\n" +
+			"3.5: \"3.5\"\n" +
+			"9223372036854775296: \"max long - 511\"\n" +
+			"9223372036854775423: \"max long - 384\"\n" +
+			"9223372036854775551: \"max long - 256\"\n" +
+			"9223372036854775679: \"max long - 128\"\n" +
+			"9223372036854775807: \"max long\"\n"
 		)]
 		[TestMethod]
 		public void LuaExtensions_SerializeTable(string tableDeclaration, string expected)

--- a/src/BizHawk.Tests.Client.Common/lua/LuaTests.cs
+++ b/src/BizHawk.Tests.Client.Common/lua/LuaTests.cs
@@ -970,10 +970,10 @@ namespace BizHawk.Tests.Client.Common.Lua
 			"9223372036854775807: \"max long\"\n"
 		)]
 		[TestMethod]
-		public void LuaExtensions_SerializeTable(string tableDeclaration, string expected)
+		public void LuaExtensions_PrettyPrintShallow(string tableDeclaration, string expected)
 		{
 			var table = (LuaTable)LuaInstance.DoString($"return {tableDeclaration}").Single();
-			var actual = table.Serialize();
+			var actual = table.PrettyPrintShallow();
 			Assert.AreEqual(expected, actual);
 		}
 	}

--- a/src/BizHawk.Tests.Client.Common/lua/LuaTests.cs
+++ b/src/BizHawk.Tests.Client.Common/lua/LuaTests.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Linq;
 
 using BizHawk.Client.Common;
+using NLua;
 
 namespace BizHawk.Tests.Client.Common.Lua
 {
@@ -915,6 +916,31 @@ namespace BizHawk.Tests.Client.Common.Lua
 		{
 			ExpectedValue = expected;
 			_ = LuaInstance.DoString(script);
+		}
+
+		[DataRow(
+			"""{123, "abc", true}""",
+			"1: 123\n" +
+			"2: \"abc\"\n" +
+			"3: True\n"
+		)]
+		[DataRow(
+			"""{ [456]="integer", [123]="integer", ["def"]="string", ["abc"]="string", [assert]="function", [false]="boolean", [coroutine.create(assert)]="thread", [{}]="table", }""",
+			"123: \"integer\"\n" +
+			"456: \"integer\"\n" +
+			"\"abc\": \"string\"\n" +
+			"\"def\": \"string\"\n" +
+			"False: \"boolean\"\n" +
+			"function: \"function\"\n" +
+			"table: \"table\"\n" +
+			"thread: \"thread\"\n"
+		)]
+		[TestMethod]
+		public void LuaExtensions_SerializeTable(string tableDeclaration, string expected)
+		{
+			var table = (LuaTable)LuaInstance.DoString($"return {tableDeclaration}").Single();
+			var actual = table.Serialize();
+			Assert.AreEqual(expected, actual);
 		}
 	}
 }


### PR DESCRIPTION
- Fix `ArgumentException` when printing a table that contains keys of mixed types `{1, a=1}` or non-`IComparable` types `{[assert]="function", [{}]="table"}` (regression in 631e5c37b4df48bd68f9c4e1b8ace033aca05b5a)
- Sort keys by most types, even in mixed tables
- Rewrite printing code with a stringbuilder
- Only surround strings in quotes, both for keys and values

### Repro

```lua
print({
	1,
	[56789.56789] = 56789.56789,
	p = "p",
	[true] = true,
	2,
	[1234.1234] = 1234.1234,
	[forms.createcolor(255, 0, 0, 255)] = "red",
	x = "x",
	3,
	c = "c",
	[coroutine.create(function() end)] = "coroutine",
	[false] = false,
	["1"] = "one",
	[{}] = {},
	[assert] = assert,
	[-1] = -1,
	[forms.createcolor(0, 0, 0, 255)] = "black",
	[0xFFFFFFFFFFFFFFF] = "longmax",
	[math.huge]= "infinity",
})
```

#### 2.10
```
"1": "1"
"-1": "-1"
"1": "one"
"1152921504606846975": "longmax"
"1234,1234": "1234,1234"
"2": "2"
"3": "3"
"56789,56789": "56789,56789"
"∞": "infinity"
"c": "c"
"Color [A=255, R=0, G=0, B=0]": "black"
"Color [A=255, R=255, G=0, B=0]": "red"
"False": "False"
"function": "function"
"p": "p"
"table": "table"
"thread": "coroutine"
"True": "True"
"x": "x"
```

#### 2.11
```
NLua.Exceptions.LuaScriptException: [string "main"]:1: A .NET exception occured in user-code
System.ArgumentException: Object must be of type "Int64".
```
with a simple table like `{1, 2, 3}`:
```
1: "1"
2: "2"
3: "3"
```

#### PR
```
-1: -1
1: 1
2: 2
3: 3
1152921504606846975: "longmax"
"1": "one"
"c": "c"
"p": "p"
"x": "x"
1234,1234: 1234,1234
56789,56789: 56789,56789
∞: "infinity"
False: False
True: True
Color [A=255, R=0, G=0, B=0]: "black"
Color [A=255, R=255, G=0, B=0]: "red"
function: function
table: table
thread: "coroutine"
```

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
