### PR TITLE
Add the WM_CLASS property to the BizHawk window

### DIFF
--- a/src/BizHawk.Client.Common/ArgParser.cs
+++ b/src/BizHawk.Client.Common/ArgParser.cs
@@ -117,6 +117,11 @@ namespace BizHawk.Client.Common
 			Description = "pairs in the format `k1:v1;k2:v2` (mind your shell escape sequences); if the value is `true`/`false` it's interpreted as a boolean, if it's a valid 32-bit signed integer e.g. `-1234` it's interpreted as such, if it's a valid 32-bit float e.g. `12.34` it's interpreted as such, else it's interpreted as a string",
 		};
 
+		private static readonly Option<string?> OptionWMClass = new ("--wmclass")
+		{
+			Description = "set a custom WM_CLASS for this Bizhawk initiation, Linux only."
+		};
+
 		static ArgParser()
 		{
 			OptionAVDumpFrameList.Description = $"comma-separated list of integers, indices of frames which should be included in the A/V dump (encoding); implies `{OptionAVDumpEndAtFrame.Name}=<end>` where `<end>` is the highest frame listed";
@@ -162,6 +167,7 @@ namespace BizHawk.Client.Common
 			root.Add(/* --url-post */ OptionHTTPClientURIPOST);
 			root.Add(/* --userdata */ OptionUserdataUnparsedPairs);
 			root.Add(/* --version */ OptionQueryAppVersion);
+			root.Add(/* --wmclass */ OptionWMClass);
 
 			return root;
 		}
@@ -268,7 +274,8 @@ namespace BizHawk.Client.Common
 				openExtToolDll: result.GetValue(OptionOpenExternalTool),
 				socketProtocol: result.GetValue(OptionSocketServerUseUDP) ? ProtocolType.Udp : ProtocolType.Tcp,
 				userdataUnparsedPairs: userdataUnparsedPairs,
-				cmdRom: result.GetValue(ArgumentRomFilePath)
+				cmdRom: result.GetValue(ArgumentRomFilePath),
+				wmClassName: result.GetValue(OptionWMClass)
 			);
 			return null;
 		}

--- a/src/BizHawk.Client.Common/ArgParser.cs
+++ b/src/BizHawk.Client.Common/ArgParser.cs
@@ -119,7 +119,7 @@ namespace BizHawk.Client.Common
 
 		private static readonly Option<string?> OptionWMClass = new ("--wmclass")
 		{
-			Description = "set a custom WM_CLASS for this Bizhawk initiation, Linux only."
+			Description = "set a custom WM_CLASS for this Bizhawk initiation, Linux only.",
 		};
 
 		static ArgParser()

--- a/src/BizHawk.Client.Common/ParsedCLIFlags.cs
+++ b/src/BizHawk.Client.Common/ParsedCLIFlags.cs
@@ -51,6 +51,8 @@ namespace BizHawk.Client.Common
 
 		public readonly string? cmdRom;
 
+		public readonly string? wmClassName;
+
 		public ParsedCLIFlags(
 			int? cmdLoadSlot,
 			string? cmdLoadState,
@@ -73,7 +75,8 @@ namespace BizHawk.Client.Common
 			string? openExtToolDll,
 			ProtocolType socketProtocol,
 			IReadOnlyList<(string Key, string Value)>? userdataUnparsedPairs,
-			string? cmdRom)
+			string? cmdRom,
+			string? wmClassName)
 		{
 			this.cmdLoadSlot = cmdLoadSlot;
 			this.cmdLoadState = cmdLoadState;
@@ -97,6 +100,7 @@ namespace BizHawk.Client.Common
 			SocketProtocol = socketProtocol;
 			UserdataUnparsedPairs = userdataUnparsedPairs;
 			this.cmdRom = cmdRom;
+			this.wmClassName = wmClassName;
 		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -914,6 +914,8 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		private bool _skipNextAltRelease = true;
 
+		private bool _runWMSetOnce = true;
+
 		public int ProgramRunLoop()
 		{
 			// needs to be done late, after the log console snaps on top
@@ -1014,6 +1016,13 @@ namespace BizHawk.Client.EmuHawk
 				StepRunLoop_Core();
 				Render();
 				StepRunLoop_Throttle();
+
+				//Code to set WM_CLASS only need be run once, but must be run after the application has rendered at least once
+				if(_runWMSetOnce && OSTailoredCode.CurrentOS==OSTailoredCode.DistinctOS.Linux)
+				{
+					OSTailoredCode.SetWMClass(_x11Display,"BizHawk");
+					_runWMSetOnce = false;
+				}
 
 				// HACK: RAIntegration might peek at memory during messages
 				// we need this to allow memory access here, otherwise it will deadlock

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -295,6 +295,13 @@ namespace BizHawk.Client.EmuHawk
 				else Console.WriteLine($"requested ext. tool dll {requestedExtToolDll} could not be loaded");
 			}
 
+			//Code to set WM_CLASS
+			if(OSTailoredCode.CurrentOS==OSTailoredCode.DistinctOS.Linux)
+			{
+				string wmclass = _argParser.wmClassName is not null ? _argParser.wmClassName : "BizHawk";
+				XlibImports.SetWMClass(_x11Display, wmclass);
+			}
+
 #if DEBUG
 			AddDebugMenu();
 #endif
@@ -914,8 +921,6 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		private bool _skipNextAltRelease = true;
 
-		private bool _runWMSetOnce = true;
-
 		public int ProgramRunLoop()
 		{
 			// needs to be done late, after the log console snaps on top
@@ -1016,14 +1021,6 @@ namespace BizHawk.Client.EmuHawk
 				StepRunLoop_Core();
 				Render();
 				StepRunLoop_Throttle();
-
-				//Code to set WM_CLASS only need be run once, but must be run after the application has rendered at least once
-				if(_runWMSetOnce && OSTailoredCode.CurrentOS==OSTailoredCode.DistinctOS.Linux)
-				{
-					string wmclass = _argParser.wmClassName is not null ? _argParser.wmClassName : "BizHawk";
-					OSTailoredCode.SetWMClass(_x11Display,wmclass);
-					_runWMSetOnce = false;
-				}
 
 				// HACK: RAIntegration might peek at memory during messages
 				// we need this to allow memory access here, otherwise it will deadlock

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1020,7 +1020,8 @@ namespace BizHawk.Client.EmuHawk
 				//Code to set WM_CLASS only need be run once, but must be run after the application has rendered at least once
 				if(_runWMSetOnce && OSTailoredCode.CurrentOS==OSTailoredCode.DistinctOS.Linux)
 				{
-					OSTailoredCode.SetWMClass(_x11Display,"BizHawk");
+					string wmclass = _argParser.wmClassName is not null ? _argParser.wmClassName : "BizHawk";
+					OSTailoredCode.SetWMClass(_x11Display,wmclass);
 					_runWMSetOnce = false;
 				}
 

--- a/src/BizHawk.Common/LSB/XlibImports.cs
+++ b/src/BizHawk.Common/LSB/XlibImports.cs
@@ -715,7 +715,7 @@ namespace BizHawk.Common
 		[DllImport(XLIB)]
 		[return: MarshalAs(UnmanagedType.SysUInt)]
 		public static extern Keysym XkbKeycodeToKeysym(IntPtr display, uint keycode, int group, int level);
-	
+
 		[DllImport(XLIB)]
 		public static extern IntPtr XAllocClassHint();
 
@@ -733,10 +733,7 @@ namespace BizHawk.Common
 
 		[DllImport(XLIB)]
 		public static extern Status XQueryTree(IntPtr display, IntPtr window, out IntPtr rootReturn, out IntPtr parentReturn, out IntPtr[] childrenReturn, out int childCount);
-		
 		[DllImport(XLIB)]
 		public static extern Status XFetchName(IntPtr display, IntPtr window, out string returnedName);
-		
 	}
-
 }

--- a/src/BizHawk.Common/LSB/XlibImports.cs
+++ b/src/BizHawk.Common/LSB/XlibImports.cs
@@ -716,7 +716,7 @@ namespace BizHawk.Common
 		[return: MarshalAs(UnmanagedType.SysUInt)]
 		public static extern Keysym XkbKeycodeToKeysym(IntPtr display, uint keycode, int group, int level);
 	
-			[DllImport(XLIB)]
+		[DllImport(XLIB)]
 		public static extern IntPtr XAllocClassHint();
 
 		[DllImport(XLIB)]
@@ -727,15 +727,16 @@ namespace BizHawk.Common
 
 		public struct XClassHint
 		{
-			public IntPtr res_name;	
+			public IntPtr res_name;
 			public IntPtr res_class;
 		}
 
 		[DllImport(XLIB)]
 		public static extern Status XQueryTree(IntPtr display, IntPtr window, out IntPtr rootReturn, out IntPtr parentReturn, out IntPtr[] childrenReturn, out int childCount);
-	
+		
 		[DllImport(XLIB)]
 		public static extern Status XFetchName(IntPtr display, IntPtr window, out string returnedName);
-
+		
 	}
+
 }

--- a/src/BizHawk.Common/LSB/XlibImports.cs
+++ b/src/BizHawk.Common/LSB/XlibImports.cs
@@ -715,5 +715,27 @@ namespace BizHawk.Common
 		[DllImport(XLIB)]
 		[return: MarshalAs(UnmanagedType.SysUInt)]
 		public static extern Keysym XkbKeycodeToKeysym(IntPtr display, uint keycode, int group, int level);
+	
+			[DllImport(XLIB)]
+		public static extern IntPtr XAllocClassHint();
+
+		[DllImport(XLIB)]
+		public static extern Status XSetClassHint(IntPtr display, IntPtr window, IntPtr classHint);
+
+		[DllImport(XLIB)]
+		public static extern Status XGetClassHint(IntPtr display, IntPtr window, out IntPtr classHint);
+
+		public struct XClassHint
+		{
+			public IntPtr res_name;	
+			public IntPtr res_class;
+		}
+
+		[DllImport(XLIB)]
+		public static extern Status XQueryTree(IntPtr display, IntPtr window, out IntPtr rootReturn, out IntPtr parentReturn, out IntPtr[] childrenReturn, out int childCount);
+	
+		[DllImport(XLIB)]
+		public static extern Status XFetchName(IntPtr display, IntPtr window, out string returnedName);
+
 	}
 }

--- a/src/BizHawk.Common/LSB/XlibImports.cs
+++ b/src/BizHawk.Common/LSB/XlibImports.cs
@@ -735,5 +735,41 @@ namespace BizHawk.Common
 		public static extern Status XQueryTree(IntPtr display, IntPtr window, out IntPtr rootReturn, out IntPtr parentReturn, out IntPtr[] childrenReturn, out int childCount);
 		[DllImport(XLIB)]
 		public static extern Status XFetchName(IntPtr display, IntPtr window, out string returnedName);
+
+		public static void SetWMClass(IntPtr x11Display, string className)
+		{
+			//Establish reference to xDisplay
+			if(x11Display == IntPtr.Zero)
+			{
+				x11Display = XOpenDisplay(null);
+			}
+			//Setup the ClassHint
+			var wmSet = new XClassHint{res_name = Marshal.StringToCoTaskMemAnsi("BizHawk"), res_class = Marshal.StringToCoTaskMemAnsi(className)};
+			IntPtr point = XAllocClassHint();
+			Marshal.StructureToPtr(wmSet, point, true);
+
+			//To find the window we must query twice, once to get the array length and the second to populate
+			XQueryTree(x11Display, XDefaultRootWindow(x11Display), out _, out _, out _, out int windowCount);
+			IntPtr[] windowList = new IntPtr[windowCount];
+			XQueryTree(x11Display, XDefaultRootWindow(x11Display), out _, out _, out windowList, out windowCount);
+			for(int windowIterator = 0; windowIterator < windowCount; windowIterator++)
+			{
+				XFetchName(x11Display, windowList[windowIterator], out string name);
+				if(name?.Contains("BizHawk") == true)
+				{
+					//Interogate if a WM_CLASS is already set
+					XGetClassHint(x11Display, windowList[windowIterator], out var classHint);
+					if(classHint == IntPtr.Zero)
+					{
+						//Assign+Retrieve - doesn't seem to set properly without retrieving it after)
+						XSetClassHint(x11Display, windowList[windowIterator], point);
+						XGetClassHint(x11Display, windowList[windowIterator],out _);
+					}
+					//Reset classHint after checking, doesn't seem to overwrite otherwise.
+					classHint = IntPtr.Zero;
+				}
+			}
+			_ = XFlush(x11Display);
+		}
 	}
 }

--- a/src/BizHawk.Common/OSTailoredCode.cs
+++ b/src/BizHawk.Common/OSTailoredCode.cs
@@ -309,7 +309,6 @@ namespace BizHawk.Common
 				XlibImports.XFetchName(x11Display, windowList[windowIterator], out string name);
 				if(name?.Contains("BizHawk") == true)
 				{
-					//A bizhawk window found:
 					//Interogate if a WM_CLASS is already set
 					XlibImports.XGetClassHint(x11Display, windowList[windowIterator], out var classHint);
 					if(classHint == IntPtr.Zero)

--- a/src/BizHawk.Common/OSTailoredCode.cs
+++ b/src/BizHawk.Common/OSTailoredCode.cs
@@ -304,7 +304,7 @@ namespace BizHawk.Common
 			XlibImports.XQueryTree(x11Display, XlibImports.XDefaultRootWindow(x11Display), out _, out _, out _, out int windowCount);
 			IntPtr[] windowList = new IntPtr[windowCount];
 			XlibImports.XQueryTree(x11Display, XlibImports.XDefaultRootWindow(x11Display), out _, out _, out windowList, out windowCount);
-			for(int windowIterator = 0; windowIterator < windowCount; windowIterator++) 
+			for(int windowIterator = 0; windowIterator < windowCount; windowIterator++)
 			{
 				XlibImports.XFetchName(x11Display, windowList[windowIterator], out string name);
 				if(name?.Contains("BizHawk") == true)

--- a/src/BizHawk.Common/OSTailoredCode.cs
+++ b/src/BizHawk.Common/OSTailoredCode.cs
@@ -292,5 +292,36 @@ namespace BizHawk.Common
 			if (stdout.EndOfStream) throw new Exception($"{noOutputMsg} ({cmd} wrote nothing to stdout)");
 			return stdout.ReadLine()!;
 		}
+
+		public static void SetWMClass(IntPtr x11Display, string className)
+		{
+			//Setup the ClassHint
+			var wmSet = new XlibImports.XClassHint{res_name = Marshal.StringToCoTaskMemAnsi("BizHawk"), res_class = Marshal.StringToCoTaskMemAnsi(className)};
+			IntPtr point = XlibImports.XAllocClassHint();
+			Marshal.StructureToPtr(wmSet, point, true);
+
+			//To find the window we must query twice, once to get the array length and the second to populate
+			XlibImports.XQueryTree(x11Display, XlibImports.XDefaultRootWindow(x11Display), out _, out _, out _, out int windowCount);
+			IntPtr[] windowList = new IntPtr[windowCount];
+			XlibImports.XQueryTree(x11Display, XlibImports.XDefaultRootWindow(x11Display), out _, out _, out windowList, out windowCount);
+			for(int windowIterator = 0; windowIterator < windowCount; windowIterator++) 
+			{
+				XlibImports.XFetchName(x11Display, windowList[windowIterator], out string name);
+				if(name?.Contains("BizHawk") == true)
+				{
+					//A bizhawk window found:
+					//Interogate if a WM_CLASS is already set
+					XlibImports.XGetClassHint(x11Display, windowList[windowIterator], out var classHint);
+					if(classHint == IntPtr.Zero)
+					{
+						//Assign+Retrieve - doesn't seem to set properly without retrieving it after)
+						XlibImports.XSetClassHint(x11Display, windowList[windowIterator], point);
+						XlibImports.XGetClassHint(x11Display, windowList[windowIterator],out _);
+					}
+					//Reset classHint after checking, doesn't seem to overwrite otherwise.
+					classHint = IntPtr.Zero;
+				}
+			}
+		}
 	}
 }

--- a/src/BizHawk.Common/OSTailoredCode.cs
+++ b/src/BizHawk.Common/OSTailoredCode.cs
@@ -292,35 +292,5 @@ namespace BizHawk.Common
 			if (stdout.EndOfStream) throw new Exception($"{noOutputMsg} ({cmd} wrote nothing to stdout)");
 			return stdout.ReadLine()!;
 		}
-
-		public static void SetWMClass(IntPtr x11Display, string className)
-		{
-			//Setup the ClassHint
-			var wmSet = new XlibImports.XClassHint{res_name = Marshal.StringToCoTaskMemAnsi("BizHawk"), res_class = Marshal.StringToCoTaskMemAnsi(className)};
-			IntPtr point = XlibImports.XAllocClassHint();
-			Marshal.StructureToPtr(wmSet, point, true);
-
-			//To find the window we must query twice, once to get the array length and the second to populate
-			XlibImports.XQueryTree(x11Display, XlibImports.XDefaultRootWindow(x11Display), out _, out _, out _, out int windowCount);
-			IntPtr[] windowList = new IntPtr[windowCount];
-			XlibImports.XQueryTree(x11Display, XlibImports.XDefaultRootWindow(x11Display), out _, out _, out windowList, out windowCount);
-			for(int windowIterator = 0; windowIterator < windowCount; windowIterator++)
-			{
-				XlibImports.XFetchName(x11Display, windowList[windowIterator], out string name);
-				if(name?.Contains("BizHawk") == true)
-				{
-					//Interogate if a WM_CLASS is already set
-					XlibImports.XGetClassHint(x11Display, windowList[windowIterator], out var classHint);
-					if(classHint == IntPtr.Zero)
-					{
-						//Assign+Retrieve - doesn't seem to set properly without retrieving it after)
-						XlibImports.XSetClassHint(x11Display, windowList[windowIterator], point);
-						XlibImports.XGetClassHint(x11Display, windowList[windowIterator],out _);
-					}
-					//Reset classHint after checking, doesn't seem to overwrite otherwise.
-					classHint = IntPtr.Zero;
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

[//]: # "A button which takes you to the automated builds, once they're been processed—fill in your GitHub username and the name of the branch (double a hyphen to escape it)."
[![dev build for branch | Leopardly:linux-wm-class](https://img.shields.io/badge/dev_build_for_branch-Leopardly:linux--wm--class-8250DF?logo=github&logoColor=333333&style=popout)](https://nightly.link/Leopardly/BizHawk/workflows/ci/linux-wm-class?preview)

Adds a set of calls to XLIB to set a WM_CLASS on Linux for BizHawk; runs once but has to be run in the main loop as the application needs to be fully loaded and rendering (If there is a better place to put this, please do let me know!). Also added support for defining the WM_CLASS to use via a CLI argument.

There were 2 issues essentially:
- Using custom .desktop s to launch Bizhawk with the roms and Lua scripts I want (for things like Kaizo) - the system has no way to correlate the running Bizhawk instance with what was launched so it falls back to using the embedded icon, rather than the icon of the .desktop file.
- Attempting to set rules with KDE's built in "Window Rules" gives you a warning that no WM_CLASS is set, meaning things like "Remove window borders" rules etc have to rely on less reliable pickups like window title.

I'll admit the first case (which is basically my justification for the CLI arg) is niche and I'm not against dropping it entirely; it just makes having say "Run X in Bizhawk" as a shortcut much easier to uniquely integrate rather than running instances all looking the same.

CI suites ran; I think that's all I needed to do?

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [ ] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
