### PR TITLE
[WIP] Improve encapsulation by passing in `IEmulator` when calling `Bk2Movie` functions

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/MovieApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/MovieApi.cs
@@ -69,7 +69,7 @@ namespace BizHawk.Client.Common
 				}
 				_movieSession.Movie.Filename = filename;
 			}
-			_movieSession.Movie.Save();
+			_movieSession.Movie.Save(_mainForm.Emulator);
 		}
 
 		public IReadOnlyDictionary<string, string> GetHeader()

--- a/src/BizHawk.Client.Common/movie/BasicMovieInfo.cs
+++ b/src/BizHawk.Client.Common/movie/BasicMovieInfo.cs
@@ -142,7 +142,7 @@ namespace BizHawk.Client.Common
 
 		public IDictionary<string, string> HeaderEntries => Header;
 
-		public bool Load()
+		public bool Load(IEmulator emulator)
 		{
 			if (!File.Exists(Filename))
 			{
@@ -154,7 +154,7 @@ namespace BizHawk.Client.Common
 				using var bl = ZipStateLoader.LoadAndDetect(Filename, true);
 				if (bl is null) return false;
 				ClearBeforeLoad();
-				LoadFields(bl);
+				LoadFields(bl, emulator);
 				if (FrameCount == 0)
 				{
 					// only iterate the input log if it hasn't been loaded already
@@ -176,7 +176,7 @@ namespace BizHawk.Client.Common
 			Comments.Clear();
 		}
 
-		protected virtual void LoadFields(ZipStateLoader bl)
+		protected virtual void LoadFields(ZipStateLoader bl, IEmulator emulator)
 		{
 			bl.GetLump(BinaryStateLump.Movieheader, abort: true, tr =>
 			{

--- a/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
+++ b/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 
 using BizHawk.Common.PathExtensions;
+using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
 {
@@ -71,7 +72,7 @@ namespace BizHawk.Client.Common
 			return bk2;
 		}
 
-		public static ITasMovie ConvertToSavestateAnchoredMovie(this ITasMovie old, int frame, byte[] savestate)
+		public static ITasMovie ConvertToSavestateAnchoredMovie(this ITasMovie old, int frame, byte[] savestate, IEmulator emulator)
 		{
 			string newFilename = ConvertFileNameToTasMovie(old.Filename);
 
@@ -115,11 +116,11 @@ namespace BizHawk.Client.Common
 				}
 			}
 
-			tas.Save();
+			tas.Save(emulator);
 			return tas;
 		}
 
-		public static ITasMovie ConvertToSaveRamAnchoredMovie(this ITasMovie old, byte[] saveRam)
+		public static ITasMovie ConvertToSaveRamAnchoredMovie(this ITasMovie old, byte[] saveRam, IEmulator emulator)
 		{
 			string newFilename = ConvertFileNameToTasMovie(old.Filename);
 
@@ -146,7 +147,7 @@ namespace BizHawk.Client.Common
 				tas.Subtitles.Add(sub);
 			}
 
-			tas.Save();
+			tas.Save(emulator);
 			return tas;
 		}
 

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.InputLog.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.InputLog.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using BizHawk.Common;
 using BizHawk.Common.StringExtensions;
+using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
 {
@@ -31,7 +32,7 @@ namespace BizHawk.Client.Common
 				: "";
 		}
 
-		public virtual bool ExtractInputLog(TextReader reader, out string errorMessage)
+		public virtual bool ExtractInputLog(TextReader reader, IEmulator emulator, out string errorMessage)
 		{
 			errorMessage = "";
 			int? stateFrame = null;
@@ -39,7 +40,7 @@ namespace BizHawk.Client.Common
 			// We are in record mode so replace the movie log with the one from the savestate
 			if (Session.Settings.EnableBackupMovies && MakeBackup && Log.Count != 0)
 			{
-				SaveBackup();
+				SaveBackup(emulator);
 				MakeBackup = false;
 			}
 

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.ModeApi.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.ModeApi.cs
@@ -1,15 +1,17 @@
-﻿namespace BizHawk.Client.Common
+﻿using BizHawk.Emulation.Common;
+
+namespace BizHawk.Client.Common
 {
 	public partial class Bk2Movie
 	{
 		public MovieMode Mode { get; protected set; } = MovieMode.Inactive;
 
-		public virtual void StartNewRecording()
+		public virtual void StartNewRecording(IEmulator emulator)
 		{
 			Mode = MovieMode.Record;
 			if (MakeBackup && Session.Settings.EnableBackupMovies && Log.Count is not 0)
 			{
-				SaveBackup();
+				SaveBackup(emulator);
 				MakeBackup = false;
 			}
 

--- a/src/BizHawk.Client.Common/movie/import/IMovieImport.cs
+++ b/src/BizHawk.Client.Common/movie/import/IMovieImport.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 
 using BizHawk.Common;
 using BizHawk.Common.StringExtensions;
+using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
 {
@@ -11,6 +12,7 @@ namespace BizHawk.Client.Common
 	{
 		ImportResult Import(
 			IDialogParent dialogParent,
+			IEmulator emulator,
 			IMovieSession session,
 			string path,
 			Config config);
@@ -26,6 +28,7 @@ namespace BizHawk.Client.Common
 
 		public ImportResult Import(
 			IDialogParent dialogParent,
+			IEmulator emulator,
 			IMovieSession session,
 			string path,
 			Config config)
@@ -67,7 +70,7 @@ namespace BizHawk.Client.Common
 						Result.Movie.Hash = hash;
 				}
 
-				Result.Movie.Save();
+				Result.Movie.Save(emulator);
 			}
 
 			return Result;

--- a/src/BizHawk.Client.Common/movie/import/MovieImport.cs
+++ b/src/BizHawk.Client.Common/movie/import/MovieImport.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 
 using BizHawk.Common.CollectionExtensions;
 using BizHawk.Common.StringExtensions;
+using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
 {
@@ -30,6 +31,7 @@ namespace BizHawk.Client.Common
 		// Attempt to import another type of movie file into a movie object.
 		public static ImportResult ImportFile(
 			IDialogParent dialogParent,
+			IEmulator emulator,
 			IMovieSession session,
 			string path,
 			Config config)
@@ -39,7 +41,7 @@ namespace BizHawk.Client.Common
 			// Create a new instance of the importer class using the no-argument constructor
 			return result is { Key: var importerType }
 				&& importerType.GetConstructor(Type.EmptyTypes)?.Invoke(Array.Empty<object>()) is IMovieImport importer
-					? importer.Import(dialogParent, session, path, config)
+					? importer.Import(dialogParent, emulator, session, path, config)
 					: ImportResult.Error($"No importer found for file type {ext}");
 		}
 	}

--- a/src/BizHawk.Client.Common/movie/interfaces/IBasicMovieInfo.cs
+++ b/src/BizHawk.Client.Common/movie/interfaces/IBasicMovieInfo.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
 {
@@ -53,6 +54,6 @@ namespace BizHawk.Client.Common
 		/// Tells the movie to load the contents of Filename
 		/// </summary>
 		/// <returns>Return whether or not the file was successfully loaded</returns>
-		bool Load();
+		bool Load(IEmulator emulator);
 	}
 }

--- a/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
+++ b/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
@@ -74,15 +74,15 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Forces the creation of a backup file of the current movie state
 		/// </summary>
-		void SaveBackup();
+		void SaveBackup(IEmulator emulator);
 
 		/// <summary>
 		/// Instructs the movie to save the current contents to Filename
 		/// </summary>
-		void Save();
+		void Save(IEmulator emulator);
 
 		/// <summary>updates the <see cref="HeaderKeys.CycleCount"/> and <see cref="HeaderKeys.ClockRate"/> headers from the currently loaded core</summary>
-		void SetCycleValues();
+		void SetCycleValues(IEmulator emulator);
 
 		/// <summary>
 		/// Writes the input log directly to the stream, bypassing the need to load it all into ram as a string
@@ -109,12 +109,12 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		/// <param name="reader">The reader containing the contents of the input log</param>
 		/// <param name="errorMessage">Returns an error message, if any</param>
-		bool ExtractInputLog(TextReader reader, out string errorMessage);
+		bool ExtractInputLog(TextReader reader, IEmulator emulator, out string errorMessage);
 
 		/// <summary>
 		/// Tells the movie to start recording from the beginning.
 		/// </summary>
-		void StartNewRecording();
+		void StartNewRecording(IEmulator emulator);
 
 		/// <summary>
 		/// Tells the movie to start playback from the beginning
@@ -157,7 +157,7 @@ namespace BizHawk.Client.Common
 		/// Records the given input into the given frame,
 		/// This is subject to normal movie recording logic
 		/// </summary>
-		void RecordFrame(int frame, IController source);
+		void RecordFrame(int targetFrame, int currentFrame, IController source);
 
 		/// <summary>
 		/// Instructs the movie to remove all input from its input log starting with the input at frame.
@@ -184,17 +184,14 @@ namespace BizHawk.Client.Common
 		void Attach(IEmulator emulator);
 
 		/// <summary>
-		/// The currently attached core or null if not yet attached
-		/// </summary>
-		IEmulator Emulator { get; }
-
-		/// <summary>
 		/// The current movie session
 		/// </summary>
 		IMovieSession Session { get; }
 
 		IStringLog GetLogEntries();
 		void CopyLog(IEnumerable<string> log);
+
+		void CheckAttachedMatches(IEmulator/*?*/ passed);
 	}
 
 	public static class MovieExtensions
@@ -218,8 +215,12 @@ namespace BizHawk.Client.Common
 		/// Emulation is currently right after the movie's last input frame,
 		/// but no further frames have been emulated.
 		/// </summary>
-		public static bool IsAtEnd(this IMovie movie) => movie != null && movie.Emulator?.Frame == movie.InputLogLength;
-
+		public static bool IsAtEnd(this IMovie movie, IEmulator emulator)
+		{
+			if (movie is null) return false;
+			movie.CheckAttachedMatches(emulator);
+			return emulator?.Frame == movie.InputLogLength;
+		}
 
 		/// <summary>
 		/// If the given movie contains a savestate it will be loaded if

--- a/src/BizHawk.Client.Common/movie/interfaces/ITasMovie.cs
+++ b/src/BizHawk.Client.Common/movie/interfaces/ITasMovie.cs
@@ -37,7 +37,7 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		void ClearFrame(int frame);
 
-		void GreenzoneCurrentFrame();
+		void GreenzoneCurrentFrame(IEmulator emulator);
 		void ToggleBoolState(int frame, string buttonName);
 		void SetAxisState(int frame, string buttonName, int val);
 		void SetAxisStates(int frame, int count, string buttonName, int val);

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
@@ -18,16 +18,16 @@ namespace BizHawk.Client.Common
 
 		// InvalidateAfter being last ensures that the GreenzoneInvalidated callback sees all edits.
 
-		public override void RecordFrame(int frame, IController source)
+		public override void RecordFrame(int targetFrame, int currentFrame, IController source)
 		{
-			ChangeLog.AddGeneralUndo(frame, frame, $"Record Frame: {frame}");
-			SetFrameAt(frame, Bk2LogEntryGenerator.GenerateLogEntry(source));
+			ChangeLog.AddGeneralUndo(targetFrame, targetFrame, $"Record Frame: {targetFrame}");
+			SetFrameAt(targetFrame, Bk2LogEntryGenerator.GenerateLogEntry(source));
 			ChangeLog.SetGeneralRedo();
 
-			LagLog[frame] = _inputPollable.IsLagFrame;
+			LagLog[targetFrame] = _inputPollable.IsLagFrame;
 			LastEditWasRecording = true;
 
-			InvalidateAfter(frame);
+			InvalidateAfter(targetFrame);
 		}
 
 		public override void Truncate(int frame)

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.IO.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.IO.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-
+using BizHawk.Emulation.Common;
 using Newtonsoft.Json;
 
 namespace BizHawk.Client.Common
@@ -62,9 +62,9 @@ namespace BizHawk.Client.Common
 			ChangeLog.Clear();
 		}
 
-		protected override void LoadFields(ZipStateLoader bl)
+		protected override void LoadFields(ZipStateLoader bl, IEmulator emulator)
 		{
-			base.LoadFields(bl);
+			base.LoadFields(bl, emulator);
 
 			if (MovieService.IsCurrentTasVersion(Header[HeaderKeys.MovieVersion]))
 			{

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -410,7 +410,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (Config.Movies.EnableBackupMovies)
 			{
-				MovieSession.Movie.SaveBackup();
+				MovieSession.Movie.SaveBackup(Emulator);
 			}
 
 			StopMovie(saveChanges: false);
@@ -1331,14 +1331,19 @@ namespace BizHawk.Client.EmuHawk
 
 		private void BackupMovieContextMenuItem_Click(object sender, EventArgs e)
 		{
-			MovieSession.Movie.SaveBackup();
+			MovieSession.Movie.SaveBackup(Emulator);
 			AddOnScreenMessage("Backup movie saved.");
 		}
 
 		private void ViewSubtitlesContextMenuItem_Click(object sender, EventArgs e)
 		{
 			if (MovieSession.Movie.NotActive()) return;
-			using EditSubtitlesForm form = new(this, MovieSession.Movie, Config.PathEntries, readOnly: MovieSession.ReadOnly);
+			using EditSubtitlesForm form = new(
+				this,
+				Emulator,
+				MovieSession.Movie,
+				Config.PathEntries,
+				readOnly: MovieSession.ReadOnly);
 			this.ShowDialogWithTempMute(form);
 		}
 
@@ -1375,7 +1380,7 @@ namespace BizHawk.Client.EmuHawk
 		private void ViewCommentsContextMenuItem_Click(object sender, EventArgs e)
 		{
 			if (MovieSession.Movie.NotActive()) return;
-			using EditCommentsForm form = new(MovieSession.Movie, MovieSession.ReadOnly);
+			using EditCommentsForm form = new(MovieSession.Movie, Emulator, MovieSession.ReadOnly);
 			this.ShowDialogWithTempMute(form);
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2665,7 +2665,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (MovieSession.Movie.IsActive())
 			{
-				MovieSession.Movie.Save();
+				MovieSession.Movie.Save(Emulator);
 				AddOnScreenMessage($"{MovieSession.Movie.Filename} saved.");
 			}
 		}
@@ -3981,7 +3981,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void ProcessMovieImport(string fn, bool start)
 		{
-			var result = MovieImport.ImportFile(this, MovieSession, fn, Config);
+			var result = MovieImport.ImportFile(this, Emulator, MovieSession, fn, Config);
 
 			if (result.Errors.Count is not 0)
 			{

--- a/src/BizHawk.Client.EmuHawk/Program.cs
+++ b/src/BizHawk.Client.EmuHawk/Program.cs
@@ -388,7 +388,7 @@ namespace BizHawk.Client.EmuHawk
 					);
 					if (result == DialogResult.Yes)
 					{
-						movieSession.Movie.Save();
+						movieSession.Movie.Save(mf.Emulator);
 					}
 				}
 #endif

--- a/src/BizHawk.Client.EmuHawk/movie/EditCommentsForm.cs
+++ b/src/BizHawk.Client.EmuHawk/movie/EditCommentsForm.cs
@@ -1,19 +1,23 @@
 using System.ComponentModel;
 using System.Windows.Forms;
 using BizHawk.Client.Common;
+using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.EmuHawk
 {
 	public partial class EditCommentsForm : Form
 	{
+		private readonly IEmulator _emulator;
+
 		private readonly IMovie _movie;
 		private readonly bool _readOnly;
 		private string _lastHeaderClicked;
 		private bool _sortReverse;
 		private readonly bool _dispose;
 
-		public EditCommentsForm(IMovie movie, bool readOnly, bool disposeOnClose = false)
+		public EditCommentsForm(IMovie movie, IEmulator emulator, bool readOnly, bool disposeOnClose = false)
 		{
+			_emulator = emulator;
 			_movie = movie;
 			_readOnly = readOnly;
 			_lastHeaderClicked = "";
@@ -55,7 +59,7 @@ namespace BizHawk.Client.EmuHawk
 				_movie.Comments.Add(c.Value.ToString());
 			}
 
-			_movie.Save();
+			_movie.Save(_emulator);
 		}
 
 		private void Cancel_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/movie/EditSubtitlesForm.cs
+++ b/src/BizHawk.Client.EmuHawk/movie/EditSubtitlesForm.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 
 using BizHawk.Client.Common;
 using BizHawk.Common.NumberExtensions;
+using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.EmuHawk
 {
@@ -14,14 +15,23 @@ namespace BizHawk.Client.EmuHawk
 
 		private readonly PathEntryCollection _pathEntries;
 
+		private readonly IEmulator _emulator;
+
 		private readonly IMovie _selectedMovie;
 		private readonly bool _readOnly;
 		private readonly bool _dispose;
 
 		public IDialogController DialogController { get; }
 
-		public EditSubtitlesForm(IDialogController dialogController, IMovie movie, PathEntryCollection pathEntries, bool readOnly, bool disposeOnClose = false)
+		public EditSubtitlesForm(
+			IDialogController dialogController,
+			IEmulator emulator,
+			IMovie movie,
+			PathEntryCollection pathEntries,
+			bool readOnly,
+			bool disposeOnClose = false)
 		{
+			_emulator = emulator;
 			_pathEntries = pathEntries;
 			_selectedMovie = movie;
 			_readOnly = readOnly;
@@ -115,7 +125,7 @@ namespace BizHawk.Client.EmuHawk
 					sub.Message = c.Value?.ToString();
 					_selectedMovie.Subtitles.Add(sub);
 				}
-				_selectedMovie.Save();
+				_selectedMovie.Save(_emulator);
 			}
 
 			Close();

--- a/src/BizHawk.Client.EmuHawk/movie/PlayMovie.cs
+++ b/src/BizHawk.Client.EmuHawk/movie/PlayMovie.cs
@@ -159,7 +159,7 @@ namespace BizHawk.Client.EmuHawk
 
 			try
 			{
-				movie.Load();
+				movie.Load(_emulator);
 
 				// Don't do this from browse
 				if (movie.Hash == _game.Hash
@@ -518,7 +518,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				// TODO this will allocate unnecessary memory when this movie is a TasMovie due to TasStateManager
 				var movie = _movieSession.Get(_movieList[MovieView.SelectedIndices[0]].Filename, true);
-				var form = new EditCommentsForm(movie, readOnly: false, disposeOnClose: true);
+				using EditCommentsForm form = new(movie, _emulator, readOnly: false, disposeOnClose: true);
 				form.Show();
 			}
 		}
@@ -530,7 +530,13 @@ namespace BizHawk.Client.EmuHawk
 			{
 				// TODO this will allocate unnecessary memory when this movie is a TasMovie due to TasStateManager
 				var movie = _movieSession.Get(_movieList[MovieView.SelectedIndices[0]].Filename, true);
-				var form = new EditSubtitlesForm(DialogController, movie, _config.PathEntries, readOnly: false, disposeOnClose: true);
+				using EditSubtitlesForm form = new(
+					DialogController,
+					_emulator,
+					movie,
+					_config.PathEntries,
+					readOnly: false,
+					disposeOnClose: true);
 				form.Show();
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
@@ -56,9 +56,10 @@ namespace BizHawk.Client.EmuHawk
 
 		protected override void UpdateBefore()
 		{
-			if (CurrentTasMovie.IsAtEnd() && !CurrentTasMovie.IsRecording())
+			if (CurrentTasMovie.IsAtEnd(Emulator) && !CurrentTasMovie.IsRecording())
 			{
-				CurrentTasMovie.RecordFrame(CurrentTasMovie.Emulator.Frame, MovieSession.StickySource);
+				var frame = Emulator.Frame;
+				CurrentTasMovie.RecordFrame(frame, frame, MovieSession.StickySource);
 			}
 		}
 
@@ -94,8 +95,8 @@ namespace BizHawk.Client.EmuHawk
 
 			if (Settings.AutoPause && _seekingTo == -1)
 			{
-				if (_doPause && CurrentTasMovie.IsAtEnd()) MainForm.PauseEmulator();
-				_doPause = !CurrentTasMovie.IsAtEnd();
+				if (_doPause && CurrentTasMovie.IsAtEnd(Emulator)) MainForm.PauseEmulator();
+				_doPause = !CurrentTasMovie.IsAtEnd(Emulator);
 			}
 
 			if (!_seekingByEdit)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -44,7 +44,9 @@ namespace BizHawk.Client.EmuHawk
 			if (AskSaveChanges())
 			{
 				var newProject = CurrentTasMovie.ConvertToSavestateAnchoredMovie(
-					Emulator.Frame, StatableEmulator.CloneSavestate());
+					Emulator.Frame,
+					StatableEmulator.CloneSavestate(),
+					Emulator);
 
 				MainForm.PauseEmulator();
 				LoadMovie(newProject, true);
@@ -57,7 +59,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				var saveRam = SaveRamEmulator?.CloneSaveRam(clearDirty: false) ?? throw new Exception("No SaveRam");
 				GoToFrame(TasView.AnyRowsSelected ? TasView.FirstSelectedRowIndex : 0);
-				var newProject = CurrentTasMovie.ConvertToSaveRamAnchoredMovie(saveRam);
+				var newProject = CurrentTasMovie.ConvertToSaveRamAnchoredMovie(saveRam, Emulator);
 				MainForm.PauseEmulator();
 				LoadMovie(newProject, true);
 			}
@@ -202,7 +204,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			_autosaveTimer.Stop();
 
-			if (Emulator.HasCycleTiming() && !CurrentTasMovie.IsAtEnd())
+			if (Emulator.HasCycleTiming() && !CurrentTasMovie.IsAtEnd(Emulator))
 			{
 				DialogController.ShowMessageBox("This core requires emulation to be on the last frame when writing the movie, otherwise movie length will appear incorrect.", "Warning", EMsgBoxIcon.Warning);
 			}
@@ -224,7 +226,7 @@ namespace BizHawk.Client.EmuHawk
 				var bk2 = CurrentTasMovie.ToBk2();
 				bk2.Filename = fileInfo.FullName;
 				bk2.Attach(Emulator); // required to be able to save the cycle count for ICycleTiming emulators
-				bk2.Save();
+				bk2.Save(Emulator);
 				MessageStatusLabel.Text = $"{bk2.Name} exported.";
 				Cursor = Cursors.Default;
 			}
@@ -943,7 +945,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void CommentsMenuItem_Click(object sender, EventArgs e)
 		{
-			using EditCommentsForm form = new(CurrentTasMovie, false)
+			using EditCommentsForm form = new(CurrentTasMovie, Emulator, false)
 			{
 				Owner = this,
 				StartPosition = FormStartPosition.Manual,
@@ -956,6 +958,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			using EditSubtitlesForm form = new(
 				DialogController,
+				Emulator,
 				CurrentTasMovie,
 				Config!.PathEntries,
 				readOnly: false)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -278,7 +278,7 @@ namespace BizHawk.Client.EmuHawk
 					EMsgBoxIcon.Question);
 				if (result == true)
 				{
-					MovieSession.Movie.Save();
+					MovieSession.Movie.Save(Emulator);
 				}
 				else if (result == null)
 				{
@@ -553,7 +553,7 @@ namespace BizHawk.Client.EmuHawk
 		private ITasMovie ConvertCurrentMovieToTasproj()
 		{
 			var tasMovie = MovieSession.Movie.ToTasMovie();
-			tasMovie.Save(); // should this be done?
+			tasMovie.Save(Emulator); // should this be done?
 			return tasMovie;
 		}
 
@@ -801,9 +801,9 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			if (saveBackup)
-				movieToSave.SaveBackup();
+				movieToSave.SaveBackup(Emulator);
 			else
-				movieToSave.Save();
+				movieToSave.Save(Emulator);
 
 			MessageStatusLabel.Text = saveBackup
 				? $"Backup .{(saveAsBk2 ? MovieService.StandardMovieExtension : MovieService.TasMovieExtension)} saved to \"Movie backups\" path."
@@ -837,7 +837,7 @@ namespace BizHawk.Client.EmuHawk
 				MessageStatusLabel.Owner.Update();
 				Cursor = Cursors.WaitCursor;
 				CurrentTasMovie.Filename = fileInfo.FullName;
-				CurrentTasMovie.Save();
+				CurrentTasMovie.Save(Emulator);
 				Settings.RecentTas.Add(CurrentTasMovie.Filename);
 				MessageStatusLabel.Text = "File saved.";
 				Cursor = Cursors.Default;

--- a/src/BizHawk.Tests.Client.Common/Movie/MovieUndoTests.cs
+++ b/src/BizHawk.Tests.Client.Common/Movie/MovieUndoTests.cs
@@ -184,39 +184,39 @@ namespace BizHawk.Tests.Client.Common.Movie
 		[TestMethod]
 		public void RecordFrameAtEnd()
 		{
-			ITasMovie movie = TasMovieTests.MakeMovie(5);
+			ITasMovie movie = TasMovieTests.MakeMovie(5, out var emulator);
 
 			ValidateActionCanUndoAndRedo(movie, () =>
 			{
-				Bk2Controller controller = new Bk2Controller(movie.Emulator.ControllerDefinition);
+				Bk2Controller controller = new Bk2Controller(emulator.ControllerDefinition);
 				controller.SetBool("A", true);
-				movie.RecordFrame(5, controller);
+				movie.RecordFrame(targetFrame: 5, currentFrame: emulator.Frame, controller);
 			});
 		}
 
 		[TestMethod]
 		public void RecordFrameInMiddle()
 		{
-			ITasMovie movie = TasMovieTests.MakeMovie(5);
+			ITasMovie movie = TasMovieTests.MakeMovie(5, out var emulator);
 
 			ValidateActionCanUndoAndRedo(movie, () =>
 			{
-				Bk2Controller controller = new Bk2Controller(movie.Emulator.ControllerDefinition);
+				Bk2Controller controller = new Bk2Controller(emulator.ControllerDefinition);
 				controller.SetBool("A", true);
-				movie.RecordFrame(2, controller);
+				movie.RecordFrame(targetFrame: 2, currentFrame: emulator.Frame, controller);
 			});
 		}
 
 		[TestMethod]
 		public void RecordFrameZero()
 		{
-			ITasMovie movie = TasMovieTests.MakeMovie(5);
+			ITasMovie movie = TasMovieTests.MakeMovie(5, out var emulator);
 
 			ValidateActionCanUndoAndRedo(movie, () =>
 			{
-				Bk2Controller controller = new Bk2Controller(movie.Emulator.ControllerDefinition);
+				Bk2Controller controller = new Bk2Controller(emulator.ControllerDefinition);
 				controller.SetBool("A", true);
-				movie.RecordFrame(0, controller);
+				movie.RecordFrame(targetFrame: 0, currentFrame: emulator.Frame, controller);
 			});
 		}
 
@@ -277,18 +277,19 @@ namespace BizHawk.Tests.Client.Common.Movie
 		[TestMethod]
 		public void AllOperationsRespectBatching()
 		{
-			ITasMovie movie = TasMovieTests.MakeMovie(10);
+			ITasMovie movie = TasMovieTests.MakeMovie(10, out var emulator);
 
 			// Some actions can move markers.
 			movie.Markers.Add(9, "");
 			movie.BindMarkersToInput = true;
 
-			Bk2Controller controllerA = new Bk2Controller(movie.Emulator.ControllerDefinition);
+			Bk2Controller controllerA = new Bk2Controller(emulator.ControllerDefinition);
 			controllerA.SetBool("A", true);
 			string entryA = Bk2LogEntryGenerator.GenerateLogEntry(controllerA);
 
 			int beginIndex = 0;
 			TasMovieTests.TestAllOperations(movie,
+				emulator,
 				() =>
 				{
 					beginIndex = movie.ChangeLog.UndoIndex;
@@ -308,7 +309,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 		[TestMethod]
 		public void AllOperationsGiveOneUndo()
 		{
-			ITasMovie movie = TasMovieTests.MakeMovie(10);
+			ITasMovie movie = TasMovieTests.MakeMovie(10, out var emulator);
 
 			// Some actions can move markers.
 			movie.Markers.Add(9, "");
@@ -316,6 +317,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 
 			int beginIndex = 0;
 			TasMovieTests.TestAllOperations(movie,
+				emulator,
 				() => beginIndex = movie.ChangeLog.UndoIndex,
 #pragma warning disable BHI1600 //TODO disambiguate assert calls
 				() => Assert.AreEqual(1, movie.ChangeLog.UndoIndex - beginIndex)
@@ -424,10 +426,10 @@ namespace BizHawk.Tests.Client.Common.Movie
 		public void GeneralRespectsMarkerBinding()
 		{
 			// This was just a silly bug.
-			ITasMovie movie = TasMovieTests.MakeMovie(5);
+			ITasMovie movie = TasMovieTests.MakeMovie(5, out var emulator);
 			movie.Markers.Add(3, "a");
 
-			Bk2Controller controllerA = new Bk2Controller(movie.Emulator.ControllerDefinition);
+			Bk2Controller controllerA = new Bk2Controller(emulator.ControllerDefinition);
 			controllerA.SetBool("A", true);
 
 			movie.BindMarkersToInput = true;


### PR DESCRIPTION
Removes all uses of `Bk2Movie.Emulator` except the assignment in `Attach`, a reference equality comparison (in `Debug.Assert`, for catching regressions), and a read of `base.Emulator.Frame` in `TasMovie.Item[]` which I left as a TODO.

Should the `MovieSession` hold a reference to the core instance? I've added a prop, set at the same time `Attach` was called, but maybe it should be passed in to all those calls too.