### PR TITLE
TAStudio: valid blank frames for OOB input indexes

### DIFF
--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.InputLog.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.InputLog.cs
@@ -28,7 +28,7 @@ namespace BizHawk.Client.Common
 		{
 			return frame < FrameCount && frame >= 0
 				? Log[frame]
-				: "";
+				: Bk2LogEntryGenerator.EmptyEntry(Session.MovieController);
 		}
 
 		public virtual bool ExtractInputLog(TextReader reader, out string errorMessage)


### PR DESCRIPTION
fixes #4529 -- cloning the last row in TAStudio works now

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
