### PR TITLE
show the column text in an empty cell when hovering over it in TAStudio

### DIFF
--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.Drawing.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.Drawing.cs
@@ -189,7 +189,11 @@ namespace BizHawk.Client.EmuHawk
 			_renderer.PrepDrawString(Font, _foreColor);
 
 			Cell currentCell = new();
-			Cell mouseCell = ShowColumnTextOnHover ? CurrentCell : null;
+			Cell mouseCell = null;
+			if (ShowColumnTextOnHover && _draggingCell == null && !IsPaintDown)
+			{
+				mouseCell = CurrentCell;
+			}
 			if (HorizontalOrientation)
 			{
 				for (int j = 0; j < visibleColumns.Count; j++)

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.Drawing.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.Drawing.cs
@@ -189,6 +189,7 @@ namespace BizHawk.Client.EmuHawk
 			_renderer.PrepDrawString(Font, _foreColor);
 
 			Cell currentCell = new();
+			Cell mouseCell = ShowColumnTextOnHover ? CurrentCell : null;
 			if (HorizontalOrientation)
 			{
 				for (int j = 0; j < visibleColumns.Count; j++)
@@ -223,6 +224,7 @@ namespace BizHawk.Client.EmuHawk
 
 						bool rePrep = false;
 						Color foreColor = _foreColor;
+						Font font = Font;
 						currentCell.Column = col;
 						currentCell.RowIndex = f + startRow;
 						if (_selectedItems.Contains(currentCell))
@@ -230,13 +232,20 @@ namespace BizHawk.Client.EmuHawk
 							foreColor = SystemColors.HighlightText;
 							rePrep = true;
 						}
+						if (text.Length == 0 && mouseCell == currentCell)
+						{
+							font = new Font(Font, FontStyle.Regular);
+							foreColor = SystemColors.GrayText;
+							text = col.Text;
+							rePrep = true;
+						}
 						if (col.Rotatable || rePrep)
 						{
-							_renderer.PrepDrawString(Font, foreColor, rotate: col.Rotatable);
+							_renderer.PrepDrawString(font, foreColor, rotate: col.Rotatable);
 							rePrep = true;
 						}
 
-						int textWidth = (int)_renderer.MeasureString(text, Font).Width;
+						int textWidth = (int)_renderer.MeasureString(text, font).Width;
 						if (col.Rotatable)
 						{
 							// Center Text
@@ -287,12 +296,25 @@ namespace BizHawk.Client.EmuHawk
 						QueryItemText(this, f + startRow, column, out var text, ref strOffsetX, ref strOffsetY);
 
 						bool rePrep = false;
+						Color foreColor = _foreColor;
+						Font font = Font;
 						currentCell.Column = column;
 						currentCell.RowIndex = f + startRow;
 						if (_selectedItems.Contains(currentCell))
 						{
-							_renderer.PrepDrawString(Font, SystemColors.HighlightText);
+							foreColor = SystemColors.HighlightText;
 							rePrep = true;
+						}
+						if (text.Length == 0 && mouseCell == currentCell)
+						{
+							font = new Font(Font, FontStyle.Regular);
+							foreColor = SystemColors.GrayText;
+							text = column.Text;
+							rePrep = true;
+						}
+						if (rePrep)
+						{
+							_renderer.PrepDrawString(font, foreColor);
 						}
 
 						DrawString(text, new Rectangle(point.X + strOffsetX, point.Y + strOffsetY, column.Width, ColumnHeight));

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -1020,21 +1020,12 @@ namespace BizHawk.Client.EmuHawk
 
 			Cell newCell = CalculatePointedCell(_currentX.Value, _currentY.Value);
 
-			if (!newCell.Equals(CurrentCell))
+			bool changed = CellChanged(newCell);
+			if (changed && (ShowColumnTextOnHover || IsHoveringOnColumnCell || WasHoveringOnColumnCell))
 			{
-				CellChanged(newCell);
-
-				if (IsHoveringOnColumnCell
-					|| (WasHoveringOnColumnCell && !IsHoveringOnColumnCell))
-				{
-					Refresh();
-				}
-				else if (_columnDown != null)
-				{
-					Refresh();
-				}
+				Refresh();
 			}
-			else if (_columnDown != null)  // Kind of silly feeling to have this check twice, but the only alternative I can think of has it refreshing twice when pointed column changes with column down, and speed matters
+			else if (_columnDown != null)
 			{
 				Refresh();
 			}
@@ -1561,13 +1552,15 @@ namespace BizHawk.Client.EmuHawk
 		/// <summary>
 		/// Call this function to change the CurrentCell to newCell
 		/// </summary>
-		private void CellChanged(Cell newCell)
+		/// <returns>true if CurrentCell was changed</returns>
+		private bool CellChanged(Cell newCell)
 		{
+			if (newCell == CurrentCell) return false;
+
 			_lastCell = CurrentCell;
 			CurrentCell = newCell;
 
-			if (PointedCellChanged is not null
-				&& !(_lastCell?.Column == CurrentCell.Column && _lastCell?.RowIndex == CurrentCell.RowIndex)) //TODO isn't this just `Cell.==`? --yoshi
+			if (PointedCellChanged is not null)
 			{
 				PointedCellChanged(this, new CellEventArgs(_lastCell, CurrentCell));
 			}
@@ -1580,6 +1573,8 @@ namespace BizHawk.Client.EmuHawk
 			{
 				_hoverTimer.Stop();
 			}
+
+			return true;
 		}
 
 		private void VerticalBar_ValueChanged(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -1057,7 +1057,7 @@ namespace BizHawk.Client.EmuHawk
 			bool refresh = false;
 			_currentX = null;
 			_currentY = null;
-			if (IsHoveringOnColumnCell)
+			if (IsHoveringOnColumnCell || ShowColumnTextOnHover)
 			{
 				refresh = true;
 			}

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -732,8 +732,6 @@ namespace BizHawk.Client.EmuHawk
 						_programmaticallyUpdatingScrollBarValues = false;
 					}
 				}
-				_programmaticallyChangingRow = false;
-				PointMouseToNewCell();
 			}
 		}
 
@@ -806,8 +804,6 @@ namespace BizHawk.Client.EmuHawk
 					}
 					while ((lastVisible - value < 0 || _lagFrames[VisibleRows - halfRow] < lastVisible - value) && FirstVisibleRow != 0);
 				}
-				_programmaticallyChangingRow = false;
-				PointMouseToNewCell();
 			}
 		}
 
@@ -918,11 +914,7 @@ namespace BizHawk.Client.EmuHawk
 					}
 				}
 			}
-			_programmaticallyChangingRow = false;
-			PointMouseToNewCell();
 		}
-
-		public bool _programmaticallyChangingRow = false;
 
 		/// <summary>
 		/// Scrolls so that the given index is visible, if it isn't already; doesn't use scroll settings.
@@ -931,8 +923,6 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (!IsVisible(index))
 			{
-				_programmaticallyChangingRow = true;
-
 				if (FirstVisibleRow > index)
 				{
 					FirstVisibleRow = index;
@@ -990,32 +980,16 @@ namespace BizHawk.Client.EmuHawk
 		private bool _columnDownMoved;
 		private int _previousX; // TODO: move me
 
-		// It's necessary to call this anytime the control is programmatically scrolled
-		// Since the mouse may not be pointing to the same cell anymore
-		public void PointMouseToNewCell()
+		public bool SuppressCellChange;
+
+		private void PointMouseToNewCell()
 		{
+			if (SuppressCellChange) return;
+
 			if (_currentX.HasValue && _currentY.HasValue)
 			{
 				var newCell = CalculatePointedCell(_currentX.Value, _currentY.Value);
-				if (CurrentCell != newCell)
-				{
-					if (QueryFrameLag != null && newCell.RowIndex.HasValue)
-					{
-						newCell.RowIndex += CountLagFramesDisplay(newCell.RowIndex.Value);
-					}
-
-					newCell.RowIndex += FirstVisibleRow;
-					if (newCell.RowIndex < 0)
-					{
-						newCell.RowIndex = 0;
-					}
-
-					if (_programmaticallyChangingRow)
-					{
-						_programmaticallyChangingRow = false;
-						CellChanged(newCell);
-					}
-				}
+				CellChanged(newCell);
 			}
 		}
 
@@ -1045,18 +1019,6 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			Cell newCell = CalculatePointedCell(_currentX.Value, _currentY.Value);
-
-			// SuuperW: Hide lag frames
-			if (QueryFrameLag != null && newCell.RowIndex.HasValue)
-			{
-				newCell.RowIndex += CountLagFramesDisplay(newCell.RowIndex.Value);
-			}
-
-			newCell.RowIndex += FirstVisibleRow;
-			if (newCell.RowIndex < 0)
-			{
-				newCell.RowIndex = 0;
-			}
 
 			if (!newCell.Equals(CurrentCell))
 			{
@@ -1627,6 +1589,7 @@ namespace BizHawk.Client.EmuHawk
 				Refresh();
 			}
 
+			PointMouseToNewCell();
 			if (_horizontalOrientation)
 			{
 				ColumnScroll?.Invoke(this, e);
@@ -1644,6 +1607,7 @@ namespace BizHawk.Client.EmuHawk
 				Refresh();
 			}
 
+			PointMouseToNewCell();
 			if (_horizontalOrientation)
 			{
 				RowScroll?.Invoke(this, e);
@@ -1901,6 +1865,18 @@ namespace BizHawk.Client.EmuHawk
 			if (!(IsPaintDown || rightButton) && newCell.RowIndex <= -1) // -2 if we're entering from the top
 			{
 				newCell.RowIndex = null;
+				return newCell;
+			}
+
+			if (QueryFrameLag != null)
+			{
+				newCell.RowIndex += CountLagFramesDisplay(newCell.RowIndex.Value);
+			}
+
+			newCell.RowIndex += FirstVisibleRow;
+			if (newCell.RowIndex < 0)
+			{
+				newCell.RowIndex = 0;
 			}
 
 			return newCell;

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -224,6 +224,13 @@ namespace BizHawk.Client.EmuHawk
 		public bool GridLines { get; set; } = true;
 
 		/// <summary>
+		/// Gets or sets a value indicating whether empty cells will display their column's text when the mouse cursor is placed over them
+		/// </summary>
+		[DefaultValue(false)]
+		[Category("Appearance")]
+		public bool ShowColumnTextOnHover { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating whether the control is horizontal or vertical
 		/// </summary>
 		[Category("Behavior")]

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -763,10 +763,6 @@ namespace BizHawk.Client.EmuHawk
 				UpdateActiveMovieInputs();
 			}
 
-			// only on mouse button down, check that the pointed to cell is the correct one (can be wrong due to scroll while playing)
-			roll._programmaticallyChangingRow = true;
-			roll.PointMouseToNewCell();
-
 			if (e.Button == MouseButtons.Middle)
 			{
 				if (MainForm.EmulatorPaused)
@@ -1342,7 +1338,9 @@ namespace BizHawk.Client.EmuHawk
 
 			if (MouseButtonHeld)
 			{
-				roll.MakeIndexVisible(roll.CurrentCell.RowIndex.Value); // todo: limit scrolling speed
+				roll.SuppressCellChange = true; // avoid inifinite recursion of scrolling cuasing PointedCellChanged
+				roll.MakeIndexVisible(roll.CurrentCell.RowIndex.Value);
+				roll.SuppressCellChange = false;
 				SetTasViewRowCount(); // refreshes
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -1275,7 +1275,6 @@ namespace BizHawk.Client.EmuHawk
 
 			if (e.NewCell.RowIndex is null || !MouseButtonHeld)
 			{
-				SetTasViewRowCount(); // redraw
 				return;
 			}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -182,6 +182,7 @@ namespace BizHawk.Client.EmuHawk
 				InputPaintingMode = true,
 				LetKeysModifySelection = true,
 				Rotatable = true,
+				ShowColumnTextOnHover = true,
 				// user configurable
 				AlwaysScroll = Settings.FollowCursorAlwaysScroll,
 				Font = Settings.TasViewFont,
@@ -1276,13 +1277,9 @@ namespace BizHawk.Client.EmuHawk
 			InputRoll roll = (InputRoll)sender;
 			toolTip1.SetToolTip(roll, null);
 
-			if (e.NewCell.RowIndex is null)
+			if (e.NewCell.RowIndex is null || !MouseButtonHeld)
 			{
-				return;
-			}
-
-			if (!MouseButtonHeld)
-			{
+				SetTasViewRowCount(); // redraw
 				return;
 			}
 


### PR DESCRIPTION
implements #4755

Hover text is the same gray regardless of whether a cell is selected. I tried using the highlight text color for this in selected cells, but that made the display for buttons too similar to the display for actually pressed buttons.

The text is also weird in horizontal mode, since the rotated text can be longer than the height of the cell.

<img width="117" height="57" alt="image" src="https://github.com/user-attachments/assets/bfd292e1-60ae-4f73-acac-e2a0dd75a8c2" />
<img width="100" height="50" alt="image" src="https://github.com/user-attachments/assets/e0d4fc15-cc23-4b5d-9911-f083648bc677" />
<img width="69" height="73" alt="image" src="https://github.com/user-attachments/assets/5a08949d-1461-496c-8958-783a944d2c81" />
<img width="111" height="45" alt="image" src="https://github.com/user-attachments/assets/602c2c33-e547-46a7-ae7a-d2430c952cb1" />

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
