### PR TITLE
fix: moving markers in TAStudio by alt-dragging would focus the menu

### DIFF
--- a/src/BizHawk.Bizware.Input/HostInputType.cs
+++ b/src/BizHawk.Bizware.Input/HostInputType.cs
@@ -9,5 +9,6 @@ namespace BizHawk.Bizware.Input
 		Mouse = 1,
 		Keyboard = 2,
 		Pad = 4,
+		Ignored = 8,
 	}
 }

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -162,6 +162,12 @@ namespace BizHawk.Client.Common
 				// useful debugging:
 				// Console.WriteLine(ie);
 
+				if (ie.Source == Bizware.Input.HostInputType.Ignored)
+				{
+					processSpecialInput(ie, false);
+					continue;
+				}
+
 				// TODO - wonder what happens if we pop up something interactive as a response to one of these hotkeys? may need to purge further processing
 
 				HostInputCoalescer.Receive(ie);

--- a/src/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/src/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -174,6 +174,31 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		private void EnqueueNewEvents(bool prohibitInput = false)
+		{
+			if (_newEvents.Count != 0)
+			{
+				//WHAT!? WE SHOULD NOT BE SO NAIVELY TOUCHING MAINFORM FROM THE INPUTTHREAD. ITS BUSY RUNNING.
+				AllowInput allowInput = prohibitInput ? AllowInput.None : MainFormInputAllowedCallback();
+
+				foreach (var ie in _newEvents)
+				{
+					if (ie.EventType == InputEventType.Press && ShouldSwallow(allowInput, ie.Source))
+					{
+						EnqueueEvent(new InputEvent() {
+							EventType = ie.EventType,
+							LogicalButton = ie.LogicalButton,
+							Source = HostInputType.Ignored, // no input or hotkey will happen, but special processing such as alt menuing may apply
+						});
+						continue;
+					}
+
+					EnqueueEvent(ie);
+				}
+			}
+			_newEvents.Clear();
+		}
+
 		public KeyValuePair<string, int>[] GetAxisValues()
 		{
 			lock (_axisValues)
@@ -205,8 +230,6 @@ namespace BizHawk.Client.EmuHawk
 				//this block is going to massively modify data structures that the binding method uses, so we have to lock it all
 				lock (this)
 				{
-					_newEvents.Clear();
-
 					//analyze keys
 					foreach (var ke in keyEvents)
 					{
@@ -217,9 +240,14 @@ namespace BizHawk.Client.EmuHawk
 					{
 						//_axisValues.Clear();
 						Adapter.ProcessHostGamepads(HandleButton, HandleAxis);
+					}
+					EnqueueNewEvents();
 
-						// analyze moose
-						if (_wantingMouseFocus.Contains(Form.ActiveForm))
+					// analyze moose
+					bool wantsMouse = _wantingMouseFocus.Contains(Form.ActiveForm);
+					if (wantsMouse)
+					{
+						lock (_axisValues)
 						{
 							var mousePos = Control.MousePosition;
 							if (_trackDeltas)
@@ -235,44 +263,19 @@ namespace BizHawk.Client.EmuHawk
 							_axisValues["WMouse X"] = mousePos.X;
 							_axisValues["WMouse Y"] = mousePos.Y;
 
-							var mouseBtns = Control.MouseButtons;
-							HandleButton("WMouse L", (mouseBtns & MouseButtons.Left) != 0, HostInputType.Mouse);
-							HandleButton("WMouse M", (mouseBtns & MouseButtons.Middle) != 0, HostInputType.Mouse);
-							HandleButton("WMouse R", (mouseBtns & MouseButtons.Right) != 0, HostInputType.Mouse);
-							HandleButton("WMouse 1", (mouseBtns & MouseButtons.XButton1) != 0, HostInputType.Mouse);
-							HandleButton("WMouse 2", (mouseBtns & MouseButtons.XButton2) != 0, HostInputType.Mouse);
-
 							// raw (relative) mouse input
 							_axisValues["RMouse X"] = mouseDeltaX + _axisValues.GetValueOrDefault("RMouse X");
 							_axisValues["RMouse Y"] = mouseDeltaY + _axisValues.GetValueOrDefault("RMouse Y");
 						}
-						else
-						{
-#if false // don't do this: for now, it will interfere with the virtualpad. don't do something similar for the mouse position either
-							// unpress all buttons
-							HandleButton("WMouse L", false, ClientInputFocus.Mouse);
-							HandleButton("WMouse M", false, ClientInputFocus.Mouse);
-							HandleButton("WMouse R", false, ClientInputFocus.Mouse);
-							HandleButton("WMouse 1", false, ClientInputFocus.Mouse);
-							HandleButton("WMouse 2", false, ClientInputFocus.Mouse);
-#endif
-						}
 					}
 
-					if (_newEvents.Count != 0)
-					{
-						//WHAT!? WE SHOULD NOT BE SO NAIVELY TOUCHING MAINFORM FROM THE INPUTTHREAD. ITS BUSY RUNNING.
-						AllowInput allowInput = MainFormInputAllowedCallback();
-
-						foreach (var ie in _newEvents)
-						{
-							//events are swallowed in some cases:
-							if (ie.EventType == InputEventType.Press && ShouldSwallow(allowInput, ie.Source))
-								continue;
-
-							EnqueueEvent(ie);
-						}
-					}
+					var mouseBtns = Control.MouseButtons;
+					HandleButton("WMouse L", (mouseBtns & MouseButtons.Left) != 0, HostInputType.Mouse);
+					HandleButton("WMouse M", (mouseBtns & MouseButtons.Middle) != 0, HostInputType.Mouse);
+					HandleButton("WMouse R", (mouseBtns & MouseButtons.Right) != 0, HostInputType.Mouse);
+					HandleButton("WMouse 1", (mouseBtns & MouseButtons.XButton1) != 0, HostInputType.Mouse);
+					HandleButton("WMouse 2", (mouseBtns & MouseButtons.XButton2) != 0, HostInputType.Mouse);
+					EnqueueNewEvents(prohibitInput: !wantsMouse);
 
 					_ignoreEventsNextPoll = false;
 				} //lock(this)


### PR DESCRIPTION
Someone more knowledgeable should test the Virtual Pad.

Holding alt allows the user to drag markers in TAStudio. When doing this, the menu bar would be focused after releasing alt. This fixes that by having `Input` not totally swallow input events, so the alt-handling code can know that a click happened. Instead they are passed through with a new `HostInputType` which `InputManager` checks for.

There was some disabled code in `Input.cs` that would have (if enabled) released all mouse buttons when a tool form is focused. Per the comment, doing this "will interfere with the virtualpad". I do not know in what way it was interfering. The updated code does allow mouse buttons to be released while a tool form is focused (but does not automatically release them when the tool form is focused). I do not know in what way it was interfering. I don't regularly use the virtual pad, but a basic test did not reveal any issues. The comment is over 10 years old so perhaps the issue no longer exists.