### PR TITLE
Do not disable recording mode when loading a branch.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -757,6 +757,8 @@ namespace BizHawk.Client.EmuHawk
 		{
 			GreenzoneInvalidatedCallback?.Invoke(frame); // lua callback
 
+			if (_suspendEditLogic) return false;
+
 			// Recording multiple frames, or auto-extending the movie, while unpaused should count as a single undo action.
 			if (CurrentTasMovie.LastEditWasRecording && !MainForm.EmulatorPaused)
 			{

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -1179,6 +1179,7 @@ namespace BizHawk.Client.EmuHawk
 			TasView.AllColumns.ColumnsChanged();
 		}
 
+		private bool _suspendEditLogic;
 		public void LoadBranch(TasBranch branch)
 		{
 			if (Settings.OldControlSchemeForBranches && !TasPlaybackBox.RecordingMode)
@@ -1187,7 +1188,9 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 
+			_suspendEditLogic = true;
 			CurrentTasMovie.LoadBranch(branch);
+			_suspendEditLogic = false;
 			LoadState(new(branch.Frame, new MemoryStream(branch.CoreData, false)));
 
 			CurrentTasMovie.TasStateManager.Capture(Emulator.Frame, Emulator.AsStatable());


### PR DESCRIPTION
Multiple people (at least 2) in Discord have brought up a recent change, thinking it may be a bug: Loading a branch disables recording mode, but did not in 2.10. This indicates that users find the change surprising and prefer the old behavior. This PR will restore that old behavior.

The change was originally done as part of making TAStudio more consistent. Editing inputs in a way that is not recording a frame should disable recording mode, but it used to be that not all edits would do this. Loading a branch is one way of changing inputs, and so it now (in master) disables recording mode.

Although disabling recording mode on branch load makes sense to me, I can see how it would be a nuisance to people who actually regularly use recording mode as part of TASing.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
