### PR TITLE
Turbo fix

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1121,15 +1121,8 @@ namespace BizHawk.Client.EmuHawk
 
 			set
 			{
-				bool wasTurboSeeking = IsTurboSeeking;
 				_pauseOnFrame = value;
 				SetPauseStatusBarIcon();
-
-				if (wasTurboSeeking && value == null) // TODO: make an Event handler instead, but the logic here is that after turbo seeking, tools will want to do a real update when the emulator finally pauses
-				{
-					// Tools.UpdateToolsBefore(); // TODO: do we need this?
-					Tools.UpdateToolsAfter();
-				}
 			}
 		}
 
@@ -2932,6 +2925,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				var isFastForwarding = IsFastForwarding;
 				var isFastForwardingOrRewinding = isFastForwarding || isRewinding || Config.Unthrottled;
+				bool atTurboSeekEnd = IsTurboSeeking && Emulator.Frame == PauseOnFrame.Value - 1;
 
 				if (isFastForwardingOrRewinding != _lastFastForwardingOrRewinding)
 				{
@@ -2949,7 +2943,7 @@ namespace BizHawk.Client.EmuHawk
 				InputManager.ClickyVirtualPadController.FrameTick();
 				InputManager.ButtonOverrideAdapter.FrameTick();
 
-				if (IsTurboing)
+				if (IsTurboing && !atTurboSeekEnd)
 				{
 					Tools.FastUpdateBefore();
 				}
@@ -3019,7 +3013,6 @@ namespace BizHawk.Client.EmuHawk
 					atten = 0;
 				}
 
-				bool atTurboSeekEnd = IsTurboSeeking && Emulator.Frame == PauseOnFrame.Value - 1;
 				bool render = !_throttle.skipNextFrame || _currAviWriter?.UsesVideo is true || atTurboSeekEnd;
 				bool newFrame = Emulator.FrameAdvance(InputManager.ControllerOutput, render, renderSound);
 
@@ -3048,17 +3041,13 @@ namespace BizHawk.Client.EmuHawk
 
 				PressFrameAdvance = false;
 
-				// Update tools, but not if we're at the end of a turbo seek. In that case, updating will happen later when the seek is ended.
-				if (!atTurboSeekEnd)
+				if (IsTurboing && !atTurboSeekEnd)
 				{
-					if (IsTurboing)
-					{
-						Tools.FastUpdateAfter();
-					}
-					else
-					{
-						UpdateToolsAfter();
-					}
+					Tools.FastUpdateAfter();
+				}
+				else
+				{
+					UpdateToolsAfter();
 				}
 
 				if (newFrame)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
@@ -79,7 +79,7 @@
 			WheelSeek(rewindStep);
 			// we need a frame advance if a state was loaded (frame has changed)
 			// and also we are seeking (not already at the target frame)
-			return Emulator.Frame != frame && _seekingTo != -1;
+			return Emulator.Frame != frame && SeekingTo != -1;
 		}
 
 		public bool WantsToControlRestartMovie { get; }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IToolForm.cs
@@ -25,10 +25,10 @@ namespace BizHawk.Client.EmuHawk
 
 		private void UpdateProgressBar()
 		{
-			if (_seekingTo != -1)
+			if (SeekingTo != -1)
 			{
 				int diff = Emulator.Frame - _seekStartFrame;
-				int unit = _seekingTo - _seekStartFrame;
+				int unit = SeekingTo - _seekStartFrame;
 				double progress = 0;
 
 				if (diff != 0 && unit != 0)
@@ -92,7 +92,7 @@ namespace BizHawk.Client.EmuHawk
 			CurrentTasMovie.TasSession.UpdateValues(Emulator.Frame, CurrentTasMovie.Branches.Current);
 			MaybeFollowCursor();
 
-			if (Settings.AutoPause && _seekingTo == -1)
+			if (Settings.AutoPause && SeekingTo == -1)
 			{
 				if (_doPause && CurrentTasMovie.IsAtEnd()) MainForm.PauseEmulator();
 				_doPause = !CurrentTasMovie.IsAtEnd();
@@ -109,7 +109,7 @@ namespace BizHawk.Client.EmuHawk
 
 		protected override void FastUpdateAfter()
 		{
-			if (_seekingTo != -1 && Emulator.Frame >= _seekingTo)
+			if (SeekingTo != -1 && Emulator.Frame >= SeekingTo)
 			{
 				bool smga = _shouldMoveGreenArrow;
 				StopSeeking();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -108,6 +108,14 @@ namespace BizHawk.Client.EmuHawk
 			_shouldMoveGreenArrow = true;
 			if (_seekingTo == -1) return;
 
+			if (Config.TurboSeek && Emulator.Frame < _seekingTo)
+			{
+				// Turbo seek does various things, including telling the core to skip rendering most frames.
+				// Thus, we need the seek to end naturally.
+				_seekingTo = Emulator.Frame + 1;
+				return;
+			}
+
 			if (WasRecording && !skipRecModeCheck)
 			{
 				TastudioRecordMode();
@@ -116,7 +124,6 @@ namespace BizHawk.Client.EmuHawk
 
 			_seekingByEdit = false;
 			_seekingTo = -1;
-			MainForm.PauseOnFrame = null; // This being unset is how MainForm knows we are not seeking, and controls TurboSeek.
 			if (_pauseAfterSeeking)
 			{
 				MainForm.PauseEmulator();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -106,7 +106,7 @@ namespace BizHawk.Client.EmuHawk
 		public void StopSeeking(bool skipRecModeCheck = false)
 		{
 			_shouldMoveGreenArrow = true;
-			if (_seekingTo == -1) return;
+			if (SeekingTo == -1) return;
 
 			if (WasRecording && !skipRecModeCheck)
 			{
@@ -115,7 +115,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			_seekingByEdit = false;
-			_seekingTo = -1;
+			SeekingTo = -1;
 			if (_pauseAfterSeeking)
 			{
 				MainForm.PauseEmulator();
@@ -371,7 +371,7 @@ namespace BizHawk.Client.EmuHawk
 
 				if (index == Emulator.Frame)
 				{
-					bitmap = index == _seekingTo
+					bitmap = index == SeekingTo
 						? sender.HorizontalOrientation ? ts_v_arrow_green_blue : ts_h_arrow_green_blue
 						: sender.HorizontalOrientation ? ts_v_arrow_blue : ts_h_arrow_blue;
 				}
@@ -456,11 +456,11 @@ namespace BizHawk.Client.EmuHawk
 
 			var record = CurrentTasMovie[index];
 
-			if (_seekingTo == index)
+			if (SeekingTo == index)
 			{
 				color = Palette.CurrentFrame_InputLog;
 			}
-			else if (_seekingTo == -1 && Emulator.Frame == index)
+			else if (SeekingTo == -1 && Emulator.Frame == index)
 			{
 				color = Palette.CurrentFrame_InputLog;
 			}
@@ -770,7 +770,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				if (MainForm.EmulatorPaused)
 				{
-					if (_seekingTo != -1)
+					if (SeekingTo != -1)
 					{
 						MainForm.UnpauseEmulator(); // resume seek
 						return;
@@ -1065,7 +1065,7 @@ namespace BizHawk.Client.EmuHawk
 				{
 					if (_shouldMoveGreenArrow)
 					{
-						RestorePositionFrame = _seekingTo != -1 ? _seekingTo : Emulator.Frame;
+						RestorePositionFrame = SeekingTo != -1 ? SeekingTo : Emulator.Frame;
 					}
 
 					GoToFrame(frame);
@@ -1203,14 +1203,14 @@ namespace BizHawk.Client.EmuHawk
 
 		private void WheelSeek(int count)
 		{
-			if (_seekingTo != -1)
+			if (SeekingTo != -1)
 			{
 				_shouldMoveGreenArrow = true;
-				_seekingTo = Math.Max(_seekingTo - count, 0);
+				SeekingTo = Math.Max(SeekingTo - count, 0);
 
-				if (count > 0 && Emulator.Frame >= _seekingTo)
+				if (count > 0 && Emulator.Frame >= SeekingTo)
 				{
-					GoToFrame(_seekingTo);
+					GoToFrame(SeekingTo);
 				}
 
 				RefreshDialog();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -108,14 +108,6 @@ namespace BizHawk.Client.EmuHawk
 			_shouldMoveGreenArrow = true;
 			if (_seekingTo == -1) return;
 
-			if (Config.TurboSeek && Emulator.Frame < _seekingTo)
-			{
-				// Turbo seek does various things, including telling the core to skip rendering most frames.
-				// Thus, we need the seek to end naturally.
-				_seekingTo = Emulator.Frame + 1;
-				return;
-			}
-
 			if (WasRecording && !skipRecModeCheck)
 			{
 				TastudioRecordMode();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -1038,7 +1038,7 @@ namespace BizHawk.Client.EmuHawk
 
 			StartFromNowSeparator.Visible = StartNewProjectFromNowMenuItem.Visible || StartANewProjectFromSaveRamMenuItem.Visible;
 			RemoveMarkersContextMenuItem.Enabled = CurrentTasMovie.Markers.Any(m => IsRowSelected(m.Frame)); // Disable the option to remove markers if no markers are selected (FCEUX does this).
-			CancelSeekContextMenuItem.Enabled = _seekingTo != -1;
+			CancelSeekContextMenuItem.Enabled = SeekingTo != -1;
 			BranchContextMenuItem.Visible = CurrentCell?.RowIndex == Emulator.Frame;
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
@@ -38,7 +38,6 @@ namespace BizHawk.Client.EmuHawk
 				_seekingByEdit = false;
 
 				_seekingTo = frame;
-				MainForm.PauseOnFrame = int.MaxValue; // This being set is how MainForm knows we are seeking, and controls TurboSeek.
 				MainForm.UnpauseEmulator();
 
 				if (_seekingTo - _seekStartFrame > 1)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
@@ -21,7 +21,7 @@ namespace BizHawk.Client.EmuHawk
 			// what is the significance of a seek to frame if we don't pause?
 			// Answer: We use this in order to temporarily disable recording mode when the user navigates to a frame. (to avoid recording between whatever is the most recent state and the user-specified frame)
 			// Other answer: turbo seek, navigating while unpaused
-			_pauseAfterSeeking = MainForm.EmulatorPaused || (_seekingTo != -1 && _pauseAfterSeeking);
+			_pauseAfterSeeking = MainForm.EmulatorPaused || (SeekingTo != -1 && _pauseAfterSeeking);
 			WasRecording = CurrentTasMovie.IsRecording() || WasRecording;
 			TastudioPlayMode();
 
@@ -37,10 +37,10 @@ namespace BizHawk.Client.EmuHawk
 				_seekStartFrame = Emulator.Frame;
 				_seekingByEdit = false;
 
-				_seekingTo = frame;
+				SeekingTo = frame;
 				MainForm.UnpauseEmulator();
 
-				if (_seekingTo - _seekStartFrame > 1)
+				if (SeekingTo - _seekStartFrame > 1)
 				{
 					MessageStatusLabel.Text = "Seeking...";
 					ProgressBar.Visible = true;
@@ -116,7 +116,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public int GetSeekFrame()
 		{
-			return _seekingTo == -1 ? Emulator.Frame : _seekingTo;
+			return SeekingTo == -1 ? Emulator.Frame : SeekingTo;
 		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -54,7 +54,7 @@ namespace BizHawk.Client.EmuHawk
 		private bool _shouldMoveGreenArrow;
 		private bool _seekingByEdit;
 
-		private int _seekingTo
+		private int SeekingTo
 		{
 			get => MainForm.PauseOnFrame ?? -1;
 			set

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -54,7 +54,17 @@ namespace BizHawk.Client.EmuHawk
 		private bool _shouldMoveGreenArrow;
 		private bool _seekingByEdit;
 
-		private int _seekingTo = -1;
+		private int _seekingTo
+		{
+			get => MainForm.PauseOnFrame ?? -1;
+			set
+			{
+				if (value == -1)
+					MainForm.PauseOnFrame = null;
+				else
+					MainForm.PauseOnFrame = value;
+			}
+		}
 
 		[ConfigPersist]
 		public TAStudioSettings Settings { get; set; } = new TAStudioSettings();


### PR DESCRIPTION
I decided to go with the option of turning TAStudio's `_seekingTo` into a property backed by `MainForm.PauseOnFrame`. I avoided the issue of using MainForm's end-of-seek logic by having it update tools at the end of a turbo seek, in the normal place (which happens before end-of-seek logic) instead of in the end-of-seek logic. Cancelling a seek by setting `PauseOnFrame` to `null` no longer updates tools, because (a) this isn't needed anymore when a seek ends; and (b) that logic was unable to have the core render a frame, so it only did part of what needs to happen when a seek is cancelled.

In order to properly cancel a turbo seek, we need to emulate one more frame. So TAStudio's `StopSeeking` has additional logic for that now.

Clicking the icon at the bottom of the main form  to "stop seeking" does not actually set `PauseOnFrame`, it just pauses. So issues still exist there. I decided against fixing that because it's a separate issue and isn't trivial to fix. (setting `PauseOnFrame` there would break the pause at end of movie feature for regular movies)

Pausing during a turbo seek will not result in rendering or tools updating. This maybe should be changed, but that also is a separate issue.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant