### PR TITLE
Discard API draw list when not drawing

### DIFF
--- a/src/BizHawk.Client.Common/DisplayManager/DisplayManagerBase.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/DisplayManagerBase.cs
@@ -765,6 +765,8 @@ namespace BizHawk.Client.Common
 						job.OffscreenBb = new(new(1, 1));
 					}
 
+					DiscardApiHawkSurfaces();
+
 					return null;
 				}
 			}
@@ -883,6 +885,7 @@ namespace BizHawk.Client.Common
 			_gl.BindDefaultRenderTarget();
 			_gl.ClearColor(Color.Black);
 			SwapBuffersOfGraphicsControl();
+			DiscardApiHawkSurfaces();
 		}
 
 		protected virtual void UpdateSourceDrawingWork(JobInfo job)


### PR DESCRIPTION
Discard the Lua/API ImGui draw command list when rendering is skipped (particularly when the window is minimized). Resolves #4486.

I did [what CasualPokePlayer suggested](https://github.com/TASEmulators/BizHawk/issues/4486#issuecomment-3368697426) and it has resolved the issue described in #4486. Everything seems to work, but to be honest I have no understanding of the render process.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
