### PR TITLE
Bulk multibyte

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/MemoryApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/MemoryApi.cs
@@ -343,5 +343,82 @@ namespace BizHawk.Client.Common
 
 		// goes here
 		public void WriteU32(long addr, uint value, string domain = null) => WriteUnsigned(addr, value, 4, domain);
+
+		public void BulkReadU8(long addr, Span<byte> dst, string domain = null)
+		{
+			var d = NamedDomainOrCurrent(domain);
+			if (addr < 0) throw new ArgumentOutOfRangeException(message: $"Attempted to read U8 values starting at address {addr:X}, which is outside the range of domain {d.Name}.", paramName: nameof(addr));
+			if (dst.IsEmpty) return;
+			ulong lastReqAddr = (ulong)(addr + dst.Length) - 1; // cannot overflow
+			if (lastReqAddr >= (ulong)d.Size) throw new Exception($"Attempted to read U8 values ending at address {lastReqAddr:X}, which is outside range of domain {d.Name}.");
+			using (d.EnterExit())
+			{
+				d.BulkPeekByte(addr, dst);
+			}
+		}
+
+		public void BulkReadU16(long addr, Span<ushort> dst, string domain = null)
+		{
+			var d = NamedDomainOrCurrent(domain);
+			if (addr < 0) throw new ArgumentOutOfRangeException(message: $"Attempted to read U16 values starting at address {addr:X}, which is outside the range of domain {d.Name}.", paramName: nameof(addr));
+			if (dst.IsEmpty) return;
+			ulong lastReqAddr = (ulong)(addr + dst.Length * sizeof(ushort)) - 1; // cannot overflow
+			if (lastReqAddr >= (ulong)d.Size) throw new Exception($"Attempted to read U16 values ending at address {lastReqAddr:X}, which is outside range of domain {d.Name}.");
+			using (d.EnterExit())
+			{
+				d.BulkPeekUshort(addr, dst, _isBigEndian);
+			}
+		}
+		public void BulkReadU32(long addr, Span<uint> dst, string domain = null)
+		{
+			var d = NamedDomainOrCurrent(domain);
+			if (addr < 0) throw new ArgumentOutOfRangeException(message: $"Attempted to read U32 values starting at address {addr:X}, which is outside the range of domain {d.Name}.", paramName: nameof(addr));
+			if (dst.IsEmpty) return;
+			ulong lastReqAddr = (ulong)(addr + dst.Length * sizeof(uint)) - 1; // cannot overflow
+			if (lastReqAddr >= (ulong)d.Size) throw new Exception($"Attempted to read U32 values ending at address {lastReqAddr:X}, which is outside range of domain {d.Name}.");
+			using (d.EnterExit())
+			{
+				d.BulkPeekUint(addr, dst, _isBigEndian);
+			}
+		}
+
+		public void BulkWriteU8(long addr, ReadOnlySpan<byte> values, string domain = null)
+		{
+			var d = NamedDomainOrCurrent(domain);
+			if (addr < 0) throw new ArgumentOutOfRangeException(message: $"Attempted to write U8 values starting at address {addr:X}, which is outside the range of domain {d.Name}.", paramName: nameof(addr));
+			if (values.IsEmpty) return;
+			ulong lastReqAddr = (ulong)(addr + values.Length) - 1; // cannot overflow
+			if (lastReqAddr >= (ulong)d.Size) throw new Exception($"Attempted to write U8 values ending at address {lastReqAddr:X}, which is outside range of domain {d.Name}.");
+			using (d.EnterExit())
+			{
+				d.BulkPokeByte(addr, values);
+			}
+		}
+
+		public void BulkWriteU16(long addr, ReadOnlySpan<ushort> values, string domain = null)
+		{
+			var d = NamedDomainOrCurrent(domain);
+			if (addr < 0) throw new ArgumentOutOfRangeException(message: $"Attempted to write U16 values starting at address {addr:X}, which is outside the range of domain {d.Name}.", paramName: nameof(addr));
+			if (values.IsEmpty) return;
+			ulong lastReqAddr = (ulong)(addr + values.Length * sizeof(ushort)) - 1; // cannot overflow
+			if (lastReqAddr >= (ulong)d.Size) throw new Exception($"Attempted to write U16 values ending at address {lastReqAddr:X}, which is outside range of domain {d.Name}.");
+			using (d.EnterExit())
+			{
+				d.BulkPokeUshort(addr, values, _isBigEndian);
+			}
+		}
+
+		public void BulkWriteU32(long addr, ReadOnlySpan<uint> values, string domain = null)
+		{
+			var d = NamedDomainOrCurrent(domain);
+			if (addr < 0) throw new ArgumentOutOfRangeException(message: $"Attempted to write U32 values starting at address {addr:X}, which is outside the range of domain {d.Name}.", paramName: nameof(addr));
+			if (values.IsEmpty) return;
+			ulong lastReqAddr = (ulong)(addr + values.Length * sizeof(uint)) - 1; // cannot overflow
+			if (lastReqAddr >= (ulong)d.Size) throw new Exception($"Attempted to write U32 values ending at address {lastReqAddr:X}, which is outside range of domain {d.Name}.");
+			using (d.EnterExit())
+			{
+				d.BulkPokeUint(addr, values, _isBigEndian);
+			}
+		}
 	}
 }

--- a/src/BizHawk.Client.Common/Api/Classes/MemoryApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/MemoryApi.cs
@@ -238,7 +238,7 @@ namespace BizHawk.Client.Common
 			var data = new byte[count];
 			using (d.EnterExit())
 			{
-				d.BulkPeekByte(addr.RangeToExclusive(addr + count), data);
+				d.BulkPeekByte(addr, data);
 			}
 			return SHA256Checksum.ComputeDigestHex(data);
 		}
@@ -256,7 +256,7 @@ namespace BizHawk.Client.Common
 			var iSrc = Math.Min(Math.Max(0L, addr), d.Size);
 			var iDst = iSrc - addr;
 			var bytes = new byte[indexAfterLast - iSrc];
-			if (iSrc < indexAfterLast) using (d.EnterExit()) d.BulkPeekByte(iSrc.RangeToExclusive(indexAfterLast), bytes);
+			if (iSrc < indexAfterLast) using (d.EnterExit()) d.BulkPeekByte(iSrc, bytes);
 			if (lastReqAddr >= d.Size) LogCallback($"Warning: Attempted reads on addresses {d.Size}..{lastReqAddr} outside range of domain {d.Name} in {nameof(ReadByteRange)}()");
 			if (bytes.Length == length) return bytes;
 			var newBytes = new byte[length];

--- a/src/BizHawk.Client.Common/Api/Interfaces/IMemoryApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IMemoryApi.cs
@@ -25,9 +25,16 @@ namespace BizHawk.Client.Common
 		int ReadS32(long addr, string domain = null);
 
 		uint ReadU8(long addr, string domain = null);
+		void BulkReadU8(long addr, Span<byte> dst, string domain = null);
+
 		uint ReadU16(long addr, string domain = null);
+		void BulkReadU16(long addr, Span<ushort> dst, string domain = null);
+
 		uint ReadU24(long addr, string domain = null);
+
 		uint ReadU32(long addr, string domain = null);
+		void BulkReadU32(long addr, Span<uint> dst, string domain = null);
+
 
 		void WriteByte(long addr, uint value, string domain = null);
 		void WriteByteRange(long addr, IReadOnlyList<byte> memoryblock, string domain = null);
@@ -39,8 +46,14 @@ namespace BizHawk.Client.Common
 		void WriteS32(long addr, int value, string domain = null);
 
 		void WriteU8(long addr, uint value, string domain = null);
+		void BulkWriteU8(long addr, ReadOnlySpan<byte> values, string domain = null);
+
 		void WriteU16(long addr, uint value, string domain = null);
+		void BulkWriteU16(long addr, ReadOnlySpan<ushort> values, string domain = null);
+
 		void WriteU24(long addr, uint value, string domain = null);
+
 		void WriteU32(long addr, uint value, string domain = null);
+		void BulkWriteU32(long addr, ReadOnlySpan<uint> values, string domain = null);
 	}
 }

--- a/src/BizHawk.Client.Common/lua/CommonLibs/MemoryLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/MemoryLuaLibrary.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.ComponentModel;
 using System.Linq;
 
@@ -130,6 +131,110 @@ namespace BizHawk.Client.Common
 			{
 				APIs.Memory.WriteByte((long) addr, (uint) v, domain);
 			}
+		}
+
+		[LuaMethodExample("local values = memory.read_u16_le_as_array(0x100, 30, \"WRAM\");")]
+		[LuaMethod("read_u16_le_as_array", "Reads count 16-bit values starting at addr into an array-like table (1-indexed).")]
+		public LuaTable ReadUshortsAsArray(long addr, int count, string domain = null)
+		{
+			ushort[] array = ArrayPool<ushort>.Shared.Rent(count);
+			try
+			{
+				APIs.Memory.SetBigEndian(false);
+				Span<ushort> values = new(array, 0, count);
+				APIs.Memory.BulkReadU16(addr, values, domain);
+				return _th.SpanToTable(values);
+			}
+			finally
+			{
+				ArrayPool<ushort>.Shared.Return(array);
+			}
+		}
+
+		[LuaMethodExample("memory.write_u16_le_as_array(0x100, { 0xABCD, 0x1234 });")]
+		[LuaMethod("write_u16_le_as_array", "Writes sequential 16-byte values starting at addr.")]
+		public void WriteUshortsAsArray(long addr, LuaTable values, string domain = null)
+		{
+			APIs.Memory.SetBigEndian(false);
+			APIs.Memory.BulkWriteU16(addr, _th.EnumerateValues<long>(values).Select(l => (ushort)l).ToArray(), domain);
+		}
+
+		[LuaMethodExample("local values = memory.read_u16_be_as_array(0x100, 30, \"WRAM\");")]
+		[LuaMethod("read_u16_be_as_array", "Reads count 16-bit values starting at addr into an array-like table (1-indexed).")]
+		public LuaTable ReadUshortsBigAsArray(long addr, int count, string domain = null)
+		{
+			ushort[] array = ArrayPool<ushort>.Shared.Rent(count);
+			try
+			{
+				APIs.Memory.SetBigEndian(true);
+				Span<ushort> values = new(array, 0, count);
+				APIs.Memory.BulkReadU16(addr, values, domain);
+				return _th.SpanToTable(values);
+			}
+			finally
+			{
+				ArrayPool<ushort>.Shared.Return(array);
+			}
+		}
+
+		[LuaMethodExample("memory.write_u16_be_as_array(0x100, { 0xABCD, 0x1234 });")]
+		[LuaMethod("write_u16_be_as_array", "Writes sequential 16-byte values starting at addr.")]
+		public void WriteUshortsAsBigArray(long addr, LuaTable values, string domain = null)
+		{
+			APIs.Memory.SetBigEndian(true);
+			APIs.Memory.BulkWriteU16(addr, _th.EnumerateValues<long>(values).Select(l => (ushort)l).ToArray(), domain);
+		}
+
+		[LuaMethodExample("local values = memory.read_u32_le_as_array(0x100, 30, \"WRAM\");")]
+		[LuaMethod("read_u32_le_as_array", "Reads count 32-bit values starting at addr into an array-like table (1-indexed).")]
+		public LuaTable ReadUintsAsArray(long addr, int count, string domain = null)
+		{
+			uint[] array = ArrayPool<uint>.Shared.Rent(count);
+			try
+			{
+				APIs.Memory.SetBigEndian(false);
+				Span<uint> values = new(array, 0, count);
+				APIs.Memory.BulkReadU32(addr, values, domain);
+				return _th.SpanToTable(values);
+			}
+			finally
+			{
+				ArrayPool<uint>.Shared.Return(array);
+			}
+		}
+
+		[LuaMethodExample("memory.write_u32_le_as_array(0x100, { 0xABCD, 0x1234 });")]
+		[LuaMethod("write_u32_le_as_array", "Writes sequential 32-byte values starting at addr.")]
+		public void WriteUintsAsArray(long addr, LuaTable values, string domain = null)
+		{
+			APIs.Memory.SetBigEndian(false);
+			APIs.Memory.BulkWriteU32(addr, _th.EnumerateValues<long>(values).Select(l => (uint)l).ToArray(), domain);
+		}
+
+		[LuaMethodExample("local values = memory.read_u32_be_as_array(0x100, 30, \"WRAM\");")]
+		[LuaMethod("read_u32_be_as_array", "Reads count 32-bit values starting at addr into an array-like table (1-indexed).")]
+		public LuaTable ReadUintsBigAsArray(long addr, int count, string domain = null)
+		{
+			uint[] array = ArrayPool<uint>.Shared.Rent(count);
+			try
+			{
+				APIs.Memory.SetBigEndian(true);
+				Span<uint> values = new(array, 0, count);
+				APIs.Memory.BulkReadU32(addr, values, domain);
+				return _th.SpanToTable(values);
+			}
+			finally
+			{
+				ArrayPool<uint>.Shared.Return(array);
+			}
+		}
+
+		[LuaMethodExample("memory.write_u32_be_as_array(0x100, { 0xABCD, 0x1234 });")]
+		[LuaMethod("write_u32_be_as_array", "Writes sequential 32-byte values starting at addr.")]
+		public void WriteUintsBigAsArray(long addr, LuaTable values, string domain = null)
+		{
+			APIs.Memory.SetBigEndian(true);
+			APIs.Memory.BulkWriteU32(addr, _th.EnumerateValues<long>(values).Select(l => (uint)l).ToArray(), domain);
 		}
 
 		[LuaMethodExample("""

--- a/src/BizHawk.Client.Common/lua/NLuaTableHelper.cs
+++ b/src/BizHawk.Client.Common/lua/NLuaTableHelper.cs
@@ -77,6 +77,13 @@ namespace BizHawk.Client.Common
 			return table;
 		}
 
+		public LuaTable SpanToTable<T>(Span<T> list, int indexFrom = 1)
+		{
+			var table = CreateTable();
+			for (int i = 0, l = list.Length; i != l; i++) table[indexFrom + i] = list[i];
+			return table;
+		}
+
 		public LuaTable MemoryBlockToTable(IReadOnlyList<byte> bytes, long startAddr)
 		{
 			var length = bytes.Count;

--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Memory.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Memory.cs
@@ -151,15 +151,14 @@ namespace BizHawk.Client.EmuHawk
 					var end = Math.Min(addr + bytes, _domainAddrStart + BankSize);
 					var length = end - addr;
 
-					if (_addressMangler == 0)
+					unsafe
 					{
-						var ret = new byte[length];
-						_domain.BulkPeekByte(((long)addr).RangeToExclusive(end), ret);
-						Marshal.Copy(ret, 0, buffer, (int)length);
-					}
-					else
-					{
-						unsafe
+						if (_addressMangler == 0)
+						{
+							Span<byte> dst = new(buffer.ToPointer(), checked((int)length));
+							_domain.BulkPeekByte(addr, dst);
+						}
+						else
 						{
 							for (var i = addr; i < end; i++)
 							{

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -632,15 +632,13 @@ namespace BizHawk.Client.EmuHawk
 			if (end <= start)
 				return dict;
 
-			var range = start.RangeToExclusive(end);
-
 			switch (dataSize)
 			{
 				default:
 				case 1:
 				{
 					var vals = new byte[end - start];
-					_domain.BulkPeekByte(range, vals);
+					_domain.BulkPeekByte(start, vals);
 					int i = 0;
 					for (var addr = start; addr < end; addr += dataSize)
 						dict.Add(addr, vals[i++]);
@@ -649,7 +647,7 @@ namespace BizHawk.Client.EmuHawk
 				case 2:
 				{
 					var vals = new ushort[(end - start) >> 1];
-					_domain.BulkPeekUshort(range, BigEndian, vals);
+					_domain.BulkPeekUshort(start, vals, BigEndian);
 					int i = 0;
 					for (var addr = start; addr < end; addr += dataSize)
 						dict.Add(addr, vals[i++]);
@@ -658,7 +656,7 @@ namespace BizHawk.Client.EmuHawk
 				case 4:
 				{
 					var vals = new uint[(end - start) >> 2];
-					_domain.BulkPeekUint(range, BigEndian, vals);
+					_domain.BulkPeekUint(start, vals, BigEndian);
 					int i = 0;
 					for (var addr = start; addr < end; addr += dataSize)
 						dict.Add(addr, vals[i++]);
@@ -2131,7 +2129,7 @@ namespace BizHawk.Client.EmuHawk
 			var addr = _highlightedAddress.Value & ~0b11L;
 			const int SIZE = 4;
 			var raw = new ushort[2 * SIZE * SIZE];
-			_domain.BulkPeekUshort(addr.RangeTo(addr + (SIZE * SIZE * sizeof(float) - 1)), bigEndian: true, raw);
+			_domain.BulkPeekUshort(addr, raw, bigEndian: true);
 			List<List<string>> strings = new();
 			for (var y = 0; y < SIZE; y++)
 			{

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -121,6 +121,43 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
+		public virtual void BulkPokeByte(long startAddress, ReadOnlySpan<byte> values)
+		{
+			long addr = startAddress;
+			using (this.EnterExit())
+			{
+				for (int i = 0; i < values.Length; i++, addr += sizeof(byte))
+				{
+					PokeByte(addr, values[i]);
+				}
+			}
+		}
+
+		public virtual void BulkPokeUshort(long startAddress, ReadOnlySpan<ushort> values, bool bigEndian)
+		{
+			long addr = startAddress;
+			using (this.EnterExit())
+			{
+				for (int i = 0; i < values.Length; i++, addr += sizeof(ushort))
+				{
+					PokeUshort(addr, values[i], bigEndian);
+				}
+			}
+		}
+
+		public virtual void BulkPokeUint(long startAddress, ReadOnlySpan<uint> values, bool bigEndian)
+		{
+			long addr = startAddress;
+			using (this.EnterExit())
+			{
+				for (int i = 0; i < values.Length; i++, addr += sizeof(uint))
+				{
+					PokeUint(addr, values[i], bigEndian);
+				}
+			}
+		}
+
+
 		public virtual void SendCheatToCore(int addr, byte value, int compare, int compare_type) { }
 
 		/// <summary>

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -20,8 +20,6 @@ namespace BizHawk.Emulation.Common
 			Unknown,
 		}
 
-		private const string ERR_MSG_BUFFER_WRONG_SIZE = "Invalid length of values array";
-
 		public string Name { get; protected set; }
 
 		public long Size { get; protected set; }
@@ -87,53 +85,38 @@ namespace BizHawk.Emulation.Common
 			PokeByte(addr + 3, scratch[3]);
 		}
 
-		public virtual void BulkPeekByte(Range<long> addresses, byte[] values)
+		public virtual void BulkPeekByte(long startAddress, Span<byte> values)
 		{
-			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
-			if (values is null) throw new ArgumentNullException(paramName: nameof(values));
-			if ((long) addresses.Count() > values.Length) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE);
-
+			long addr = startAddress;
 			using (this.EnterExit())
 			{
-				for (var i = addresses.Start; i <= addresses.EndInclusive; i++)
+				for (int i = 0; i < values.Length; i++, addr += sizeof(byte))
 				{
-					values[i - addresses.Start] = PeekByte(i);
+					values[i] = PeekByte(addr);
 				}
 			}
 		}
 
-		public virtual void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
+		public virtual void BulkPeekUshort(long startAddress, Span<ushort> values, bool bigEndian)
 		{
-			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
-			if (values is null) throw new ArgumentNullException(paramName: nameof(values));
-
-			var start = addresses.Start;
-			var end = addresses.EndInclusive + 1;
-			if (values.LongLength * sizeof(ushort) < end - start) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE);
-
+			long addr = startAddress;
 			using (this.EnterExit())
 			{
-				for (var i = 0; i < values.Length; i++, start += sizeof(ushort))
+				for (int i = 0; i < values.Length; i++, addr += sizeof(ushort))
 				{
-					values[i] = PeekUshort(start, bigEndian);
+					values[i] = PeekUshort(addr, bigEndian);
 				}
 			}
 		}
 
-		public virtual void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+		public virtual void BulkPeekUint(long startAddress, Span<uint> values, bool bigEndian)
 		{
-			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
-			if (values is null) throw new ArgumentNullException(paramName: nameof(values));
-
-			var start = addresses.Start;
-			var end = addresses.EndInclusive + 1;
-			if (values.LongLength * sizeof(uint) < end - start) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE);
-
+			long addr = startAddress;
 			using (this.EnterExit())
 			{
-				for (var i = 0; i < values.Length; i++, start += sizeof(uint))
+				for (int i = 0; i < values.Length; i++, addr += sizeof(uint))
 				{
-					values[i] = PeekUint(start, bigEndian);
+					values[i] = PeekUint(addr, bigEndian);
 				}
 			}
 		}

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -22,8 +22,6 @@ namespace BizHawk.Emulation.Common
 
 		private const string ERR_MSG_BUFFER_WRONG_SIZE = "Invalid length of values array";
 
-		private const string ERR_MSG_UNALIGNED = "The API contract doesn't define what to do for unaligned reads and writes!";
-
 		public string Name { get; protected set; }
 
 		public long Size { get; protected set; }
@@ -93,7 +91,7 @@ namespace BizHawk.Emulation.Common
 		{
 			if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
 			if (values is null) throw new ArgumentNullException(paramName: nameof(values));
-			if ((long) addresses.Count() != values.Length) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE);
+			if ((long) addresses.Count() > values.Length) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE);
 
 			using (this.EnterExit())
 			{
@@ -111,8 +109,7 @@ namespace BizHawk.Emulation.Common
 
 			var start = addresses.Start;
 			var end = addresses.EndInclusive + 1;
-			if ((start & 0b1) is not 0 || (end & 0b1) is not 0) throw new InvalidOperationException(ERR_MSG_UNALIGNED);
-			if (values.LongLength * sizeof(ushort) != end - start) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE); // a longer array could be valid, but nothing needs that so don't support it for now
+			if (values.LongLength * sizeof(ushort) < end - start) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE);
 
 			using (this.EnterExit())
 			{
@@ -130,8 +127,7 @@ namespace BizHawk.Emulation.Common
 
 			var start = addresses.Start;
 			var end = addresses.EndInclusive + 1;
-			if ((start & 0b11) is not 0 || (end & 0b11) is not 0) throw new InvalidOperationException(ERR_MSG_UNALIGNED);
-			if (values.LongLength * sizeof(uint) != end - start) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE); // `!=` not `<`, per `BulkPeekUshort`
+			if (values.LongLength * sizeof(uint) < end - start) throw new InvalidOperationException(ERR_MSG_BUFFER_WRONG_SIZE);
 
 			using (this.EnterExit())
 			{

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
@@ -1,7 +1,5 @@
 ﻿#nullable disable
 
-using System.Runtime.InteropServices;
-
 using BizHawk.Common;
 
 namespace BizHawk.Emulation.Common
@@ -10,10 +8,16 @@ namespace BizHawk.Emulation.Common
 	{
 		private Action<long, byte> _poke;
 
+		public delegate void BulkBytePeekDel(long startAddress, Span<byte> values);
+
+		public delegate void BulkUshortPeekDel(long startAddress, Span<ushort> values, bool bigEndian);
+
+		public delegate void BulkUintPeekDel(long startAddress, Span<uint> values, bool bigEndian);
+
 		// TODO: use an array of Ranges
-		private Action<Range<long>, byte[]> _bulkPeekByte { get; set; }
-		private Action<Range<long>, bool, ushort[]> _bulkPeekUshort { get; set; }
-		private Action<Range<long>, bool, uint[]> _bulkPeekUint { get; set; }
+		private BulkBytePeekDel _bulkPeekByte { get; set; }
+		private BulkUshortPeekDel _bulkPeekUshort { get; set; }
+		private BulkUintPeekDel _bulkPeekUint { get; set; }
 
 		public Func<long, byte> Peek { get; set; }
 
@@ -37,39 +41,39 @@ namespace BizHawk.Emulation.Common
 			_poke?.Invoke(addr, val);
 		}
 
-		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		public override void BulkPeekByte(long startAddress, Span<byte> values)
 		{
 			if (_bulkPeekByte != null)
 			{
-				_bulkPeekByte.Invoke(addresses, values);
+				_bulkPeekByte.Invoke(startAddress, values);
 			}
 			else
 			{
-				base.BulkPeekByte(addresses, values);
+				base.BulkPeekByte(startAddress, values);
 			}
 		}
 
-		public override void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
+		public override void BulkPeekUshort(long startAddress, Span<ushort> values, bool bigEndian)
 		{
 			if (_bulkPeekUshort != null)
 			{
-				_bulkPeekUshort.Invoke(addresses, bigEndian, values);
+				_bulkPeekUshort.Invoke(startAddress, values, bigEndian);
 			}
 			else
 			{
-				base.BulkPeekUshort(addresses, bigEndian, values);
+				base.BulkPeekUshort(startAddress, values, bigEndian);
 			}
 		}
 
-		public override void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+		public override void BulkPeekUint(long startAddress, Span<uint> values, bool bigEndian)
 		{
 			if (_bulkPeekUint != null)
 			{
-				_bulkPeekUint.Invoke(addresses, bigEndian, values);
+				_bulkPeekUint.Invoke(startAddress, values, bigEndian);
 			}
 			else
 			{
-				base.BulkPeekUint(addresses, bigEndian, values);
+				base.BulkPeekUint(startAddress, values, bigEndian);
 			}
 		}
 
@@ -80,9 +84,9 @@ namespace BizHawk.Emulation.Common
 			Func<long, byte> peek,
 			Action<long, byte> poke,
 			int wordSize,
-			Action<Range<long>, byte[]> bulkPeekByte = null,
-			Action<Range<long>, bool, ushort[]> bulkPeekUshort = null,
-			Action<Range<long>, bool, uint[]> bulkPeekUint = null)
+			BulkBytePeekDel bulkPeekByte = null,
+			BulkUshortPeekDel bulkPeekUshort = null,
+			BulkUintPeekDel bulkPeekUint = null)
 		{
 			Name = name;
 			EndianType = endian;
@@ -210,18 +214,20 @@ namespace BizHawk.Emulation.Common
 			}
 		}
 
-		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		public override void BulkPeekByte(long startAddress, Span<byte> values)
 		{
-			var start = (ulong)addresses.Start;
-			var count = addresses.Count();
-
-			if (start < (ulong)Size && (start + count) <= (ulong)Size)
+			if (startAddress < Size && (startAddress + values.Length) <= Size)
 			{
-				Marshal.Copy((IntPtr)((ulong)Data + start), values, 0, (int)count);
+				Span<byte> data = new(((IntPtr)((long)Data + startAddress)).ToPointer(), values.Length);
+				data.CopyTo(values);
+			}
+			else if (startAddress < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(startAddress));
 			}
 			else
 			{
-				throw new ArgumentOutOfRangeException(nameof(addresses));
+				throw new ArgumentOutOfRangeException(nameof(values));
 			}
 		}
 

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainStream.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainStream.cs
@@ -1,7 +1,6 @@
 #nullable disable
 
 using System.IO;
-using BizHawk.Common;
 
 namespace BizHawk.Emulation.Common
 {
@@ -58,11 +57,8 @@ namespace BizHawk.Emulation.Common
 			count = (int)Math.Min(count, Length - Position);
 			if (count == 0)
 				return 0;
-			// TODO: Memory domain doesn't have the overload we need :(
-			var poop = new byte[count];
-			// TODO: Range has the wrong end value
-			_d.BulkPeekByte(Position.RangeToExclusive(Position + count), poop);
-			Array.Copy(poop, 0, buffer, offset, count);
+			Span<byte> dst = new(buffer, offset, count);
+			_d.BulkPeekByte(Position, dst);
 			Position += count;
 			return count;
 		}

--- a/src/BizHawk.Emulation.Cores/Computers/Doom/DSDA.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Doom/DSDA.IMemoryDomains.cs
@@ -232,12 +232,8 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				var start = addresses.Start;
 				var end = addresses.EndInclusive + 1;
 
-				if ((start & 1) != 0 || (end & 1) != 0)
-					throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");
-
-				if (values.LongLength * 2 != end - start)
+				if (values.LongLength * sizeof(ushort) < end - start)
 				{
-					// a longer array could be valid, but nothing needs that so don't support it for now
 					throw new InvalidOperationException("Invalid length of values array");
 				}
 
@@ -262,12 +258,8 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				var start = addresses.Start;
 				var end = addresses.EndInclusive + 1;
 
-				if ((start & 3) != 0 || (end & 3) != 0)
-					throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");
-
-				if (values.LongLength * 4 != end - start)
+				if (values.LongLength * sizeof(uint) < end - start)
 				{
-					// a longer array could be valid, but nothing needs that so don't support it for now
 					throw new InvalidOperationException("Invalid length of values array");
 				}
 

--- a/src/BizHawk.Emulation.Cores/Computers/Doom/DSDA.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/Doom/DSDA.IMemoryDomains.cs
@@ -182,8 +182,9 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				}
 			}
 
-			private void BulkPeekByte(uint startAddr, Span<byte> values)
+			public override void BulkPeekByte(long startAddress, Span<byte> values)
 			{
+				uint startAddr = (uint)startAddress;
 				using (_exe.EnterExit())
 				{
 					while (!values.IsEmpty)
@@ -207,37 +208,9 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				}
 			}
 
-			public override void BulkPeekByte(Range<long> addresses, byte[] values)
+			public override void BulkPeekUshort(long startAddress, Span<ushort> values, bool bigEndian)
 			{
-				if (addresses is null)
-					throw new ArgumentNullException(paramName: nameof(addresses));
-				if (values is null)
-					throw new ArgumentNullException(paramName: nameof(values));
-
-				if ((long) addresses.Count() != values.Length)
-				{
-					throw new InvalidOperationException("Invalid length of values array");
-				}
-
-				BulkPeekByte((uint) addresses.Start, values);
-			}
-
-			public override void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
-			{
-				if (addresses is null)
-					throw new ArgumentNullException(paramName: nameof(addresses));
-				if (values is null)
-					throw new ArgumentNullException(paramName: nameof(values));
-
-				var start = addresses.Start;
-				var end = addresses.EndInclusive + 1;
-
-				if (values.LongLength * sizeof(ushort) < end - start)
-				{
-					throw new InvalidOperationException("Invalid length of values array");
-				}
-
-				BulkPeekByte((uint) addresses.Start, values.BytesSpan());
+				BulkPeekByte(startAddress, values.BytesSpan());
 
 				if (bigEndian)
 				{
@@ -248,22 +221,9 @@ namespace BizHawk.Emulation.Cores.Computers.Doom
 				}
 			}
 
-			public override void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+			public override void BulkPeekUint(long startAddress, Span<uint> values, bool bigEndian)
 			{
-				if (addresses is null)
-					throw new ArgumentNullException(paramName: nameof(addresses));
-				if (values is null)
-					throw new ArgumentNullException(paramName: nameof(values));
-
-				var start = addresses.Start;
-				var end = addresses.EndInclusive + 1;
-
-				if (values.LongLength * sizeof(uint) < end - start)
-				{
-					throw new InvalidOperationException("Invalid length of values array");
-				}
-
-				BulkPeekByte((uint) addresses.Start, values.BytesSpan());
+				BulkPeekByte(startAddress, values.BytesSpan());
 
 				if (bigEndian)
 				{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/3DS/Encore.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/3DS/Encore.IMemoryDomains.cs
@@ -181,8 +181,9 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				}
 			}
 
-			private void BulkPeekByte(uint startAddr, Span<byte> values)
+			public override void BulkPeekByte(long startAddress, Span<byte> values)
 			{
+				uint startAddr = (uint)startAddress;
 				while (!values.IsEmpty)
 				{
 					var page = GetPage(startAddr);
@@ -201,33 +202,9 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				}
 			}
 
-			public override void BulkPeekByte(Range<long> addresses, byte[] values)
+			public override void BulkPeekUshort(long startAddress, Span<ushort> values, bool bigEndian)
 			{
-				if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
-				if (values is null) throw new ArgumentNullException(paramName: nameof(values));
-
-				if ((long)addresses.Count() != values.Length)
-				{
-					throw new InvalidOperationException("Invalid length of values array");
-				}
-
-				BulkPeekByte((uint)addresses.Start, values);
-			}
-
-			public override void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
-			{
-				if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
-				if (values is null) throw new ArgumentNullException(paramName: nameof(values));
-
-				var start = addresses.Start;
-				var end = addresses.EndInclusive + 1;
-
-				if (values.LongLength * sizeof(ushort) < end - start)
-				{
-					throw new InvalidOperationException("Invalid length of values array");
-				}
-
-				BulkPeekByte((uint) addresses.Start, values.BytesSpan());
+				BulkPeekByte(startAddress, values.BytesSpan());
 
 				if (bigEndian)
 				{
@@ -238,20 +215,9 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				}
 			}
 
-			public override void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+			public override void BulkPeekUint(long startAddress, Span<uint> values, bool bigEndian)
 			{
-				if (addresses is null) throw new ArgumentNullException(paramName: nameof(addresses));
-				if (values is null) throw new ArgumentNullException(paramName: nameof(values));
-
-				var start = addresses.Start;
-				var end = addresses.EndInclusive + 1;
-
-				if (values.LongLength * sizeof(uint) < end - start)
-				{
-					throw new InvalidOperationException("Invalid length of values array");
-				}
-
-				BulkPeekByte((uint) addresses.Start, values.BytesSpan());
+				BulkPeekByte(startAddress, values.BytesSpan());
 
 				if (bigEndian)
 				{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/3DS/Encore.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/3DS/Encore.IMemoryDomains.cs
@@ -222,12 +222,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				var start = addresses.Start;
 				var end = addresses.EndInclusive + 1;
 
-				if ((start & 1) != 0 || (end & 1) != 0)
-					throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");
-
-				if (values.LongLength * 2 != end - start)
+				if (values.LongLength * sizeof(ushort) < end - start)
 				{
-					// a longer array could be valid, but nothing needs that so don't support it for now
 					throw new InvalidOperationException("Invalid length of values array");
 				}
 
@@ -250,12 +246,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.N3DS
 				var start = addresses.Start;
 				var end = addresses.EndInclusive + 1;
 
-				if ((start & 3) != 0 || (end & 3) != 0)
-					throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");
-
-				if (values.LongLength * 4 != end - start)
+				if (values.LongLength * sizeof(uint) < end - start)
 				{
-					// a longer array could be valid, but nothing needs that so don't support it for now
 					throw new InvalidOperationException("Invalid length of values array");
 				}
 

--- a/src/BizHawk.Emulation.Cores/Waterbox/WaterboxMemoryDomain.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/WaterboxMemoryDomain.cs
@@ -345,7 +345,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				_read8.Access((IntPtr)p, startAddress, values.Length);
 		}
 
-		public void BulkPokeByte(long addr, Span<byte> values)
+		public override void BulkPokeByte(long addr, ReadOnlySpan<byte> values)
 		{
 			if ((ulong)addr + (ulong)values.Length > (ulong)Size || addr < 0) throw new ArgumentOutOfRangeException(nameof(addr), message: AddressRangeError);
 
@@ -362,7 +362,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				_read16.Access((IntPtr)p, startAddress, values.Length);
 		}
 
-		public void BulkPokeUshort(long addr, Span<ushort> values)
+		public override void BulkPokeUshort(long addr, ReadOnlySpan<ushort> values, bool bigEndian)
 		{
 			if ((ulong)addr + (ulong)values.Length * sizeof(ushort) > (ulong)Size || addr < 0) throw new ArgumentOutOfRangeException(nameof(addr), message: AddressRangeError);
 
@@ -379,7 +379,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				_read32.Access((IntPtr)p, startAddress, values.Length);
 		}
 
-		public void BulkPokeUint(long addr, Span<uint> values)
+		public override void BulkPokeUint(long addr, ReadOnlySpan<uint> values, bool bigEndian)
 		{
 			if ((ulong)addr + (ulong)values.Length * sizeof(uint) > (ulong)Size || addr < 0) throw new ArgumentOutOfRangeException(nameof(addr), message: AddressRangeError);
 

--- a/src/BizHawk.Emulation.Cores/Waterbox/WaterboxMemoryDomain.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/WaterboxMemoryDomain.cs
@@ -102,27 +102,31 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			}
 		}
 
-		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		public override void BulkPeekByte(long startAddress, Span<byte> values)
 		{
 			if (_addressMangler != 0)
 			{
-				base.BulkPeekByte(addresses, values);
+				base.BulkPeekByte(startAddress, values);
 				return;
 			}
 
-			var start = (ulong)addresses.Start;
-			var count = addresses.Count();
+			var start = (ulong)startAddress;
 
-			if (start < (ulong)Size && (start + count) <= (ulong)Size)
+			if (startAddress < Size && (start + (ulong)values.Length) <= (ulong)Size)
 			{
 				using (_monitor.EnterExit())
 				{
-					Marshal.Copy(Z.US((ulong)_data + start), values, 0, (int)count);
+					Span<byte> data = new(Z.US((ulong)_data + start).ToPointer(), values.Length);
+					data.CopyTo(values);
 				}
+			}
+			else if (startAddress < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(startAddress));
 			}
 			else
 			{
-				throw new ArgumentOutOfRangeException(nameof(addresses));
+				throw new ArgumentOutOfRangeException(nameof(values));
 			}
 		}
 	}
@@ -219,25 +223,28 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			}
 		}
 
-		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		public override void BulkPeekByte(long startAddress, Span<byte> values)
 		{
 			if (_addressMangler != 0)
 			{
-				base.BulkPeekByte(addresses, values);
+				base.BulkPeekByte(startAddress, values);
 				return;
 			}
 
-			var start = (ulong)addresses.Start;
-			var count = addresses.Count();
+			var start = (ulong)startAddress;
 
-			if (start < (ulong)Size && (start + count) <= (ulong)Size)
+			if (startAddress < Size && (start + (ulong)values.Length) <= (ulong)Size)
 			{
 				fixed (byte* p = values)
-					_access.Access((IntPtr)p, (long)start, (long)count, false);
+					_access.Access((IntPtr)p, (long)start, values.Length, false);
+			}
+			else if (startAddress < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(startAddress));
 			}
 			else
 			{
-				throw new ArgumentOutOfRangeException(nameof(addresses));
+				throw new ArgumentOutOfRangeException(nameof(values));
 			}
 		}
 	}
@@ -329,13 +336,13 @@ namespace BizHawk.Emulation.Cores.Waterbox
 			_write32.Access((IntPtr)(&val), addr, 1);
 		}
 
-		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		public override void BulkPeekByte(long startAddress, Span<byte> values)
 		{
-			if ((ulong)addresses.Start + addresses.Count() > (ulong)Size || addresses.Start < 0) throw new ArgumentOutOfRangeException(nameof(addresses), message: AddressRangeError);
-			if (addresses.Count() > (uint)values.Length) throw new ArgumentException(message: $"Length of {nameof(values)} must be at least {nameof(addresses)} count.", nameof(values));
+			if ((ulong)startAddress + (ulong)values.Length > (ulong)Size) throw new ArgumentOutOfRangeException(nameof(values), message: AddressRangeError);
+			else if (startAddress < 0) throw new ArgumentOutOfRangeException(nameof(startAddress), message: AddressRangeError);
 
 			fixed (byte* p = values)
-				_read8.Access((IntPtr)p, addresses.Start, (long)addresses.Count());
+				_read8.Access((IntPtr)p, startAddress, values.Length);
 		}
 
 		public void BulkPokeByte(long addr, Span<byte> values)
@@ -346,14 +353,13 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				_write8.Access((IntPtr)p, addr, values.Length);
 		}
 
-		public override void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
+		public override void BulkPeekUshort(long startAddress, Span<ushort> values, bool bigEndian)
 		{
-			if ((ulong)addresses.Start + addresses.Count() > (ulong)Size || addresses.Start < 0) throw new ArgumentOutOfRangeException(nameof(addresses), message: AddressRangeError);
-			if (addresses.Count() > (uint)values.Length * sizeof(ushort)) throw new ArgumentException(message: $"Length of {nameof(values)} must be at least {nameof(addresses)} count.", nameof(values));
-			if ((addresses.Count() & 1) != 0) throw new ArgumentOutOfRangeException(nameof(addresses), "Requested byte count must be divisible by 2."); // TODO: The caller should be specifying the count of ushorts, not the count of bytes!
+			if ((ulong)startAddress + (ulong)values.Length * sizeof(ushort) > (ulong)Size) throw new ArgumentOutOfRangeException(nameof(values), message: AddressRangeError);
+			else if (startAddress < 0) throw new ArgumentOutOfRangeException(nameof(startAddress), message: AddressRangeError);
 
 			fixed (ushort* p = values)
-				_read16.Access((IntPtr)p, addresses.Start, (long)addresses.Count() / sizeof(ushort));
+				_read16.Access((IntPtr)p, startAddress, values.Length);
 		}
 
 		public void BulkPokeUshort(long addr, Span<ushort> values)
@@ -364,14 +370,13 @@ namespace BizHawk.Emulation.Cores.Waterbox
 				_write16.Access((IntPtr)p, addr, values.Length);
 		}
 
-		public override void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+		public override void BulkPeekUint(long startAddress, Span<uint> values, bool bigEndian)
 		{
-			if ((ulong)addresses.Start + addresses.Count() > (ulong)Size || addresses.Start < 0) throw new ArgumentOutOfRangeException(nameof(addresses), message: AddressRangeError);
-			if (addresses.Count() > (uint)values.Length * sizeof(uint)) throw new ArgumentException(message: $"Length of {nameof(values)} must be at least {nameof(addresses)} count.", nameof(values));
-			if ((addresses.Count() & 3) != 0) throw new ArgumentOutOfRangeException(nameof(addresses), "Requested byte count must be divisible by 4."); // TODO: The caller should be specifying the count of uints, not the count of bytes!
+			if ((ulong)startAddress + (ulong)values.Length * sizeof(uint) > (ulong)Size) throw new ArgumentOutOfRangeException(nameof(values), message: AddressRangeError);
+			else if (startAddress < 0) throw new ArgumentOutOfRangeException(nameof(startAddress), message: AddressRangeError);
 
 			fixed (uint* p = values)
-				_read32.Access((IntPtr)p, addresses.Start, (long)addresses.Count() / sizeof(uint));
+				_read32.Access((IntPtr)p, startAddress, values.Length);
 		}
 
 		public void BulkPokeUint(long addr, Span<uint> values)

--- a/src/BizHawk.Tests.Client.Common/Api/MemoryApiTests.cs
+++ b/src/BizHawk.Tests.Client.Common/Api/MemoryApiTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using BizHawk.Common;
 using BizHawk.Client.Common;
 using BizHawk.Emulation.Common;
+using BizHawk.Common.CollectionExtensions;
 
 namespace BizHawk.Tests.Client.Common.Api
 {
@@ -97,6 +98,215 @@ namespace BizHawk.Tests.Client.Common.Api
 				new byte[8],
 				memApi => memApi.WriteByteRange(9, new byte[] { 0x01, 0x23, 0x45, 0x67 }),
 				"fully above upper boundary");
+		}
+
+		[TestMethod]
+		public void TestBulkPeekU8()
+		{
+			byte[] memContents = new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF };
+			var memApi = CreateDummyApi(memContents);
+			byte[] outputArray = new byte[12];
+
+			Assert.Throws<Exception>(() => memApi.BulkReadU8(addr: -6, dst: new Span<byte>(outputArray, 0, 2)), "fully below lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU8(addr: -1, dst: new Span<byte>(outputArray, 0, 2)), "crosses lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU8(addr: 8, dst: new Span<byte>(outputArray, 0, 2)), "fully above upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU8(addr: 7, dst: new Span<byte>(outputArray, 0, 2)), "crosses upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU8(addr: -2, dst: new Span<byte>(outputArray, 0, 12)), "crosses both boundaries");
+
+			Span<byte> output;
+			output = new(outputArray, 0, 8);
+			memApi.BulkReadU8(addr: 0, dst: output);
+			CollectionAssert.That.AreEqual(
+				new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF },
+				output,
+				"whole domain");
+			output = new(outputArray, 0, 4);
+			memApi.BulkReadU8(addr: 2, dst: output);
+			CollectionAssert.That.AreEqual(
+				new byte[] { 0x45, 0x67, 0x89, 0xAB },
+				output,
+				"strict contains");
+			output = new(outputArray, 0, 0);
+			memApi.BulkReadU8(addr: 0, dst: output);
+			CollectionAssert.That.AreEqual(
+				Array.Empty<byte>(),
+				output,
+				"empty");
+		}
+
+		[TestMethod]
+		public void TestBulkPokeU8()
+		{
+			IMemoryApi memApi = CreateDummyApi(new byte[8]);
+			Assert.Throws<Exception>(() => memApi.BulkWriteU8(-4, new byte[] { 0x01, 0x23, 0x45, 0x67 }), "fully below lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU8(-2, new byte[] { 0x01, 0x23, 0x45, 0x67 }), "crosses lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU8(8, new byte[] { 0x01, 0x23, 0x45, 0x67 }), "fully above upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU8(6, new byte[] { 0x01, 0x23, 0x45, 0x67 }), "crosses upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU8(-2, new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0xFE, 0xDC, 0xBA, 0x98 }), "crosses both boundaries");
+
+			void TestCase(IReadOnlyList<byte> expected, Action<IMemoryApi> action, string message)
+			{
+				var memDomainContents = new byte[8];
+				action(CreateDummyApi(memDomainContents));
+
+				CollectionAssert.That.AreEqual(expected, memDomainContents, message);
+			}
+
+			TestCase(
+				new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF },
+				memApi => memApi.BulkWriteU8(0, new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF }),
+				"whole domain");
+			TestCase(
+				new byte[] { default, default, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB },
+				memApi => memApi.BulkWriteU8(2, new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB }),
+				"strict contains");
+			TestCase(
+				new byte[8],
+				memApi => memApi.BulkWriteU8(2, Array.Empty<byte>()),
+				"empty");
+		}
+
+
+		[TestMethod]
+		public void TestBulkPeekU16()
+		{
+			ushort[] memContents = new ushort[] { 0x0123, 0x4567, 0x89AB, 0xCDEF };
+			byte[] memBytes = new byte[8];
+			memContents.BytesSpan().CopyTo(memBytes);
+
+			var memApi = CreateDummyApi(memBytes);
+			ushort[] outputArray = new ushort[6];
+
+			Assert.Throws<Exception>(() => memApi.BulkReadU16(addr: -6, dst: new Span<ushort>(outputArray, 0, 2)), "fully below lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU16(addr: -2, dst: new Span<ushort>(outputArray, 0, 2)), "crosses lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU16(addr: 8, dst: new Span<ushort>(outputArray, 0, 2)), "fully above upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU16(addr: 6, dst: new Span<ushort>(outputArray, 0, 2)), "crosses upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU16(addr: -2, dst: new Span<ushort>(outputArray, 0, 6)), "crosses both boundaries");
+
+			Span<ushort> output;
+			output = new(outputArray, 0, 4);
+			memApi.BulkReadU16(addr: 0, dst: output);
+			CollectionAssert.That.AreEqual(
+				new ushort[] { 0x0123, 0x4567, 0x89AB, 0xCDEF },
+				output,
+				"whole domain");
+			output = new(outputArray, 0, 3);
+			memApi.BulkReadU16(addr: 2, dst: output);
+			CollectionAssert.That.AreEqual(
+				new ushort[] { 0x4567, 0x89AB, 0xCDEF },
+				output,
+				"strict contains");
+			output = new(outputArray, 0, 0);
+			memApi.BulkReadU16(addr: 2, dst: output);
+			CollectionAssert.That.AreEqual(
+				Array.Empty<ushort>(),
+				output,
+				"empty");
+		}
+
+		[TestMethod]
+		public void TestBulkPokeU16()
+		{
+			IMemoryApi memApi = CreateDummyApi(new byte[8]);
+			Assert.Throws<Exception>(() => memApi.BulkWriteU16(-4, new ushort[] { 0x0123, 0x4567 }), "fully below lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU16(-2, new ushort[] { 0x0123, 0x4567 }), "crosses lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU16(8, new ushort[] { 0x0123, 0x4567 }), "fully above upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU16(6, new ushort[] { 0x0123, 0x4567 }), "crosses upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU16(-2, new ushort[] { 0x0123, 0x4567, 0x89AB, 0xCDEF, 0xFEDC, 0xBA98 }), "crosses both boundaries");
+
+			void TestCase(IReadOnlyList<ushort> expected, Action<IMemoryApi> action, string message)
+			{
+				var memDomainContents = new byte[8];
+				action(CreateDummyApi(memDomainContents));
+				ushort[] memUshorts = new ushort[4];
+				memDomainContents.CopyTo(memUshorts.BytesSpan());
+
+				CollectionAssert.That.AreEqual(expected, memUshorts, message);
+			}
+
+			TestCase(
+				new ushort[] { 0x0123, 0x4567, 0x89AB, 0xCDEF },
+				memApi => memApi.BulkWriteU16(0, new ushort[] { 0x0123, 0x4567, 0x89AB, 0xCDEF }),
+				"whole domain");
+			TestCase(
+				new ushort[] { default, 0x0123, 0x4567, 0x89AB },
+				memApi => memApi.BulkWriteU16(2, new ushort[] { 0x0123, 0x4567, 0x89AB }),
+				"strict contains");
+			TestCase(
+				new ushort[4],
+				memApi => memApi.BulkWriteU16(2, Array.Empty<ushort>()),
+				"empty");
+		}
+
+		[TestMethod]
+		public void TestBulkPeekU32()
+		{
+			uint[] memContents = new uint[] { 0x01234567, 0x89ABCDEF };
+			byte[] memBytes = new byte[8];
+			memContents.BytesSpan().CopyTo(memBytes);
+
+			var memApi = CreateDummyApi(memBytes);
+			uint[] outputArray = new uint[2];
+
+			Assert.Throws<Exception>(() => memApi.BulkReadU32(addr: -10, dst: new Span<uint>(outputArray, 0, 2)), "fully below lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU32(addr: -4, dst: new Span<uint>(outputArray, 0, 2)), "crosses lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU32(addr: 8, dst: new Span<uint>(outputArray, 0, 2)), "fully above upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU32(addr: 4, dst: new Span<uint>(outputArray, 0, 2)), "crosses upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkReadU32(addr: -4, dst: new Span<uint>(outputArray, 0, 4)), "crosses both boundaries");
+
+
+			Span<uint> output;
+			output = new(outputArray, 0, 2);
+			memApi.BulkReadU32(addr: 0, dst: output);
+			CollectionAssert.That.AreEqual(
+				new uint[] { 0x01234567, 0x89ABCDEF },
+				output,
+				"whole domain");
+			output = new(outputArray, 0, 1);
+			memApi.BulkReadU32(addr: 4, dst: output);
+			CollectionAssert.That.AreEqual(
+				new uint[] { 0x89ABCDEF },
+				output,
+				"strict contains");
+			output = new(outputArray, 0, 0);
+			memApi.BulkReadU32(addr: 0, dst: output);
+			CollectionAssert.That.AreEqual(
+				Array.Empty<uint>(),
+				output,
+				"empty");
+		}
+
+		[TestMethod]
+		public void TestBulkPokeU32()
+		{
+			IMemoryApi memApi = CreateDummyApi(new byte[8]);
+			Assert.Throws<Exception>(() => memApi.BulkWriteU32(-8, new uint[] { 0x01234567, 0x89ABCDEF }), "fully below lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU32(-4, new uint[] { 0x01234567, 0x89ABCDEF }), "crosses lower boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU32(8, new uint[] { 0x01234567, 0x89ABCDEF }), "fully above upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU32(4, new uint[] { 0x01234567, 0x89ABCDEF }), "crosses upper boundary");
+			Assert.Throws<Exception>(() => memApi.BulkWriteU32(-4, new uint[] { 0x01234567, 0x89ABCDEF, 0xFEDCBA98, 0x76543210 }), "crosses both boundaries");
+
+			void TestCase(IReadOnlyList<uint> expected, Action<IMemoryApi> action, string message)
+			{
+				var memDomainContents = new byte[8];
+				action(CreateDummyApi(memDomainContents));
+				uint[] memUints = new uint[2];
+				memDomainContents.CopyTo(memUints.BytesSpan());
+
+				CollectionAssert.That.AreEqual(expected, memUints, message);
+			}
+			TestCase(
+				new uint[] { 0x01234567, 0x89ABCDEF },
+				memApi => memApi.BulkWriteU32(0, new uint[] { 0x01234567, 0x89ABCDEF }),
+				"whole domain");
+			TestCase(
+				new uint[] { default, 0x01234567 },
+				memApi => memApi.BulkWriteU32(4, new uint[] { 0x01234567 }),
+				"strict contains");
+			TestCase(
+				new uint[2],
+				memApi => memApi.BulkWriteU32(0, Array.Empty<uint>()),
+				"empty");
 		}
 
 		[TestMethod]

--- a/src/BizHawk.Tests.Client.Common/Movie/FakeEmulator.cs
+++ b/src/BizHawk.Tests.Client.Common/Movie/FakeEmulator.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
 
 using BizHawk.Common;
 using BizHawk.Emulation.Common;
@@ -6,10 +8,9 @@ using BizHawk.Emulation.Common;
 namespace BizHawk.Tests.Client.Common.Movie
 {
 	[Core("Fake", "Author", false, false)]
-	internal class FakeEmulator : IEmulator, IStatable, IInputPollable
+	internal class FakeEmulator : IEmulator, IStatable, IInputPollable, IMemoryDomains
 	{
-		private BasicServiceProvider _serviceProvider;
-		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
+		public static readonly byte[] InitialMemory;
 
 		private static readonly ControllerDefinition _cd = new ControllerDefinition("fake controller")
 		{
@@ -21,7 +22,14 @@ namespace BizHawk.Tests.Client.Common.Movie
 		static FakeEmulator()
 		{
 			_cd.BuildMnemonicsCache("fake");
+
+			InitialMemory = new byte[16];
+			for (int i = 0; i < InitialMemory.Length; i++) InitialMemory[i] = (byte)(i + 1);
 		}
+
+		private BasicServiceProvider _serviceProvider;
+		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
+
 
 		public ControllerDefinition ControllerDefinition => _cd;
 
@@ -39,8 +47,26 @@ namespace BizHawk.Tests.Client.Common.Movie
 		private InputCallbackSystem _inputCallbacks = new();
 		public IInputCallbackSystem InputCallbacks => _inputCallbacks;
 
+		private List<MemoryDomain> _domains;
+		public MemoryDomain MainMemory { get; set; }
+
+		public bool HasSystemBus => false;
+
+		public MemoryDomain SystemBus => throw new NotImplementedException();
+
+		int IReadOnlyCollection<MemoryDomain>.Count => 1;
+
+		public MemoryDomain this[int index] => _domains[index];
+
+		public MemoryDomain? this[string name] => name == MainMemory.Name ? MainMemory : null;
+
 		public FakeEmulator()
 		{
+			byte[] mem = new byte[InitialMemory.Length];
+			InitialMemory.CopyTo(mem, 0);
+			MainMemory = new MemoryDomainByteArray("main", MemoryDomain.Endian.Little, mem, true, 4);
+			_domains = new() { MainMemory };
+
 			_serviceProvider = new(this);
 		}
 
@@ -74,5 +100,9 @@ namespace BizHawk.Tests.Client.Common.Movie
 			writer.Write(LagCount);
 			writer.Write(IsLagFrame);
 		}
+
+		public bool Has(string name) => name == MainMemory.Name;
+		public IEnumerator<MemoryDomain> GetEnumerator() => _domains.GetEnumerator();
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}
 }

--- a/src/BizHawk.Tests.Client.Common/lua/LuaMemoryTests.cs
+++ b/src/BizHawk.Tests.Client.Common/lua/LuaMemoryTests.cs
@@ -1,0 +1,87 @@
+﻿using BizHawk.Common;
+using BizHawk.Common.CollectionExtensions;
+using BizHawk.Tests.Client.Common.Movie;
+
+namespace BizHawk.Tests.Client.Common.lua
+{
+	[DoNotParallelize]
+	[TestClass]
+	public class LuaMemoryTests
+	{
+		[TestMethod]
+		public void Test_read_u16_le_as_array()
+		{
+			// arrange
+			LuaTestContext context = new();
+			context.AddScript("memory/read_u16_le_as_array.lua", true);
+			ushort[] memUshorts = new ushort[FakeEmulator.InitialMemory.Length / sizeof(ushort)];
+			FakeEmulator.InitialMemory.CopyTo(memUshorts.BytesSpan());
+
+			// act
+			context.RunYielding();
+
+			// assert
+			context.AssertLogMatches(memUshorts[0].ToString(), memUshorts[1].ToString());
+		}
+
+		[TestMethod]
+		public void Test_read_u16_be_as_array()
+		{
+			// arrange
+			LuaTestContext context = new();
+			context.AddScript("memory/read_u16_be_as_array.lua", true);
+			ushort[] memUshorts = new ushort[FakeEmulator.InitialMemory.Length / sizeof(ushort)];
+			FakeEmulator.InitialMemory.CopyTo(memUshorts.BytesSpan());
+			EndiannessUtils.MutatingByteSwap16(memUshorts.BytesSpan());
+
+			// act
+			context.RunYielding();
+
+			// assert
+			context.AssertLogMatches(memUshorts[0].ToString(), memUshorts[1].ToString());
+		}
+
+		[TestMethod]
+		public void Test_write_u16_le_as_array() => LuaTestContext.RunTestFromLuaScript("memory/write_u16_le_as_array.lua");
+		[TestMethod]
+		public void Test_write_u16_be_as_array() => LuaTestContext.RunTestFromLuaScript("memory/write_u16_be_as_array.lua");
+
+		[TestMethod]
+		public void Test_read_u32_le_as_array()
+		{
+			// arrange
+			LuaTestContext context = new();
+			context.AddScript("memory/read_u32_le_as_array.lua", true);
+			uint[] memUints = new uint[FakeEmulator.InitialMemory.Length / sizeof(uint)];
+			FakeEmulator.InitialMemory.CopyTo(memUints.BytesSpan());
+
+			// act
+			context.RunYielding();
+
+			// assert
+			context.AssertLogMatches(memUints[0].ToString(), memUints[1].ToString());
+		}
+
+		[TestMethod]
+		public void Test_read_u32_be_as_array()
+		{
+			// arrange
+			LuaTestContext context = new();
+			context.AddScript("memory/read_u32_be_as_array.lua", true);
+			uint[] memUints = new uint[FakeEmulator.InitialMemory.Length / sizeof(uint)];
+			FakeEmulator.InitialMemory.CopyTo(memUints.BytesSpan());
+			EndiannessUtils.MutatingByteSwap32(memUints.BytesSpan());
+
+			// act
+			context.RunYielding();
+
+			// assert
+			context.AssertLogMatches(memUints[0].ToString(), memUints[1].ToString());
+		}
+
+		[TestMethod]
+		public void Test_write_u32_le_as_array() => LuaTestContext.RunTestFromLuaScript("memory/write_u32_le_as_array.lua");
+		[TestMethod]
+		public void Test_write_u32_be_as_array() => LuaTestContext.RunTestFromLuaScript("memory/write_u32_be_as_array.lua");
+	}
+}

--- a/src/BizHawk.Tests.Client.Common/lua/LuaTestContext.cs
+++ b/src/BizHawk.Tests.Client.Common/lua/LuaTestContext.cs
@@ -12,6 +12,26 @@ namespace BizHawk.Tests.Client.Common.lua
 	{
 		private static readonly string BASE_SCRIPT_PATH = Path.Combine(Environment.CurrentDirectory, "lua/scripts");
 
+		/// <summary>
+		/// Run a Lua script that contains the full test code.
+		/// A successful test should print "pass" and nothing else.
+		/// </summary>
+		public static void RunTestFromLuaScript(string path)
+		{
+			LuaTestContext context = new();
+			context.AddScript(path, true);
+			context.RunYielding();
+
+			if (context.loggedMessages.Count == 0)
+			{
+				Assert.Fail("Expected script to print \"pass\", but got nothing.");
+			}
+			if (context.loggedMessages.Count > 1 || context.loggedMessages[0] != "pass")
+			{
+				Assert.Fail(string.Join("\n", context.loggedMessages));
+			}
+		}
+
 		private LuaLibraries lua;
 
 		public List<string> loggedMessages = new();

--- a/src/BizHawk.Tests.Client.Common/lua/scripts/memory/read_u16_be_as_array.lua
+++ b/src/BizHawk.Tests.Client.Common/lua/scripts/memory/read_u16_be_as_array.lua
@@ -1,0 +1,3 @@
+﻿values = memory.read_u16_be_as_array(0, 2)
+print(values[1])
+print(values[2])

--- a/src/BizHawk.Tests.Client.Common/lua/scripts/memory/read_u16_le_as_array.lua
+++ b/src/BizHawk.Tests.Client.Common/lua/scripts/memory/read_u16_le_as_array.lua
@@ -1,0 +1,3 @@
+﻿values = memory.read_u16_le_as_array(0, 2)
+print(values[1])
+print(values[2])

--- a/src/BizHawk.Tests.Client.Common/lua/scripts/memory/read_u32_be_as_array.lua
+++ b/src/BizHawk.Tests.Client.Common/lua/scripts/memory/read_u32_be_as_array.lua
@@ -1,0 +1,3 @@
+﻿values = memory.read_u32_be_as_array(0, 2)
+print(values[1])
+print(values[2])

--- a/src/BizHawk.Tests.Client.Common/lua/scripts/memory/read_u32_le_as_array.lua
+++ b/src/BizHawk.Tests.Client.Common/lua/scripts/memory/read_u32_le_as_array.lua
@@ -1,0 +1,3 @@
+﻿values = memory.read_u32_le_as_array(0, 2)
+print(values[1])
+print(values[2])

--- a/src/BizHawk.Tests.Client.Common/lua/scripts/memory/write_u16_be_as_array.lua
+++ b/src/BizHawk.Tests.Client.Common/lua/scripts/memory/write_u16_be_as_array.lua
@@ -1,0 +1,16 @@
+﻿write_values = {101, 102}
+memory.write_u16_be_as_array(0, write_values)
+read_values = memory.read_u16_be_as_array(0, #write_values)
+
+match = true
+if #write_values ~= #read_values then
+	print(string.format("Read incorrect number of values. Expected %i, got %i", #write_values, #read_values))
+	match = false
+end
+for i = 1, #write_values do
+	if read_values[i] ~= write_values[i] then
+		match = false
+		print(string.format("Incorrect value read back at Lua table index %i. Expected %i, got %i", i, write_values[i], read_values[i]))
+	end
+end
+if match then print("pass") end

--- a/src/BizHawk.Tests.Client.Common/lua/scripts/memory/write_u16_le_as_array.lua
+++ b/src/BizHawk.Tests.Client.Common/lua/scripts/memory/write_u16_le_as_array.lua
@@ -1,0 +1,16 @@
+﻿write_values = {101, 102}
+memory.write_u16_le_as_array(0, write_values)
+read_values = memory.read_u16_le_as_array(0, #write_values)
+
+match = true
+if #write_values ~= #read_values then
+	print(string.format("Read incorrect number of values. Expected %i, got %i", #write_values, #read_values))
+	match = false
+end
+for i = 1, #write_values do
+	if read_values[i] ~= write_values[i] then
+		match = false
+		print(string.format("Incorrect value read back at Lua table index %i. Expected %i, got %i", i, write_values[i], read_values[i]))
+	end
+end
+if match then print("pass") end

--- a/src/BizHawk.Tests.Client.Common/lua/scripts/memory/write_u32_be_as_array.lua
+++ b/src/BizHawk.Tests.Client.Common/lua/scripts/memory/write_u32_be_as_array.lua
@@ -1,0 +1,16 @@
+﻿write_values = {101, 102}
+memory.write_u32_be_as_array(0, write_values)
+read_values = memory.read_u32_be_as_array(0, #write_values)
+
+match = true
+if #write_values ~= #read_values then
+	print(string.format("Read incorrect number of values. Expected %i, got %i", #write_values, #read_values))
+	match = false
+end
+for i = 1, #write_values do
+	if read_values[i] ~= write_values[i] then
+		match = false
+		print(string.format("Incorrect value read back at Lua table index %i. Expected %i, got %i", i, write_values[i], read_values[i]))
+	end
+end
+if match then print("pass") end

--- a/src/BizHawk.Tests.Client.Common/lua/scripts/memory/write_u32_le_as_array.lua
+++ b/src/BizHawk.Tests.Client.Common/lua/scripts/memory/write_u32_le_as_array.lua
@@ -1,0 +1,16 @@
+﻿write_values = {101, 102}
+memory.write_u32_le_as_array(0, write_values)
+read_values = memory.read_u32_le_as_array(0, #write_values)
+
+match = true
+if #write_values ~= #read_values then
+	print(string.format("Read incorrect number of values. Expected %i, got %i", #write_values, #read_values))
+	match = false
+end
+for i = 1, #write_values do
+	if read_values[i] ~= write_values[i] then
+		match = false
+		print(string.format("Incorrect value read back at Lua table index %i. Expected %i, got %i", i, write_values[i], read_values[i]))
+	end
+end
+if match then print("pass") end


### PR DESCRIPTION
To enable bulk poke/peek access for 16 and 32 bit values, I have given `MemoryDomain` , `IMemoryApi`, and `MemoryLuaLibrary` some new functions.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
