### PR TITLE
more sensible handling of our special hotkey default binding "conflicts"

### DIFF
--- a/src/BizHawk.Client.Common/config/Binding.cs
+++ b/src/BizHawk.Client.Common/config/Binding.cs
@@ -208,7 +208,8 @@ namespace BizHawk.Client.Common
 
 #if DEBUG
 			var bindings = dict.Values
-				.Where(static info => !info.DisplayName.StartsWith("RA ") && !string.IsNullOrEmpty(info.DefaultBinding))
+				// We skip TAStudio analog hotkeys because they have special handling (no other hotkey can trigger when in analog editing mode)
+				.Where(static info => !(info.DisplayName.StartsWith("Analog ") && info.TabGroup == "TAStudio") && !string.IsNullOrEmpty(info.DefaultBinding))
 				.Select(static info => info.DefaultBinding)
 				.ToArray();
 			Debug.Assert(bindings.Distinct().CountIsExactly(bindings.Length), "Do not default bind multiple hotkeys to the same button combination.");


### PR DESCRIPTION
Previously I'd introduced code to automatically detect conflicts with our default hotkey bindings. I had made it ignore RA hotkeys, since some of those are bound to the same keys as other hotkeys but that didn't seem to be an actual issue.

I think this way of doing it is better, though: Instead of ignoring RA hotkeys, ignore the other group that has the same keys bound: TAStudio's analog edit hotkeys. I think this is better because MainForm.Hotkey.cs has special handling for analog editing mode, which prevents all other hotkeys from being triggered if analog edit mode is active. So it is actually impossible for these to conflict with anything else. But there is no such special handling for RA hotkeys. (Maybe there should be? I don't know.)

Someone familiar with the RA integration might have a different idea here.