### PR TITLE
Fix `events.onexit` callbacks accessing a disposed core and crashing

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3942,6 +3942,8 @@ namespace BizHawk.Client.EmuHawk
 				if (saveMovieResult == TryAgainResult.Canceled) return false;
 			}
 
+			if (Tools.Has<LuaConsole>()) Tools.LuaConsole.CallScriptExitCallbacks(); // important to do this here with the stale `IEmulator`, see https://github.com/TASEmulators/BizHawk/issues/4629
+
 			if (clearSram)
 			{
 				var path = Config.PathEntries.SaveRamAbsolutePath(Game, MovieSession.Movie);

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -568,6 +568,11 @@ namespace BizHawk.Client.EmuHawk
 		public void CallStateSaveCallbacks(string userFriendlyStateName)
 			=> LuaImp.CallSaveStateEvent(userFriendlyStateName);
 
+		public void CallScriptExitCallbacks()
+		{
+			foreach (var lf in LuaImp.ScriptList) LuaImp.CallExitEvent(lf, alsoUnregister: true);
+		}
+
 		protected override void UpdateBefore()
 		{
 			if (LuaImp.IsUpdateSupressed)

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaLibraries.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaLibraries.cs
@@ -279,7 +279,11 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		public void CallExitEvent(LuaFile lf)
+		/// <param name="alsoUnregister">
+		/// <c>LuaConsole.CallScriptExitCallbacks</c> passes <see langword="true" /> for this so that the subsequent call to <c>LuaConsole.Restart</c>
+		/// doesn't cause those callbacks to run at a point where the core has already been disposed
+		/// </param>
+		public void CallExitEvent(LuaFile lf, bool alsoUnregister = false)
 		{
 			foreach (var exitCallback in RegisteredFunctions
 				.Where(l => l.Event == NamedLuaFunction.EVENT_TYPE_ENGINESTOP
@@ -287,6 +291,7 @@ namespace BizHawk.Client.EmuHawk
 				.ToList())
 			{
 				exitCallback.Call();
+				if (alsoUnregister) RegisteredFunctions.Remove(exitCallback);
 			}
 		}
 


### PR DESCRIPTION
Dead simple, and doesn't interfere with running `onexit` callbacks when individual scripts are stopped.