### PR TITLE
[DOSBox-x] Adding key-activated alternative mouse resolution

### DIFF
--- a/src/BizHawk.Emulation.Common/Base Implementations/Bk2MnemonicLookup.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/Bk2MnemonicLookup.cs
@@ -900,6 +900,7 @@ namespace BizHawk.Emulation.Common
 				["Mouse Left Button"] = 'l',
 				["Mouse Middle Button"] = 'm',
 				["Mouse Right Button"] = 'r',
+				["Switch Mouse Internal Resolution"] = 'M',
 				["Previous Floppy Disk"] = '<',
 				["Next Floppy Disk"] = '>',
 				["Swap Floppy Disk"] = 'v',

--- a/src/BizHawk.Emulation.Cores/Computers/DOS/DOSBox.Controllers.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/DOS/DOSBox.Controllers.cs
@@ -72,6 +72,9 @@ namespace BizHawk.Emulation.Cores.Computers.DOS
 				// To adjust sensitivity, use the corresponding sync setting (global sensitivity for raw deltas is a TODO)
 				controller.AddAxis(Inputs.Mouse + " " + MouseInputs.SpeedX, (-180).RangeTo(180), 0);
 				controller.AddAxis(Inputs.Mouse + " " + MouseInputs.SpeedY, (-180).RangeTo(180), 0);
+
+				// Adding switch for enabling/disabling mouse internal resolution for games (e.g., Syndicate) that apply software-based resolution which offsets the mouse position
+				controller.BoolButtons.Add(Inputs.SwitchMouseInternalResolution);
 			}
 
 			// Adding drive management buttons
@@ -138,6 +141,7 @@ namespace BizHawk.Emulation.Cores.Computers.DOS
 			public const string PrevCDROM = "Previous CDROM";
 			public const string NextCDROM = "Next CDROM";
 			public const string SwapCDROM = "Swap CDROM";
+			public const string SwitchMouseInternalResolution = "Switch Mouse Internal Resolution";
 		}
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Computers/DOS/DOSBox.ISettable.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/DOS/DOSBox.ISettable.cs
@@ -277,6 +277,27 @@ namespace BizHawk.Emulation.Cores.Computers.DOS
 			[DefaultValue(LibDOSBox.SVGA_MAX_HEIGHT)]
 			public uint MouseAbsoluteScreenHeight { get; set; }
 
+			[DisplayName("Mouse Internal Resolution (Left)")]
+			[Description("Indicates the left position (in pixels) of the internal mouse resolution. Useful for games (e.g., Syndicate) that implement an internal resolution that is different from the screen resolution. Must be activated manually during gameplay.")]
+			[DefaultValue(0)]
+			public uint MouseInternalResolutionLeft { get; set; }
+
+			[DisplayName("Mouse Internal Resolution (Right)")]
+			[Description("Indicates the right position (in pixels) of the internal mouse resolution. Useful for games (e.g., Syndicate) that implement an internal resolution that is different from the screen resolution. Must be activated manually during gameplay.")]
+			[DefaultValue(LibDOSBox.SVGA_MAX_WIDTH)]
+			public uint MouseInternalResolutionRight { get; set; }
+
+			[DisplayName("Mouse Internal Resolution (Top)")]
+			[Description("Indicates the top position (in pixels) of the internal mouse resolution. Useful for games (e.g., Syndicate) that implement an internal resolution that is different from the screen resolution. Must be activated manually during gameplay.")]
+			[DefaultValue(0)]
+			public uint MouseInternalResolutionTop { get; set; }
+
+			[DisplayName("Mouse Internal Resolution (Bottom)")]
+			[Description("Indicates the bottom position (in pixels) of the internal mouse resolution. Useful for games (e.g., Syndicate) that implement an internal resolution that is different from the screen resolution. Must be activated manually during gameplay.")]
+			[DefaultValue(LibDOSBox.SVGA_MAX_HEIGHT)]
+			public uint MouseInternalResolutionBottom { get; set; }
+
+
 			[DisplayName("Mount Formatted Hard Disk Drive")]
 			[Description("Determines whether to mount an empty writable formatted hard disk in drive C:. The hard disk will be fully located in memory so make sure you have enough RAM available. Its contents can be exported to the host filesystem.\n\nThis value will be ignored if a hard disk image (.hdd) is provided.")]
 			[DefaultValue(HardDiskOptions.None)]

--- a/src/BizHawk.Emulation.Cores/Computers/DOS/DOSBox.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/DOS/DOSBox.cs
@@ -50,6 +50,9 @@ namespace BizHawk.Emulation.Cores.Computers.DOS
 		private int _currentCDROM = 0;
 		private bool _disposed;
 
+		// Mouse-related variables
+		private bool _useMouseInternalResolution = false;
+
 		private string GetFullName(IRomAsset rom) => Path.GetFileName(rom.RomPath.SubstringAfter('|'));
 		private string GetFullName(IDiscAsset disk) => Path.GetFileName(disk.DiscData.Name.SubstringAfter('|'));
 
@@ -385,6 +388,8 @@ namespace BizHawk.Emulation.Cores.Computers.DOS
 		private bool _isNextCDROMPressed = false;
 		private bool _isSwapCDROMPressed = false;
 
+		private bool _isSwitchMouseInternalResolutionPressed = false;
+
 		protected override LibWaterboxCore.FrameInfo FrameAdvancePrep(IController controller, bool render, bool rendersound)
 		{
 			DriveLightOn = false;
@@ -414,6 +419,11 @@ namespace BizHawk.Emulation.Cores.Computers.DOS
 			// Setting mouse inputs
 			if (_syncSettings.EnableMouse)
 			{
+				if (!_isSwitchMouseInternalResolutionPressed && controller.IsPressed(Inputs.SwitchMouseInternalResolution))
+				{
+					_useMouseInternalResolution = !_useMouseInternalResolution;
+				}
+
 				// Getting new mouse state values
 				DOSBox.MouseState mouseState = new()
 				{
@@ -426,8 +436,25 @@ namespace BizHawk.Emulation.Cores.Computers.DOS
 
 				var deltaX = controller.AxisValue($"{Inputs.Mouse} {MouseInputs.SpeedX}");
 				var deltaY = controller.AxisValue($"{Inputs.Mouse} {MouseInputs.SpeedY}");
-				fi.Mouse.PosX = mouseState.PosX;
-				fi.Mouse.PosY = mouseState.PosY;
+
+				if (_useMouseInternalResolution)
+				{
+					var horizontalOffset = Math.Max(0, mouseState.PosX - (int) _syncSettings.MouseInternalResolutionLeft);
+					horizontalOffset = Math.Min(horizontalOffset, (int) _syncSettings.MouseInternalResolutionRight);
+					var horizontalRatio = (float) _syncSettings.MouseAbsoluteScreenWidth / (_syncSettings.MouseInternalResolutionRight - _syncSettings.MouseInternalResolutionLeft);
+					fi.Mouse.PosX = (int) (horizontalOffset * horizontalRatio);
+
+					var verticalOffset = Math.Max(0, mouseState.PosY - (int) _syncSettings.MouseInternalResolutionTop);
+					verticalOffset = Math.Min(verticalOffset, (int) _syncSettings.MouseInternalResolutionBottom);
+					var verticalRatio = (float) _syncSettings.MouseAbsoluteScreenHeight / (_syncSettings.MouseInternalResolutionBottom - _syncSettings.MouseInternalResolutionTop);
+					fi.Mouse.PosY = (int) (verticalOffset * verticalRatio);
+				}
+				else
+				{
+					fi.Mouse.PosX = mouseState.PosX;
+					fi.Mouse.PosY = mouseState.PosY;
+				}
+
 				fi.Mouse.DeltaX = deltaX != 0 ? deltaX : fi.Mouse.PosX - _lastMouseState.PosX;
 				fi.Mouse.DeltaY = deltaY != 0 ? deltaY : fi.Mouse.PosY - _lastMouseState.PosY;
 
@@ -505,6 +532,8 @@ namespace BizHawk.Emulation.Cores.Computers.DOS
 			_isNextCDROMPressed = controller.IsPressed(Inputs.NextCDROM);
 			_isSwapCDROMPressed = controller.IsPressed(Inputs.SwapCDROM);
 
+			_isSwitchMouseInternalResolutionPressed = controller.IsPressed(Inputs.SwitchMouseInternalResolution);
+
 			// Processing keyboard inputs
 			foreach (var (name, key) in _keyboardMap)
 			{
@@ -570,6 +599,8 @@ namespace BizHawk.Emulation.Cores.Computers.DOS
 			writer.Write(_lastMouseState.LeftButtonHeld);
 			writer.Write(_lastMouseState.MiddleButtonHeld);
 			writer.Write(_lastMouseState.RightButtonHeld);
+
+			writer.Write(_useMouseInternalResolution);
 
 			// Storing current refresh rate
 			writer.Write(VsyncNumerator);

--- a/src/BizHawk.Emulation.Cores/Computers/DOS/DOSBox.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/DOS/DOSBox.cs
@@ -618,6 +618,8 @@ namespace BizHawk.Emulation.Cores.Computers.DOS
 			_lastMouseState.MiddleButtonHeld = reader.ReadBoolean();
 			_lastMouseState.RightButtonHeld = reader.ReadBoolean();
 
+			_useMouseInternalResolution = reader.ReadBoolean();
+
 			// Restoring refresh rate
 			var newVsyncNumerator = reader.ReadInt32();
 			var newVsyncDenominator = reader.ReadInt32();


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

[//]: # "A button which takes you to the automated builds, once they're been processed—fill in your GitHub username and the name of the branch (double a hyphen to escape it)."
[![dev build for branch | TASEmulators:dosboxMouseAltResolution](https://img.shields.io/badge/dev_build_for_branch-TASEmulators:dosboxMouseAltResolution-8250DF?logo=github&logoColor=333333&style=popout)](https://nightly.link/TASEmulators/BizHawk/workflows/ci/dosboxMouseAltResolution?preview)

Some DOS games operate with different resolutions during gameplay. One example is Syndicate which uses 800x600 during menuing:

<img width="635" height="481" alt="image" src="https://github.com/user-attachments/assets/766b4b91-6db9-4ddb-812c-4f1e63886980" />

and 800x500(+50 offset) during a mission:

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/8844603f-0eea-4bd2-9321-1017993d6454" />

This means no single mouse absolute resolution can be used to perfectly map it to both. That's why I am introducing a way to specify an alternative resolution (with offsets) that can be (de)activated with a key during gameplay. 


[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
