### PR TITLE
refactor: migrate first batch of Forms to FormBase

### DIFF
--- a/src/BizHawk.Client.EmuHawk/AVOut/FFmpegWriterForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/FFmpegWriterForm.Designer.cs
@@ -136,7 +136,6 @@
             this.Name = "FFmpegWriterForm";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Choose Video Format";
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/src/BizHawk.Client.EmuHawk/AVOut/FFmpegWriterForm.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/FFmpegWriterForm.cs
@@ -7,7 +7,7 @@ namespace BizHawk.Client.EmuHawk
 	/// <summary>
 	/// configures the FFmpegWriter
 	/// </summary>
-	public partial class FFmpegWriterForm : Form
+	public partial class FFmpegWriterForm : FormBase
 	{
 		/// <summary>
 		/// stores a single format preset

--- a/src/BizHawk.Client.EmuHawk/AVOut/FFmpegWriterForm.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/FFmpegWriterForm.cs
@@ -9,6 +9,8 @@ namespace BizHawk.Client.EmuHawk
 	/// </summary>
 	public partial class FFmpegWriterForm : FormBase
 	{
+		protected override string WindowTitleStatic => "Choose Video Format";
+
 		/// <summary>
 		/// stores a single format preset
 		/// </summary>

--- a/src/BizHawk.Client.EmuHawk/AVOut/GifWriterForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/GifWriterForm.Designer.cs
@@ -121,7 +121,6 @@
             this.Name = "GifWriterForm";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "GIF Writer Options";
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).EndInit();
             this.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/AVOut/GifWriterForm.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/GifWriterForm.cs
@@ -5,6 +5,8 @@ namespace BizHawk.Client.EmuHawk
 {
 	public partial class GifWriterForm : FormBase
 	{
+		protected override string WindowTitleStatic => "GIF Writer Options";
+
 		public GifWriterForm()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/AVOut/GifWriterForm.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/GifWriterForm.cs
@@ -3,7 +3,7 @@ using BizHawk.Client.Common;
 
 namespace BizHawk.Client.EmuHawk
 {
-	public partial class GifWriterForm : Form
+	public partial class GifWriterForm : FormBase
 	{
 		public GifWriterForm()
 		{

--- a/src/BizHawk.Client.EmuHawk/AVOut/JMDForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/JMDForm.Designer.cs
@@ -138,7 +138,6 @@
             this.Name = "JmdForm";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "JMD Compression Options";
             ((System.ComponentModel.ISupportInitialize)(this.threadsBar)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.compressionBar)).EndInit();
             this.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/AVOut/JMDForm.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/JMDForm.cs
@@ -7,6 +7,8 @@ namespace BizHawk.Client.EmuHawk
 	/// </summary>
 	public partial class JmdForm : FormBase
 	{
+		protected override string WindowTitleStatic => "JMD Compression Options";
+
 		public JmdForm()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/AVOut/JMDForm.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/JMDForm.cs
@@ -5,7 +5,7 @@ namespace BizHawk.Client.EmuHawk
 	/// <summary>
 	/// implements a minimal dialog for configuring JMDWriter
 	/// </summary>
-	public partial class JmdForm : Form
+	public partial class JmdForm : FormBase
 	{
 		public JmdForm()
 		{

--- a/src/BizHawk.Client.EmuHawk/AVOut/SynclessRecordingTools.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/SynclessRecordingTools.Designer.cs
@@ -51,7 +51,6 @@
 			this.MaximizeBox = false;
 			this.MinimizeBox = false;
 			this.Name = "SynclessRecordingTools";
-			this.Text = "Syncless Recording";
 			this.ResumeLayout(false);
 
 		}

--- a/src/BizHawk.Client.EmuHawk/AVOut/SynclessRecordingTools.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/SynclessRecordingTools.cs
@@ -12,6 +12,8 @@ namespace BizHawk.Client.EmuHawk
 {
 	public partial class SynclessRecordingTools : FormBase, IDialogParent
 	{
+		protected override string WindowTitleStatic => "Syncless Recording";
+
 		private readonly Config _config;
 
 		private readonly IGameInfo _game;

--- a/src/BizHawk.Client.EmuHawk/AVOut/SynclessRecordingTools.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/SynclessRecordingTools.cs
@@ -10,7 +10,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.EmuHawk
 {
-	public partial class SynclessRecordingTools : Form, IDialogParent
+	public partial class SynclessRecordingTools : FormBase, IDialogParent
 	{
 		private readonly Config _config;
 

--- a/src/BizHawk.Client.EmuHawk/ArchiveChooser.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/ArchiveChooser.Designer.cs
@@ -225,7 +225,6 @@
 			this.Name = "ArchiveChooser";
 			this.ShowIcon = false;
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Choose File From Archive";
 			this.Load += new System.EventHandler(this.ArchiveChooser_Load);
 			this.flowLayoutPanel1.ResumeLayout(false);
 			this.tableLayoutPanel1.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/ArchiveChooser.cs
+++ b/src/BizHawk.Client.EmuHawk/ArchiveChooser.cs
@@ -11,6 +11,8 @@ namespace BizHawk.Client.EmuHawk
 {
 	public partial class ArchiveChooser : FormBase
 	{
+		protected override string WindowTitleStatic => "Choose File From Archive";
+
 		private readonly IList<ListViewItem> _archiveItems = new List<ListViewItem>();
 		private readonly ToolTip _errorBalloon = new ToolTip();
 

--- a/src/BizHawk.Client.EmuHawk/ArchiveChooser.cs
+++ b/src/BizHawk.Client.EmuHawk/ArchiveChooser.cs
@@ -9,7 +9,7 @@ using BizHawk.Common.StringExtensions;
 
 namespace BizHawk.Client.EmuHawk
 {
-	public partial class ArchiveChooser : Form
+	public partial class ArchiveChooser : FormBase
 	{
 		private readonly IList<ListViewItem> _archiveItems = new List<ListViewItem>();
 		private readonly ToolTip _errorBalloon = new ToolTip();

--- a/src/BizHawk.Client.EmuHawk/config/AutofireConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/AutofireConfig.Designer.cs
@@ -146,7 +146,6 @@
 			this.MinimumSize = new System.Drawing.Size(339, 129);
 			this.Name = "AutofireConfig";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Autofire Configuration";
 			this.Load += new System.EventHandler(this.AutofireConfig_Load);
 			((System.ComponentModel.ISupportInitialize)(this.nudPatternOn)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.nudPatternOff)).EndInit();

--- a/src/BizHawk.Client.EmuHawk/config/AutofireConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/AutofireConfig.cs
@@ -5,6 +5,8 @@ namespace BizHawk.Client.EmuHawk
 {
 	public partial class AutofireConfig : FormBase
 	{
+		protected override string WindowTitleStatic => "Autofire Configuration";
+
 		private readonly Config _config;
 		private readonly AutofireController _autoFireController;
 		private readonly StickyAutofireController _stickyAutofireController;

--- a/src/BizHawk.Client.EmuHawk/config/AutofireConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/AutofireConfig.cs
@@ -3,7 +3,7 @@ using BizHawk.Client.Common;
 
 namespace BizHawk.Client.EmuHawk
 {
-	public partial class AutofireConfig : Form
+	public partial class AutofireConfig : FormBase
 	{
 		private readonly Config _config;
 		private readonly AutofireController _autoFireController;

--- a/src/BizHawk.Client.EmuHawk/config/ControllerConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/ControllerConfig.Designer.cs
@@ -282,7 +282,6 @@
 			this.MinimumSize = new System.Drawing.Size(948, 611);
 			this.Name = "ControllerConfig";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Controller Config";
 			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ControllerConfig_FormClosed);
 			this.Load += new System.EventHandler(this.ControllerConfig_Load);
 			this.tabControl1.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
@@ -14,6 +14,8 @@ namespace BizHawk.Client.EmuHawk
 {
 	public partial class ControllerConfig : FormBase, IDialogParent
 	{
+		protected override string WindowTitleStatic => "Controller Config";
+
 		private static readonly Dictionary<string, Lazy<Bitmap>> ControllerImages = new Dictionary<string, Lazy<Bitmap>>();
 		private readonly IEmulator _emulator;
 		private readonly Config _config;

--- a/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
@@ -12,7 +12,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.EmuHawk
 {
-	public partial class ControllerConfig : Form, IDialogParent
+	public partial class ControllerConfig : FormBase, IDialogParent
 	{
 		private static readonly Dictionary<string, Lazy<Bitmap>> ControllerImages = new Dictionary<string, Lazy<Bitmap>>();
 		private readonly IEmulator _emulator;


### PR DESCRIPTION
Migrated 7 forms from `Form` to `FormBase` as tracked in #4005:

- `ArchiveChooser`
- `FFmpegWriterForm`
- `GifWriterForm`
- `JmdForm`
- `SynclessRecordingTools`
- `AutofireConfig`
- `ControllerConfig`

Each change is a one-line base class swap. The remaining forms from the checklist can follow in subsequent PRs.

Partial fix for #4005