### PR TITLE
Small fix for crashing log window when written from other thread

### DIFF
--- a/src/BizHawk.Client.EmuHawk/LogWindow.cs
+++ b/src/BizHawk.Client.EmuHawk/LogWindow.cs
@@ -103,7 +103,7 @@ namespace BizHawk.Client.EmuHawk
 		private void doUpdateListSize()
 		{
 			virtualListView1.VirtualListSize = _lines.Count;
-			virtualListView1.EnsureVisible(_lines.Count - 1);
+			virtualListView1.EnsureVisible(virtualListView1.VirtualListSize - 1);
 		}
 
 		private void appendInvoked(string str)
@@ -218,3 +218,4 @@ namespace BizHawk.Client.EmuHawk
 		}
 	}
 }
+


### PR DESCRIPTION
For some reason, changing this code to this makes it stop crashing when writing to the console from another thread. The value from `_lines.Count` was not the same in `virtualListView1.VirtualListSize`, maybe write to VirtuListSize are delayed?

[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

Prevent crashs when writing in the console from multiple threads.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [ ] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
