### PR TITLE
Handle mouse buttons when the active form changes

### DIFF
--- a/src/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/src/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -23,6 +23,8 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		private readonly HashSet<Control> _wantingMouseFocus = new HashSet<Control>();
+		private bool _wantsMouse;
+		private Control/*?*/ _lastControl;
 
 #pragma warning disable CA2211 // public field
 		public static Input Instance;
@@ -244,8 +246,22 @@ namespace BizHawk.Client.EmuHawk
 					EnqueueNewEvents();
 
 					// analyze moose
-					bool wantsMouse = _wantingMouseFocus.Contains(Form.ActiveForm);
-					if (wantsMouse)
+					Control/*?*/ activeForm = Form.ActiveForm;
+					bool newWantsMouse = _wantingMouseFocus.Contains(activeForm);
+					if (activeForm != _lastControl && !_wantsMouse && newWantsMouse)
+					{
+						// We set our internal state to unpress all mouse buttons, so any pressed buttons can get new events for the newly active form.
+						HandleButton("WMouse L", false, HostInputType.Mouse);
+						HandleButton("WMouse M", false, HostInputType.Mouse);
+						HandleButton("WMouse R", false, HostInputType.Mouse);
+						HandleButton("WMouse 1", false, HostInputType.Mouse);
+						HandleButton("WMouse 2", false, HostInputType.Mouse);
+						EnqueueNewEvents(prohibitInput: !_wantsMouse); // if any unpress event were generated, process them even though they probably do nothing
+					}
+					_lastControl = activeForm;
+					_wantsMouse = newWantsMouse;
+
+					if (_wantsMouse)
 					{
 						lock (_axisValues)
 						{
@@ -275,7 +291,7 @@ namespace BizHawk.Client.EmuHawk
 					HandleButton("WMouse R", (mouseBtns & MouseButtons.Right) != 0, HostInputType.Mouse);
 					HandleButton("WMouse 1", (mouseBtns & MouseButtons.XButton1) != 0, HostInputType.Mouse);
 					HandleButton("WMouse 2", (mouseBtns & MouseButtons.XButton2) != 0, HostInputType.Mouse);
-					EnqueueNewEvents(prohibitInput: !wantsMouse);
+					EnqueueNewEvents(prohibitInput: !_wantsMouse);
 
 					_ignoreEventsNextPoll = false;
 				} //lock(this)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -865,6 +865,8 @@ namespace BizHawk.Client.EmuHawk
 #endif
 				}
 			}
+
+			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, true);
 		}
 
 		private void CheckMayCloseAndCleanup(object/*?*/ closingSender, CancelEventArgs closingArgs)
@@ -896,6 +898,8 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 			Tools.Close();
+
+			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, false);
 		}
 
 		private readonly bool _suppressSyncSettingsWarning;
@@ -1286,7 +1290,6 @@ namespace BizHawk.Client.EmuHawk
 		protected override void OnActivated(EventArgs e)
 		{
 			base.OnActivated(e);
-			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, true);
 
 			if (Config.CaptureMouse)
 			{
@@ -1297,8 +1300,6 @@ namespace BizHawk.Client.EmuHawk
 
 		protected override void OnDeactivate(EventArgs e)
 		{
-			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, false);
-
 			if (Config.CaptureMouse)
 			{
 				CaptureMouse(false);

--- a/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
@@ -56,27 +56,17 @@ namespace BizHawk.Client.EmuHawk
 			ControllerImages.Add("Amiga Controller", Properties.Resources.AmigaKeyboard);
 		}
 
-		protected override void OnActivated(EventArgs e)
-		{
-			base.OnActivated(e);
-			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, true);
-		}
-
-		protected override void OnDeactivate(EventArgs e)
-		{
-			base.OnDeactivate(e);
-			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, false);
-		}
-
 		private void ControllerConfig_Load(object sender, EventArgs e)
 		{
 			Icon = Properties.Resources.GameControllerIcon;
 			Text = $"{_emulator.ControllerDefinition.Name} Configuration";
+			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, true);
 		}
 
 		private void ControllerConfig_FormClosed(object sender, FormClosedEventArgs e)
 		{
 			Input.Instance.ClearEvents();
+			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, false);
 		}
 
 		private delegate Control PanelCreator<TBindValue>(Dictionary<string, TBindValue> settings, List<string> buttons, Size size);

--- a/src/BizHawk.Client.EmuHawk/config/HotkeyConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/HotkeyConfig.cs
@@ -20,18 +20,8 @@ namespace BizHawk.Client.EmuHawk
 			InitializeComponent();
 			Icon = Properties.Resources.HotKeysIcon;
 			tabPage1.Select();
-		}
 
-		protected override void OnActivated(EventArgs e)
-		{
-			base.OnActivated(e);
 			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, true);
-		}
-
-		protected override void OnDeactivate(EventArgs e)
-		{
-			base.OnDeactivate(e);
-			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, false);
 		}
 
 		private void HotkeyConfig_Load(object sender, EventArgs e)
@@ -50,6 +40,7 @@ namespace BizHawk.Client.EmuHawk
 		private void HotkeyConfig_FormClosed(object sender, FormClosedEventArgs e)
 		{
 			Input.Instance.ClearEvents();
+			Input.Instance.ControlInputFocus(this, HostInputType.Mouse, false);
 		}
 
 		private void IDB_CANCEL_Click(object sender, EventArgs e)


### PR DESCRIPTION
Before [3eb9cb9](https://github.com/TASEmulators/BizHawk/commit/3eb9cb9d765bfca829ea66bb514fb125bca90377) the state of mouse buttons was not checked by `Input` when the active form did not "want mouse" (meaning, clicking on that form should not result in controller inputs being pressed or hotkeys being triggered). After, they are checked and so no non-"ignored" mouse input event would be generated if you click on the main form when TAStudio was active.

This PR fixes that by having `Input` detect when the active form changes, and then clears its mouse state and generates new mouse events. This only happens when moving from a non-mouse-wanting form to a mouse-wanting form, which seems consistent with the behavior of 2.11 but might not be ideal. This is because clicking on TAStudio while the main form is active will result in a mouse input most of the time; `Input` sees the mouse button being pressed before `Form.ActiveForm` changes. If we clear mouse state and generate new events going the other way too then any controller inputs bound to the mouse button will be quickly released after `ActiveForm` changes, but the inputs will still happen. But even with this issue, this is an improvement over 2.11. In 2.11 if you click on TAStudio while the main form is active, any controller input bound to the mouse button will be pressed and will not be released when the mouse button is released. Now, it will be released when the mouse button is released.

I also had to change call sites of `Input.ControlInputFocus`, which previously was being called in forms' `OnActivated` and `OnDeactivate` methods. This doesn't make any sense to me, since the call to `Input.ControlInputFocus` in `OnDeactivate` is not required; mouse inputs won't happen when the form is active because `Input` checks which form is active. EDIT: It had to be changed because if the form does not remain in the wanting-mouse state, `Input` may see it does not want mouse (because `ControlInputFocus` had not yet been called in `OnActivated`) and thus not produce new mouse events when the active form switches. It's a race condition.

Please test, @RetroEdit.

Fixes #4717 

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
