### PR TITLE
Fix video filename with ffmpeg writer

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3210,14 +3210,9 @@ namespace BizHawk.Client.EmuHawk
 
 				aw = Config.VideoWriterAudioSyncEffective ? new VideoStretcher(aw) : new AudioStretcher(aw);
 				aw.SetMovieParameters(Emulator.VsyncNumerator(), Emulator.VsyncDenominator());
-				if (Config.AVWriterResizeWidth > 0 && Config.AVWriterResizeHeight > 0)
-				{
-					aw.SetVideoParameters(Config.AVWriterResizeWidth, Config.AVWriterResizeHeight);
-				}
-				else
-				{
-					aw.SetVideoParameters(_currentVideoProvider.BufferWidth, _currentVideoProvider.BufferHeight);
-				}
+				(IVideoProvider output, Action dispose) = GetCaptureProvider();
+				aw.SetVideoParameters(output.BufferWidth, output.BufferHeight);
+				if (dispose != null) dispose();
 
 				aw.SetAudioParameters(44100, 2, 16);
 
@@ -3322,6 +3317,70 @@ namespace BizHawk.Client.EmuHawk
 			RewireSound();
 		}
 
+		private (IVideoProvider Output, Action/*?*/ Dispose) GetCaptureProvider()
+		{
+			// TODO ZERO - this code is pretty jacked. we'll want to frugalize buffers better for speedier dumping, and we might want to rely on the GL layer for padding
+			if (Config.AVWriterResizeWidth > 0 && Config.AVWriterResizeHeight > 0)
+			{
+				BitmapBuffer bbIn = null;
+				Bitmap bmpIn = null;
+				try
+				{
+					bbIn = Config.AviCaptureOsd
+						? CaptureOSD()
+						: new BitmapBuffer(_currentVideoProvider.BufferWidth, _currentVideoProvider.BufferHeight, _currentVideoProvider.GetVideoBuffer());
+
+					bbIn.DiscardAlpha();
+
+					Bitmap bmpOut = new(width: Config.AVWriterResizeWidth, height: Config.AVWriterResizeHeight, PixelFormat.Format32bppArgb);
+					bmpIn = bbIn.ToSysdrawingBitmap();
+					using (var g = Graphics.FromImage(bmpOut))
+					{
+						if (Config.AVWriterPad)
+						{
+							g.Clear(Color.FromArgb(_currentVideoProvider.BackgroundColor));
+							g.DrawImageUnscaled(bmpIn, (bmpOut.Width - bmpIn.Width) / 2, (bmpOut.Height - bmpIn.Height) / 2);
+						}
+						else
+						{
+							g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
+							g.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.Half;
+							g.DrawImage(bmpIn, new Rectangle(0, 0, bmpOut.Width, bmpOut.Height));
+						}
+					}
+
+					IVideoProvider output = new BmpVideoProvider(bmpOut, _currentVideoProvider.VsyncNumerator, _currentVideoProvider.VsyncDenominator);
+					return (output, bmpOut.Dispose);
+				}
+				finally
+				{
+					bbIn?.Dispose();
+					bmpIn?.Dispose();
+				}
+			}
+			else
+			{
+				BitmapBuffer source = null;
+				if (Config.AviCaptureOsd)
+				{
+					source = CaptureOSD();
+				}
+				else if (Config.AviCaptureLua)
+				{
+					source = CaptureLua();
+				}
+
+				if (source != null)
+				{
+					return (new BitmapBufferVideoProvider(source), source.Dispose);
+				}
+				else
+				{
+					return (_currentVideoProvider, null);
+				}
+			}
+		}
+
 		private void AbortAv()
 		{
 			if (_currAviWriter == null)
@@ -3365,73 +3424,16 @@ namespace BizHawk.Client.EmuHawk
 
 		private void AvFrameAdvance()
 		{
-			if (_currAviWriter == null) return;
-
 			// is this the best time to handle this? or deeper inside?
 			if (_argParser._currAviWriterFrameList?.Contains(Emulator.Frame) != false)
 			{
-				// TODO ZERO - this code is pretty jacked. we'll want to frugalize buffers better for speedier dumping, and we might want to rely on the GL layer for padding
+				if (_currAviWriter == null) return;
+				Action dispose = null;
 				try
 				{
-					IVideoProvider output;
-					IDisposable disposableOutput = null;
-					if (Config.AVWriterResizeWidth > 0 && Config.AVWriterResizeHeight > 0)
-					{
-						BitmapBuffer bbIn = null;
-						Bitmap bmpIn = null;
-						try
-						{
-							bbIn = Config.AviCaptureOsd
-								? CaptureOSD()
-								: new BitmapBuffer(_currentVideoProvider.BufferWidth, _currentVideoProvider.BufferHeight, _currentVideoProvider.GetVideoBuffer());
-
-							bbIn.DiscardAlpha();
-
-							Bitmap bmpOut = new(width: Config.AVWriterResizeWidth, height: Config.AVWriterResizeHeight, PixelFormat.Format32bppArgb);
-							bmpIn = bbIn.ToSysdrawingBitmap();
-							using (var g = Graphics.FromImage(bmpOut))
-							{
-								if (Config.AVWriterPad)
-								{
-									g.Clear(Color.FromArgb(_currentVideoProvider.BackgroundColor));
-									g.DrawImageUnscaled(bmpIn, (bmpOut.Width - bmpIn.Width) / 2, (bmpOut.Height - bmpIn.Height) / 2);
-								}
-								else
-								{
-									g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
-									g.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.Half;
-									g.DrawImage(bmpIn, new Rectangle(0, 0, bmpOut.Width, bmpOut.Height));
-								}
-							}
-
-							output = new BmpVideoProvider(bmpOut, _currentVideoProvider.VsyncNumerator, _currentVideoProvider.VsyncDenominator);
-							disposableOutput = (IDisposable) output;
-						}
-						finally
-						{
-							bbIn?.Dispose();
-							bmpIn?.Dispose();
-						}
-					}
-					else
-					{
-						if (Config.AviCaptureOsd)
-						{
-							output = new BitmapBufferVideoProvider(CaptureOSD());
-							disposableOutput = (IDisposable) output;
-						}
-						else if (Config.AviCaptureLua)
-						{
-							output = new BitmapBufferVideoProvider(CaptureLua());
-							disposableOutput = (IDisposable) output;
-						}
-						else
-						{
-							output = _currentVideoProvider;
-						}
-					}
-
 					_currAviWriter.SetFrame(Emulator.Frame);
+
+					(IVideoProvider output, dispose) = GetCaptureProvider();
 
 					short[] samp;
 					int nsamp;
@@ -3444,14 +3446,16 @@ namespace BizHawk.Client.EmuHawk
 						((AudioStretcher) _currAviWriter).DumpAV(output, _aviSoundInputAsync, out samp, out nsamp);
 					}
 
-					disposableOutput?.Dispose();
-
 					_dumpProxy.PutSamples(samp, nsamp);
 				}
 				catch (Exception e)
 				{
 					ShowMessageBox(owner: null, $"Video dumping died:\n\n{e}");
 					AbortAv();
+				}
+				finally
+				{
+					if (dispose != null) dispose();
 				}
 			}
 


### PR DESCRIPTION
Issue fixed:
1) Set window size to 2x.
2) Enable A/V capture OSD
3) Record video with ffmpeg writer, give the name "test.mp4"
4) Frame advance to actually capture a frame
Result: The video is written to "test_1.mp4". File "test.mp4" was created but has no video.

This PR fixes the issue by pulling out the logic for acquiring a `IVideoProvider` that was being used in `MainForm.AvFrameAdvance` to its own method, and using that method to obtain the initial video resolution.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
