### PR TITLE
When clicking a frame that doesn't exist in TAStudio, select it once the frame exists.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -300,6 +300,10 @@ namespace BizHawk.Client.EmuHawk
 						while (iLastToKeep > -1 && (_selectedItems[iLastToKeep].RowIndex ?? -1) >= _rowCount) iLastToKeep--;
 						_selectedItems = _selectedItems.Slice(start: 0, length: iLastToKeep + 1);
 					}
+					else if (_lastFailedSelection != null && _selectedItems.Count == 0)
+					{
+						SelectCell(_lastFailedSelection);
+					}
 
 					RecalculateScrollBars();
 				}
@@ -596,6 +600,12 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		private int? _lastSelectedRow;
+
+		/// <summary>
+		/// The idea for this is to allow a row to be "selected" before it exists.
+		/// <br/>For example, clicking on the cursor column in TAStudio to seek to a frame that is past the end of the movie. This should select the row once the seek ends.
+		/// </summary>
+		private Cell/*?*/ _lastFailedSelection;
 
 		public void SelectRow(int index, bool val)
 		{
@@ -1833,6 +1843,7 @@ namespace BizHawk.Client.EmuHawk
 		/// <param name="toggle">Specifies whether or not to toggle the current state, rather than force the value to true</param>
 		private void SelectCell(Cell cell, bool toggle = false)
 		{
+			_lastFailedSelection = null;
 			if (cell.RowIndex is int row && row < RowCount)
 			{
 				if (!MultiSelect)
@@ -1875,6 +1886,10 @@ namespace BizHawk.Client.EmuHawk
 						_selectedItems.Add(CurrentCell);
 					}
 				}
+			}
+			else
+			{
+				_lastFailedSelection = cell;
 			}
 		}
 


### PR DESCRIPTION
Now when you click to toggle a button past the end of the movie, that frame will be selected. And when you click the cursor column to seek past the end of the movie, that frame will be selected once it is reached.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant