### PR TITLE
Create a `MemoryDomain` subclass which wraps `IDebuggable` reg get/set

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -1506,7 +1506,15 @@ namespace BizHawk.Client.EmuHawk
 					Checked = _domain.Name == _romDomain.Name,
 				};
 
-				MemoryDomainsMenuItem.DropDownItems.Add(new ToolStripSeparator());
+				var n = MemoryDomains.Count - 1;
+				if (MemoryDomains[n] is RegistersMemoryDomain)
+				{
+					MemoryDomainsMenuItem.DropDownItems.Insert(n, new ToolStripSeparator());
+				}
+				else
+				{
+					MemoryDomainsMenuItem.DropDownItems.Add(new ToolStripSeparator());
+				}
 				MemoryDomainsMenuItem.DropDownItems.Add(romMenuItem);
 
 				romMenuItem.Click += (o, ev) => SetMemoryDomain(_romDomain.Name);

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/WatchEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/WatchEditor.cs
@@ -193,7 +193,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				default:
 				case Mode.New:
-					SelectedWidth = MemoryDomains.First().WordSize;
+					SelectedWidth = MemoryDomains[0].WordSize;
 					break;
 				case Mode.Duplicate:
 				case Mode.Edit:

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainList.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainList.cs
@@ -20,8 +20,10 @@ namespace BizHawk.Emulation.Common
 			return this.Any(md => md.Name == name);
 		}
 
-		public MemoryDomainList(IList<MemoryDomain> domains)
-			: base(domains)
+		public MemoryDomainList(IList<MemoryDomain> domains, IDebuggable/*?*/ debuggableCore = null)
+			: base(debuggableCore is null
+				? domains
+				: domains.Append(new RegistersMemoryDomain(debuggableCore)).ToArray())
 		{
 		}
 

--- a/src/BizHawk.Emulation.Common/Base Implementations/RegistersMemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/RegistersMemoryDomain.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+using BizHawk.Common.StringExtensions;
+
+using LookupEntry = (string RegName, byte RegWidthBytes, byte ByteOffset);
+
+namespace BizHawk.Emulation.Common
+{
+	public sealed class RegistersMemoryDomain : MemoryDomain
+	{
+		private const string ERR_FMT_STR_INVALID_ADDR = "invalid address, must be in 0..<{0}";
+
+		public static ImmutableArray<LookupEntry> GenLookup(IDictionary<string, RegisterValue> regs)
+		{
+			List<LookupEntry> entries = new();
+			foreach (var (name, val) in regs)
+			{
+				var widthBytes = unchecked((byte) (val.BitSize / 8));
+				if (val.BitSize % 8 is not 0) widthBytes++;
+				byte i = widthBytes;
+				while (i > 0) entries.Add((RegName: name, RegWidthBytes: widthBytes, ByteOffset: --i));
+			}
+			while (entries.Count % sizeof(uint) is not 0) entries.Add((string.Empty, 0, 0)); // padding for Hex Editor
+			return entries.ToImmutableArray();
+		}
+
+		private readonly IDebuggable _debuggableCore;
+
+		private readonly ImmutableArray<LookupEntry> _lookup;
+
+		public RegistersMemoryDomain(IDebuggable debuggableCore)
+		{
+			_debuggableCore = debuggableCore;
+			var regs = _debuggableCore.GetCpuFlagsAndRegisters();
+			_lookup = GenLookup(regs);
+			EndianType = Endian.Big;
+			var cpuName = regs.Keys.CommonPrefix();
+			Name = cpuName.Length is 0 ? "CPU registers" : $"{new string(cpuName)/*trailing space*/}registers";
+			Size = _lookup.Sum(static entry => entry.RegWidthBytes);
+			WordSize = sizeof(byte);
+			Writable = !debuggableCore.GetType().GetMethod("SetCpuRegister").CustomAttributes
+				.Any(ad => ad.AttributeType == typeof(FeatureNotImplementedAttribute));
+		}
+
+		public override byte PeekByte(long addr)
+		{
+			if (addr < 0 || _lookup.Length <= addr) throw new ArgumentOutOfRangeException(paramName: nameof(addr), addr, message: string.Format(ERR_FMT_STR_INVALID_ADDR, _lookup.Length));
+			var (name, width, offset) = _lookup[unchecked((int) addr)];
+			if (width is 0) return default; // padding for Hex Editor
+			var toReturn = unchecked((uint) _debuggableCore.GetCpuFlagsAndRegisters()[name].Value);
+			toReturn >>= 8 * offset;
+			return unchecked((byte) toReturn);
+		}
+
+		public override void PokeByte(long addr, byte val)
+		{
+			if (addr < 0 || _lookup.Length <= addr) throw new ArgumentOutOfRangeException(paramName: nameof(addr), addr, message: string.Format(ERR_FMT_STR_INVALID_ADDR, _lookup.Length));
+			var (name, width, offset) = _lookup[unchecked((int) addr)];
+			if (width is 0) return; // padding for Hex Editor
+			switch (width)
+			{
+				case 8 or 7 or 6 or 5:
+					throw new NotSupportedException($"{nameof(IDebuggable)}.{nameof(IDebuggable.SetCpuRegister)} does not support poking registers wider than 32 bits");
+				case 4 or 3:
+				{
+					var toWrite = unchecked((uint) _debuggableCore.GetCpuFlagsAndRegisters()[name].Value);
+					switch (offset)
+					{
+						case 3:
+							toWrite &= 0x00FF_FFFFU;
+							toWrite |= unchecked((ushort) (val << 24));
+							break;
+						case 2:
+							toWrite &= 0xFF00_FFFFU;
+							toWrite |= unchecked((ushort) (val << 16));
+							break;
+						case 1:
+							toWrite &= 0xFFFF_00FFU;
+							toWrite |= unchecked((ushort) (val << 8));
+							break;
+						default:
+							toWrite &= 0xFFFF_FF00U;
+							toWrite |= val;
+							break;
+					}
+					_debuggableCore.SetCpuRegister(name, unchecked((int) toWrite));
+					break;
+				}
+				case 2:
+				{
+					var toWrite = unchecked((ushort) _debuggableCore.GetCpuFlagsAndRegisters()[name].Value);
+					if (offset is 1)
+					{
+						toWrite &= 0x00FF;
+						toWrite |= unchecked((ushort) (val << 8));
+					}
+					else
+					{
+						toWrite &= 0xFF00;
+						toWrite |= val;
+					}
+					_debuggableCore.SetCpuRegister(name, toWrite);
+					break;
+				}
+				case 1:
+					_debuggableCore.SetCpuRegister(name, val);
+					break;
+				default:
+					throw new InvalidOperationException();
+			}
+		}
+	}
+}

--- a/src/BizHawk.Emulation.Common/Interfaces/Services/IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Common/Interfaces/Services/IMemoryDomains.cs
@@ -13,7 +13,7 @@ namespace BizHawk.Emulation.Common
 	/// If this service is available the client will expose many RAM related tools such as the Hex Editor, RAM Search/Watch, and Cheats
 	/// In addition, this is an essential service for effective LUA scripting, and many other tools
 	/// </summary>
-	public interface IMemoryDomains : IEnumerable<MemoryDomain>, IEmulatorService
+	public interface IMemoryDomains : IReadOnlyList<MemoryDomain>, IEmulatorService
 	{
 		MemoryDomain? this[string name] { get; }
 

--- a/src/BizHawk.Emulation.Cores/Calculators/Emu83/Emu83.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Calculators/Emu83/Emu83.IMemoryDomains.cs
@@ -40,7 +40,7 @@ namespace BizHawk.Emulation.Cores.Calculators.Emu83
 					LibEmu83.TI83_WriteMemory(Context, (ushort)addr, val);
 				}, 1));
 
-			MemoryDomains = new MemoryDomainList(_memoryDomains);
+			MemoryDomains = new MemoryDomainList(_memoryDomains, this);
 			_serviceProvider.Register(MemoryDomains);
 		}
 	}

--- a/src/BizHawk.Emulation.Cores/Calculators/TI83/TI83.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Calculators/TI83/TI83.IMemoryDomains.cs
@@ -31,7 +31,7 @@ namespace BizHawk.Emulation.Cores.Calculators.TI83
 
 			SyncAllByteArrayDomains();
 
-			_memoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList());
+			_memoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList(), this);
 			((BasicServiceProvider) ServiceProvider).Register(_memoryDomains);
 
 			_memoryDomainsInit = true;

--- a/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.IMemoryDomains.cs
@@ -33,7 +33,7 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 
 			SyncAllByteArrayDomains();
 
-			memoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList());
+			memoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList(), this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(memoryDomains);
 
 			_memoryDomainsInit = true;

--- a/src/BizHawk.Emulation.Cores/Computers/AppleII/AppleII.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/AppleII/AppleII.IMemoryDomains.cs
@@ -52,7 +52,7 @@ namespace BizHawk.Emulation.Cores.Computers.AppleII
 
 			domains.Add(systemBusDomain);
 
-			_memoryDomains = new MemoryDomainList(domains);
+			_memoryDomains = new MemoryDomainList(domains, this);
 			((BasicServiceProvider) ServiceProvider).Register(_memoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Computers/Commodore64/C64.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Commodore64/C64.IMemoryDomains.cs
@@ -47,7 +47,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 				domains.AddRange(_board.CartPort.CreateMemoryDomains());
 			}
 
-			_memoryDomains = new MemoryDomainList(domains);
+			_memoryDomains = new MemoryDomainList(domains, this);
 			((BasicServiceProvider)ServiceProvider).Register(_memoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.IMemoryDomains.cs
@@ -33,7 +33,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 
 			SyncAllByteArrayDomains();
 
-			memoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList());
+			memoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList(), this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(memoryDomains);
 
 			_memoryDomainsInit = true;

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.IMemoryDomains.cs
@@ -47,7 +47,7 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 
 			SyncAllByteArrayDomains();
 
-			MemoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList());
+			MemoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList(), this);
 			((BasicServiceProvider)ServiceProvider).Register(MemoryDomains);
 
 			_memoryDomainsInit = true;

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.IMemoryDomains.cs
@@ -62,7 +62,7 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 					1)
 			};
 
-			_memoryDomains = new MemoryDomainList(domains);
+			_memoryDomains = new MemoryDomainList(domains, this);
 			((BasicServiceProvider) ServiceProvider).Register(_memoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.IMemoryDomains.cs
@@ -30,7 +30,7 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 
 			SyncAllByteArrayDomains();
 
-			_memoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList());
+			_memoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList(), this);
 			((BasicServiceProvider)ServiceProvider).Register<IMemoryDomains>(_memoryDomains);
 
 			_memoryDomainsInit = true;

--- a/src/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.MemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.MemoryDomains.cs
@@ -41,7 +41,7 @@ namespace BizHawk.Emulation.Cores.Consoles.ChannelF
 
 			SyncAllByteArrayDomains();
 
-			_memoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList()) { MainMemory = domains[0] };
+			_memoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList(), this) { MainMemory = domains[0] };
 			((BasicServiceProvider)ServiceProvider).Register(_memoryDomains);
 
 			_memoryDomainsInit = true;

--- a/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.IMemoryDomains.cs
@@ -35,7 +35,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 					1),
 			};
 
-			MemoryDomains = new MemoryDomainList(domains);
+			MemoryDomains = new MemoryDomainList(domains, this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.IMemoryDomains.cs
@@ -60,7 +60,7 @@ namespace BizHawk.Emulation.Cores.Intellivision
 				)
 			};
 
-			MemoryDomains = new MemoryDomainList(domains);
+			MemoryDomains = new MemoryDomainList(domains, this);
 			((BasicServiceProvider) ServiceProvider).Register(MemoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IMemoryDomains.cs
@@ -54,7 +54,7 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 				domains.Add(CartRam);
 			}
 
-			MemoryDomains = new MemoryDomainList(domains);
+			MemoryDomains = new MemoryDomainList(domains, this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/BSNES/BsnesCore.IMemoryDomains.cs
@@ -58,7 +58,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.BSNES
 
 			mm.Add(Api.exe.GetPagesDomain());
 
-			_memoryDomains = new(mm);
+			_memoryDomains = new(mm, this);
 			((BasicServiceProvider) ServiceProvider).Register<IMemoryDomains>(_memoryDomains);
 
 			_memoryDomains.MainMemory = _memoryDomains[_isSGB ? "SGB WRAM" : "WRAM"];

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IMemoryDomains.cs
@@ -52,7 +52,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 				}, 4)
 			};
 
-			_memoryDomains = new(mm);
+			_memoryDomains = new(mm, this);
 			WireMemoryDomainPointers();
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IMemoryDomains.cs
@@ -67,7 +67,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 				domains.Add(CartRam);
 			}
 
-			MemoryDomains = new MemoryDomainList(domains);
+			MemoryDomains = new MemoryDomainList(domains, this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IMemoryDomains.cs
@@ -96,7 +96,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 				domains.Add(cartRamR);
 			}
 
-			MemoryDomains = new MemoryDomainList(domains);
+			MemoryDomains = new MemoryDomainList(domains, this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IMemoryDomains.cs
@@ -137,7 +137,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 				domains.Add(cartRamR);
 			}
 
-			MemoryDomains = new MemoryDomainList(domains);
+			MemoryDomains = new MemoryDomainList(domains, this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IMemoryDomains.cs
@@ -178,7 +178,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 				domains.Add(cartRamD);
 			}
 
-			MemoryDomains = new MemoryDomainList(domains);
+			MemoryDomains = new MemoryDomainList(domains, this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.IMemoryDomains.cs
@@ -49,7 +49,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 
 			CreateMemoryDomain(LibGambatte.MemoryAreas.cartram, "CartRAM");
 
-			MemoryDomains = new MemoryDomainList(_memoryDomains);
+			MemoryDomains = new MemoryDomainList(_memoryDomains, this);
 			_serviceProvider.Register(MemoryDomains);
 		}
 	}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IMemoryDomains.cs
@@ -107,7 +107,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 					pokeByte, 4
 				));
 
-			MemoryDomains = new MemoryDomainList(_memoryDomains);
+			MemoryDomains = new MemoryDomainList(_memoryDomains, this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
 		}
 	}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IMemoryDomains.cs
@@ -72,7 +72,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 			if (!_memoryDomainsSetup)
 			{
-				_memoryDomains = new MemoryDomainList(domains);
+				_memoryDomains = new MemoryDomainList(domains, this);
 				(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(_memoryDomains);
 				_memoryDomainsSetup = true;
 			}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.IMemoryDomains.cs
@@ -42,7 +42,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 					QN.qn_poke_prgbus(Context, (int)addr, val);
 				}, 1));
 
-			_memoryDomains = new MemoryDomainList(mm);
+			_memoryDomains = new MemoryDomainList(mm, this);
 			((BasicServiceProvider) ServiceProvider).Register(_memoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.IMemoryDomains.cs
@@ -76,7 +76,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 
 			_memoryDomainList.Add(Api.GetPagesDomain());
 
-			_memoryDomains = new MemoryDomainList(_memoryDomainList);
+			_memoryDomains = new MemoryDomainList(_memoryDomainList, this);
 			((BasicServiceProvider) ServiceProvider).Register(_memoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SameBoy/SameBoy.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SameBoy/SameBoy.IMemoryDomains.cs
@@ -54,7 +54,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Sameboy
 					LibSameboy.sameboy_cpuwrite(SameboyState, (ushort)addr, val);
 				}, 1));
 
-			MemoryDomains = new MemoryDomainList(_memoryDomains);
+			MemoryDomains = new MemoryDomainList(_memoryDomains, this);
 			((MemoryDomainList)MemoryDomains).MainMemory = MemoryDomains["WRAM"];
 			_serviceProvider.Register(MemoryDomains);
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.IMemoryDomains.cs
@@ -48,7 +48,7 @@ namespace BizHawk.Emulation.Cores.PCEngine
 			domains.AddRange(_byteArrayDomains.Values);
 			domains.AddRange(_ushortArrayDomains.Values);
 
-			_memoryDomains = new MemoryDomainList(domains);
+			_memoryDomains = new MemoryDomainList(domains, this);
 			_memoryDomains.SystemBus = cpuBusDomain;
 			_memoryDomains.MainMemory = _byteArrayDomains["Main Memory"];
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IMemoryDomains.cs
@@ -81,7 +81,7 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 				domains.Add(cartRamR);
 			}
 
-			_memoryDomains = new MemoryDomainList(domains);
+			_memoryDomains = new MemoryDomainList(domains, this);
 			((BasicServiceProvider) ServiceProvider).Register(_memoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IMemoryDomains.cs
@@ -38,7 +38,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 
 			SyncAllByteArrayDomains();
 
-			MemoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList());
+			MemoryDomains = new MemoryDomainList(_byteArrayDomains.Values.Concat(domains).ToList(), this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
 
 			_memoryDomainsInit = true;

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IMemoryDomains.cs
@@ -197,7 +197,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 				}
 
 				mm.Add(_elf.GetPagesDomain());
-				_memoryDomains = new MemoryDomainList(mm) { SystemBus = systemBus };
+				_memoryDomains = new MemoryDomainList(mm, this) { SystemBus = systemBus };
 				((BasicServiceProvider) ServiceProvider).Register(_memoryDomains);
 			}
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.IDebuggable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.IDebuggable.cs
@@ -152,7 +152,7 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 				(a, v) => { OctoshockDll.shock_PokeMemory(psx, (uint)a, v); },
 				4));
 
-			MemoryDomains = new MemoryDomainList(mmd);
+			MemoryDomains = new MemoryDomainList(mmd, this);
 			(ServiceProvider as BasicServiceProvider).Register<IMemoryDomains>(MemoryDomains);
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.IMemoryDomains.cs
@@ -26,7 +26,7 @@ namespace BizHawk.Emulation.Cores.WonderSwan
 				mmd.Add(new MemoryDomainIntPtr(sName, MemoryDomain.Endian.Little, data, size, true, 1));
 			}
 
-			((BasicServiceProvider) ServiceProvider).Register<IMemoryDomains>(new MemoryDomainList(mmd));
+			((BasicServiceProvider) ServiceProvider).Register<IMemoryDomains>(new MemoryDomainList(mmd, this));
 		}
 	}
 }


### PR DESCRIPTION
[![dev build for branch | TASEmulators:regs-mem-domain](https://img.shields.io/badge/dev_build_for_branch-TASEmulators:regs--mem--domain-8250DF?logo=github&logoColor=333333&style=popout)](https://nightly.link/TASEmulators/BizHawk/workflows/ci/regs-mem-domain?preview)

<img width="406" height="351" alt="Screenshot_20250926_042924" src="https://github.com/user-attachments/assets/6b3bc02b-502e-4e1e-ad79-eba80409ef5a" />