### PR TITLE
Allow redrawing Lua while multiple scripts are open

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/GuiApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/GuiApi.cs
@@ -142,7 +142,7 @@ namespace BizHawk.Client.Common
 
 		public void ClearGraphics(DisplaySurfaceID? surfaceID = null) => Get2DRenderer(surfaceID).Clear();
 
-		public void ClearText() => _displayManager.OSD.ClearGuiText();
+		public void ClearText() => _displayManager.OSD.ClearApiHawkText();
 
 		public void SetDefaultForegroundColor(Color color) => _defaultForeground = color;
 

--- a/src/BizHawk.Client.Common/Api/Classes/GuiApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/GuiApi.cs
@@ -140,9 +140,20 @@ namespace BizHawk.Client.Common
 		public void AddMessage(string message, [LiteralExpected] int? duration = null)
 			=> _dialogController.AddOnScreenMessage(message, duration);
 
-		public void ClearGraphics(DisplaySurfaceID? surfaceID = null) => Get2DRenderer(surfaceID).Clear();
+		public void ClearGraphics(DisplaySurfaceID? surfaceID = null) => LogCallback("the `ClearGraphics()` function has been deprecated; use `Draw()`\n");
 
-		public void ClearText() => _displayManager.OSD.ClearApiHawkText();
+		public void ClearText() => LogCallback("the `ClearText()` function has been deprecated; use `Draw()`\n");
+
+		public void Draw()
+		{
+			_displayManager.DiscardApiHawkSurfaces();
+			_displayManager.ClearApiHawkSurfaces();
+			_displayManager.OnDraw?.Invoke();
+		}
+
+		public void AddDrawCallback(Action callback) => _displayManager.OnDraw += callback;
+
+		public void RemoveDrawCallback(Action callback) => _displayManager.OnDraw -= callback;
 
 		public void SetDefaultForegroundColor(Color color) => _defaultForeground = color;
 

--- a/src/BizHawk.Client.Common/Api/Classes/GuiApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/GuiApi.cs
@@ -140,9 +140,15 @@ namespace BizHawk.Client.Common
 		public void AddMessage(string message, [LiteralExpected] int? duration = null)
 			=> _dialogController.AddOnScreenMessage(message, duration);
 
-		public void ClearGraphics(DisplaySurfaceID? surfaceID = null) => Get2DRenderer(surfaceID).Clear();
+		public void ClearGraphics(DisplaySurfaceID? surfaceID = null) => LogCallback("the `ClearGraphics()` function has been deprecated; use `Draw()`\n");
 
-		public void ClearText() => _displayManager.OSD.ClearApiHawkText();
+		public void ClearText() => LogCallback("the `ClearText()` function has been deprecated; use `Draw()`\n");
+
+		public void Draw() => _displayManager.DoApiRedraw();
+
+		public void AddDrawCallback(Action callback) => _displayManager.OnDraw += callback;
+
+		public void RemoveDrawCallback(Action callback) => _displayManager.OnDraw -= callback;
 
 		public void SetDefaultForegroundColor(Color color) => _defaultForeground = color;
 

--- a/src/BizHawk.Client.Common/Api/Interfaces/IGuiApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IGuiApi.cs
@@ -33,8 +33,24 @@ namespace BizHawk.Client.Common
 
 		void AddMessage(string message, int? duration = null);
 
+		[Obsolete("use Draw and AddDrawCallback instead")]
 		void ClearGraphics(DisplaySurfaceID? surfaceID = null);
+
+		[Obsolete("use Draw and AddDrawCallback instead")]
 		void ClearText();
+
+		/// <summary>
+		/// Clears all prior drawings and calls any actions given to <see cref="AddDrawCallback(Action)"/>.
+		/// This should only be used when you want to redraw while paused.
+		/// </summary>
+		void Draw();
+
+		/// <summary>
+		/// The given action will be called before each API draw. This means after each frame and any time <see cref="Draw"/> is called.
+		/// </summary>
+		void AddDrawCallback(Action callback);
+		void RemoveDrawCallback(Action callback);
+
 		void SetDefaultForegroundColor(Color color);
 		void SetDefaultBackgroundColor(Color color);
 		Color GetDefaultTextBackground();

--- a/src/BizHawk.Client.Common/DisplayManager/DisplayManagerBase.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/DisplayManagerBase.cs
@@ -51,6 +51,8 @@ namespace BizHawk.Client.Common
 
 		public SnowyNullVideo SnowyVP { get; private set; }
 
+		public Action/*?*/ OnDraw;
+
 		protected DisplayManagerBase(
 			Config config,
 			IEmulator emulator,

--- a/src/BizHawk.Client.Common/DisplayManager/DisplayManagerBase.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/DisplayManagerBase.cs
@@ -961,12 +961,16 @@ namespace BizHawk.Client.Common
 				? _apiHawkIDTo2DRenderer.GetValueOrPut(surfaceID, _ => _gl.Create2DRenderer(_imGuiResourceCache))
 				: throw new ArgumentOutOfRangeException(paramName: nameof(surfaceID), surfaceID, message: "invalid surface ID");
 
+		/// <summary>
+		/// Clear stuff drawn by the gui API
+		/// </summary>
 		public void ClearApiHawkSurfaces()
 		{
 			foreach (var renderer in _apiHawkIDTo2DRenderer.Values)
 			{
 				renderer.Clear();
 			}
+			OSD.ClearApiHawkText();
 		}
 
 		public void DiscardApiHawkSurfaces()

--- a/src/BizHawk.Client.Common/DisplayManager/DisplayManagerBase.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/DisplayManagerBase.cs
@@ -51,6 +51,8 @@ namespace BizHawk.Client.Common
 
 		public SnowyNullVideo SnowyVP { get; private set; }
 
+		public Action/*?*/ OnDraw;
+
 		protected DisplayManagerBase(
 			Config config,
 			IEmulator emulator,
@@ -971,6 +973,15 @@ namespace BizHawk.Client.Common
 				renderer.Clear();
 			}
 			OSD.ClearApiHawkText();
+		}
+
+		/// <summary>
+		/// Clear stuff drawn by the gui API and raise the draw event.
+		/// </summary>
+		public void DoApiRedraw()
+		{
+			ClearApiHawkSurfaces();
+			OnDraw?.Invoke();
 		}
 
 		public void DiscardApiHawkSurfaces()

--- a/src/BizHawk.Client.Common/DisplayManager/OSDManager.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/OSDManager.cs
@@ -120,7 +120,7 @@ namespace BizHawk.Client.Common
 			});
 		}
 
-		public void ClearGuiText()
+		public void ClearApiHawkText()
 			=> _guiTextList.Clear();
 
 		private void DrawMessage(IBlitter g, UIMessage message, int yOffset)

--- a/src/BizHawk.Client.Common/lua/NamedLuaFunction.cs
+++ b/src/BizHawk.Client.Common/lua/NamedLuaFunction.cs
@@ -28,6 +28,8 @@ namespace BizHawk.Client.Common
 
 		public const string EVENT_TYPE_FUTURE = "BeforeFutureFrame";
 
+		public const string EVENT_TYPE_DRAW = "OnDraw";
+
 		private readonly LuaFunction _function;
 
 		private readonly ILuaLibraries _luaImp;

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2936,7 +2936,7 @@ namespace BizHawk.Client.EmuHawk
 				_lastFastForwardingOrRewinding = isFastForwardingOrRewinding;
 
 				// Clear stuff previously drawn by gui API
-				OSD.ClearGuiText();
+				DisplayManager.ClearApiHawkSurfaces();
 
 				CheatList.Pulse();
 
@@ -4098,7 +4098,7 @@ namespace BizHawk.Client.EmuHawk
 				return false;
 			}
 
-			OSD.ClearGuiText();
+			DisplayManager.ClearApiHawkSurfaces();
 			if (SavestateLoaded is not null)
 			{
 				StateLoadedEventArgs args = new(userFriendlyStateName);

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2935,7 +2935,7 @@ namespace BizHawk.Client.EmuHawk
 
 				_lastFastForwardingOrRewinding = isFastForwardingOrRewinding;
 
-				// client input-related duties
+				// Clear stuff previously drawn by gui API
 				OSD.ClearGuiText();
 
 				CheatList.Pulse();

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3055,6 +3055,7 @@ namespace BizHawk.Client.EmuHawk
 						UpdateToolsAfter();
 					}
 				}
+				DisplayManager.OnDraw?.Invoke();
 
 				if (newFrame)
 				{

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2919,7 +2919,7 @@ namespace BizHawk.Client.EmuHawk
 				_lastFastForwardingOrRewinding = isFastForwardingOrRewinding;
 
 				// Clear stuff previously drawn by gui API
-				OSD.ClearGuiText();
+				DisplayManager.ClearApiHawkSurfaces();
 
 				CheatList.Pulse();
 
@@ -4080,7 +4080,7 @@ namespace BizHawk.Client.EmuHawk
 				return false;
 			}
 
-			OSD.ClearGuiText();
+			DisplayManager.ClearApiHawkSurfaces();
 			if (SavestateLoaded is not null)
 			{
 				StateLoadedEventArgs args = new(userFriendlyStateName);

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3033,6 +3033,7 @@ namespace BizHawk.Client.EmuHawk
 				{
 					UpdateToolsAfter();
 				}
+				DisplayManager.OnDraw?.Invoke();
 
 				if (newFrame)
 				{

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2918,7 +2918,7 @@ namespace BizHawk.Client.EmuHawk
 
 				_lastFastForwardingOrRewinding = isFastForwardingOrRewinding;
 
-				// client input-related duties
+				// Clear stuff previously drawn by gui API
 				OSD.ClearGuiText();
 
 				CheatList.Pulse();

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -4096,6 +4096,8 @@ namespace BizHawk.Client.EmuHawk
 			UpdateToolsLoadstate();
 			InputManager.AutoFireController.ClearStarts();
 
+			DisplayManager.OnDraw?.Invoke(); // not DoApiRedraw, so scripts drawing in the savestate load event still work
+
 			//we don't want to analyze how to intermix movies, rewinding, and states
 			//so purge rewind history when loading a state while doing a movie
 			if (ToolControllingRewind is null && MovieSession.Movie.IsActive())

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/GuiLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/GuiLuaLibrary.cs
@@ -6,9 +6,11 @@ using NLua;
 
 namespace BizHawk.Client.EmuHawk
 {
-	public sealed class GuiLuaLibrary : LuaLibraryBase, IDisposable
+	public sealed class GuiLuaLibrary : LuaLibraryBase, IDisposable, IRegisterFunctions
 	{
 		private DisplaySurfaceID _rememberedSurfaceID = DisplaySurfaceID.EmuCore;
+
+		public NLFAddCallback CreateAndRegisterNamedFunction { get; set; }
 
 		public GuiLuaLibrary(ILuaLibraries luaLibsImpl, ApiContainer apiContainer, Action<string> logOutputCallback)
 			: base(luaLibsImpl, apiContainer, logOutputCallback) {}
@@ -37,15 +39,36 @@ namespace BizHawk.Client.EmuHawk
 		public void AddMessage(string message)
 			=> APIs.Gui.AddMessage(message);
 
-		[LuaMethodExample("gui.clearGraphics( );")]
+#pragma warning disable CS0618
+		[LuaDeprecatedMethod]
 		[LuaMethod("clearGraphics", "clears all lua drawn graphics from the screen")]
 		public void ClearGraphics(string surfaceName = null)
 			=> APIs.Gui.ClearGraphics(surfaceID: UseOrFallback(surfaceName));
 
-		[LuaMethodExample("gui.cleartext( );")]
+		[LuaDeprecatedMethod]
 		[LuaMethod("cleartext", "clears all text created by gui.text()")]
 		public void ClearText()
 			=> APIs.Gui.ClearText();
+#pragma warning restore CS0618
+
+		[LuaMethodExample("gui.draw();")]
+		[LuaMethod("draw", "Clears all prior drawings and calls any functions given to gui.addDrawCallback. Use this to re-draw while paused.")]
+		public void Draw()
+		{
+			APIs.Gui.Draw();
+		}
+
+		[LuaMethodExample("local draw_cb_id = gui.addDrawCallback(\r\n\tfunction()\r\n\t\t-- gui.draw*** calls go here\r\n\tend);")]
+		[LuaMethod("addDrawCallback", "The given function will be called before each API draw. This means after each frame and any time gui.draw is called.")]
+		public string AddDrawCallback(LuaFunction luaf, string name = null)
+		{
+			INamedLuaFunction nlf = CreateAndRegisterNamedFunction(luaf, NamedLuaFunction.EVENT_TYPE_DRAW, ApiGroup.PROHIBITED_MID_FRAME, name);
+			Action callback = () => nlf.Call();
+			APIs.Gui.AddDrawCallback(callback);
+			nlf.OnRemove += () => APIs.Gui.RemoveDrawCallback(callback);
+
+			return nlf.GuidStr;
+		}
 
 		[LuaMethodExample("gui.defaultForeground( 0x000000FF );")]
 		[LuaMethod("defaultForeground", "Sets the default foreground color to use in drawing methods, white by default")]

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -146,7 +146,6 @@ namespace BizHawk.Client.EmuHawk
 					ResetDrawSurfacePadding();
 					ClearFileWatches();
 					LuaImp?.Close();
-					DisplayManager.OSD.ClearGuiText();
 				}
 				else
 				{
@@ -978,7 +977,6 @@ namespace BizHawk.Client.EmuHawk
 				UpdateDialog();
 				DisplayManager.ClearApiHawkSurfaces();
 				DisplayManager.ClearApiHawkTextureCache();
-				DisplayManager.OSD.ClearGuiText();
 				if (!_openedFiles.Any(static lf => !lf.IsSeparator)) ResetDrawSurfacePadding(); // just removed last script, reset padding
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -144,7 +144,8 @@ namespace BizHawk.Client.EmuHawk
 				{
 					Settings.Columns = LuaListView.AllColumns;
 
-					DisplayManager.ClearApiHawkSurfaces();
+					_openedFiles.StopAllScripts();
+					DisplayManager.DoApiRedraw();
 					DisplayManager.ClearApiHawkTextureCache();
 					ResetDrawSurfacePadding();
 					ClearFileWatches();
@@ -1003,7 +1004,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 
 				UpdateDialog();
-				DisplayManager.ClearApiHawkSurfaces();
+				DisplayManager.DoApiRedraw();
 				DisplayManager.ClearApiHawkTextureCache();
 				if (!_openedFiles.Any(static lf => !lf.IsSeparator)) ResetDrawSurfacePadding(); // just removed last script, reset padding
 			}
@@ -1511,7 +1512,8 @@ namespace BizHawk.Client.EmuHawk
 
 		private void EraseToolbarItem_Click(object sender, EventArgs e)
 		{
-			DisplayManager.ClearApiHawkSurfaces();
+			// tooltip says this is specifically for "stale" or "stuck" stuff
+			DisplayManager.DoApiRedraw();
 		}
 
 		// Stupid designer

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -149,7 +149,6 @@ namespace BizHawk.Client.EmuHawk
 					ResetDrawSurfacePadding();
 					ClearFileWatches();
 					LuaImp?.Close();
-					DisplayManager.OSD.ClearGuiText();
 				}
 				else
 				{
@@ -1006,7 +1005,6 @@ namespace BizHawk.Client.EmuHawk
 				UpdateDialog();
 				DisplayManager.ClearApiHawkSurfaces();
 				DisplayManager.ClearApiHawkTextureCache();
-				DisplayManager.OSD.ClearGuiText();
 				if (!_openedFiles.Any(static lf => !lf.IsSeparator)) ResetDrawSurfacePadding(); // just removed last script, reset padding
 			}
 		}


### PR DESCRIPTION
Currently if a Lua script wants to re-draw it has to do one or more of:
```
gui.clearGraphics("client")
gui.clearGraphics("emucore")
gui.cleartext()
```
and then draw it's stuff. But this clears everything drawn by other scripts as well, without giving them an opportunity to re-draw.

Having multiple Lua scripts that draw was also made difficult by the fact that some things that Lua draws weren't being cleared on each new frame. This means if any Lua script wants to clear what it drew, it must call `clearGraphics` which again can interfere with other scripts.

So this PR does two things:
1) Make it so that all things drawn by the Gui API are cleared at the start of each frame. (previously it only cleared things done with `DrawString`, which makes no sense)
2) Replace the various clear*** Lua methods with an OnDraw event and a method that raises it.

EDIT: This now also updates other causes of clearing to also call the new draw event.

A Lua script can now do something like:
```
function onDraw()
	gui.text(30, 50, emu.framecount())
end
gui.addDrawCallback(onDraw)
```
and another script can call `gui.draw()` to clear its drawings. The `gui.draw` call will end up calling the first Lua's `onDraw` function so that it isn't affected by the second script's wanting to clear.

We could also make it so that the Lua Console calls `IGuiApi.Draw` when a script is stopped. But this should happen only if the user manually stops it, since a Lua script may want to just draw once and exit, leaving the drawings on screen until the next frame.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant