### PR TITLE
Avoid loading TAStudio with no visible columns

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using BizHawk.Client.Common;
 using BizHawk.Client.EmuHawk.ToolExtensions;
 using BizHawk.Client.EmuHawk.Properties;
+using BizHawk.Common.CollectionExtensions;
 using BizHawk.Common.StringExtensions;
 using BizHawk.Emulation.Common;
 using BizHawk.WinForms.Controls;
@@ -446,6 +447,16 @@ namespace BizHawk.Client.EmuHawk
 			foreach (var column in columnsToHide)
 			{
 				column.Visible = false;
+			}
+			if (!TasView.AllColumns.Where(static c => c.Visible)
+#if true
+				.CountIsAtLeast(2))
+#else
+				.Select(static c => c.Name).Except([ CursorColumnName, FrameColumnName ]).Any())
+#endif
+			{
+				// edge case: no columns are visible!
+				foreach (var c in TasView.AllColumns) c.Visible = true; // as a fallback, just show everything
 			}
 
 			foreach (var column in TasView.VisibleColumns)


### PR DESCRIPTION
[![dev build for branch | TASEmulators:tastudio-no-empty-when-vkeyboard](https://img.shields.io/badge/dev_build_for_branch-TASEmulators:tastudio--no--empty--when--vkeyboard-8250DF?logo=github&logoColor=333333&style=popout)](https://nightly.link/TASEmulators/BizHawk/workflows/ci/tastudio-no-empty-when-vkeyboard?preview)

edit: Didn't work. Will need a dev who can repro (I think it's with DOSBox-X).

Reported on Discord by @ShinobiWannabe.