### PR TITLE
Add unit tests for `ArgParser` and improve output of `--help`

### DIFF
--- a/src/BizHawk.Tests.Client.Common/ArgParserTests.cs
+++ b/src/BizHawk.Tests.Client.Common/ArgParserTests.cs
@@ -1,3 +1,6 @@
+using System.IO;
+using System.Linq;
+
 using BizHawk.Client.Common;
 
 namespace BizHawk.Tests.Client.Common
@@ -10,6 +13,16 @@ namespace BizHawk.Tests.Client.Common
 		[TestMethod]
 		public void TestConfigWithHelpOrVersion(params string[] args)
 			=> Assert.AreEqual(0, ArgParser.ParseArguments(out _, args, fromUnitTest: true));
+
+		[TestMethod]
+		public void TestHelpSaysPassFlagsFirst()
+		{
+			using StringWriter output = new();
+			ArgParser.RunHelpActionForUnitTest(output);
+			var outputLines = output.ToString().Split('\n');
+			var usageLine = outputLines[outputLines.Index().First(tuple => tuple.Item.Contains("Usage:")).Index + 1].ToUpperInvariant();
+			Assert.IsTrue(usageLine.IndexOf("OPTION") < usageLine.IndexOf("ROM"));
+		}
 
 		[DataRow("rom.nes", "--nonexistent")]
 		[DataRow("--nonexistent", "rom.nes")]


### PR DESCRIPTION
From https://github.com/TASEmulators/BizHawk/commit/5c73d5b4178a6c637a7351f60fac39f058df995e#r177008277.

If this is merged, notify dotnet/command-line-api issue 2765.