### PR TITLE
Make branch load lua event more useful

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -237,7 +237,6 @@ namespace BizHawk.Client.EmuHawk
 			if (!BranchView.AnyRowsSelected) return false; // why'd we do all that then
 
 			var success = LoadSelectedBranch();
-			Tastudio.BranchLoadedCallback?.Invoke(BranchView.FirstSelectedRowIndex);
 			return success;
 		}
 
@@ -337,7 +336,6 @@ namespace BizHawk.Client.EmuHawk
 			if (_branchUndo == BranchUndo.Load)
 			{
 				Tastudio.LoadBranch(_backupBranch);
-				Tastudio.BranchLoadedCallback?.Invoke(Branches.IndexOf(_backupBranch));
 				Tastudio.MainForm.AddOnScreenMessage("Branch Load canceled");
 			}
 			else if (_branchUndo == BranchUndo.Update)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
@@ -28,7 +28,7 @@ namespace BizHawk.Client.EmuHawk
 			var closestState = GetPriorStateForFramebuffer(frame);
 			if (frame < Emulator.Frame || (closestState.Key > Emulator.Frame && !skipLoadState))
 			{
-				LoadState(closestState, true);
+				LoadState(closestState);
 			}
 			closestState.Value.Dispose();
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -968,7 +968,7 @@ namespace BizHawk.Client.EmuHawk
 			return CurrentTasMovie.TasStateManager.GetStateClosestToFrame(frame > 0 ? frame - 1 : 0);
 		}
 
-		public void LoadState(KeyValuePair<int, Stream> state, bool discardApiHawkSurfaces = false)
+		public void LoadState(KeyValuePair<int, Stream> state, int? branchIndex = null)
 		{
 			StatableEmulator.LoadStateBinary(new BinaryReader(state.Value));
 
@@ -977,9 +977,15 @@ namespace BizHawk.Client.EmuHawk
 				Emulator.ResetCounters();
 			}
 
-			UpdateTools();
-			if (discardApiHawkSurfaces)
+			if (branchIndex.HasValue)
 			{
+				BranchLoadedCallback?.Invoke(branchIndex.Value);
+			}
+			UpdateTools();
+			if (!branchIndex.HasValue)
+			{
+				// If we are not a branch, we won't have a saved inamge.
+				// We will emulate 1 frame to get one, so we can discard now.
 				DisplayManager.DiscardApiHawkSurfaces();
 			}
 		}
@@ -1245,7 +1251,7 @@ namespace BizHawk.Client.EmuHawk
 			_suspendEditLogic = true;
 			CurrentTasMovie.LoadBranch(branch);
 			_suspendEditLogic = false;
-			LoadState(new(branch.Frame, new MemoryStream(branch.CoreData, false)));
+			LoadState(new(branch.Frame, new MemoryStream(branch.CoreData, false)), CurrentTasMovie.Branches.IndexOf(branch));
 
 			CurrentTasMovie.TasStateManager.Capture(Emulator.Frame, Emulator.AsStatable());
 			QuickBmpFile.Copy(new BitmapBufferVideoProvider(branch.CoreFrameBuffer), VideoProvider);


### PR DESCRIPTION
I have a Lua script for tracking RNG, that includes logic that runs when rewinding. It also has some logic to handle branch loads, but this fails because Lua can't know a branch was loaded until after the regular Lua after-frame update. This PR fixes that by invoking the branch load event earlier.