### PR TITLE
Input stuff

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
@@ -74,16 +74,23 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		public void SetAnalog(IReadOnlyDictionary<string, int?> controls, int? controller = null)
+		public void SetAnalog(IReadOnlyDictionary<string, int> controls, int? controller = null)
 		{
-			foreach (var (k, v) in controls) SetAnalog(k, v, controller);
+			// If a controller is specified, we need to iterate over unique button names. If not, we iterate over
+			// ALL button names with P{controller} prefixes
+			foreach (var axis in _inputManager.ActiveController.ToAxisControlNameList(controller))
+			{
+				SetAnalog(axis, controls.TryGetValue(axis, out var state) ? state : null, controller);
+			}
 		}
 
 		public void SetAnalog(string control, int? value = null, int? controller = null)
 		{
 			try
 			{
-				_inputManager.StickyHoldController.SetAxisHold(controller == null ? control : $"P{controller} {control}", value);
+				var axisToSet = controller == null ? control : $"P{controller} {control}";
+				if (value == null) _inputManager.OverrideAdapter.UnSetAxis(axisToSet);
+				else _inputManager.OverrideAdapter.SetAxis(axisToSet, value.Value);
 			}
 			catch
 			{

--- a/src/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
@@ -46,8 +46,8 @@ namespace BizHawk.Client.Common
 				LogCallback($"invalid mnemonic string: {inputLogEntry}");
 				return;
 			}
-			foreach (var button in controller.Definition.BoolButtons) _inputManager.ButtonOverrideAdapter.SetButton(button, controller.IsPressed(button));
-			foreach (var axis in controller.Definition.Axes.Keys) _inputManager.ButtonOverrideAdapter.SetAxis(axis, controller.AxisValue(axis));
+			foreach (var button in controller.Definition.BoolButtons) _inputManager.OverrideAdapter.SetButton(button, controller.IsPressed(button));
+			foreach (var axis in controller.Definition.Axes.Keys) _inputManager.OverrideAdapter.SetAxis(axis, controller.AxisValue(axis));
 		}
 
 		public void Set(IReadOnlyDictionary<string, bool> buttons, int? controller = null)
@@ -65,8 +65,8 @@ namespace BizHawk.Client.Common
 			try
 			{
 				var buttonToSet = controller == null ? button : $"P{controller} {button}";
-				if (state == null) _inputManager.ButtonOverrideAdapter.UnSet(buttonToSet);
-				else _inputManager.ButtonOverrideAdapter.SetButton(buttonToSet, state.Value);
+				if (state == null) _inputManager.OverrideAdapter.UnSet(buttonToSet);
+				else _inputManager.OverrideAdapter.SetButton(buttonToSet, state.Value);
 
 				//"Overrides" is a gross line of code in that flushes overrides into the current controller.
 				//That's not really the way it was meant to work which was that it should pull all its values through the filters before ever using them.
@@ -79,7 +79,7 @@ namespace BizHawk.Client.Common
 				_inputManager.ActiveController.LatchFromPhysical(_inputManager.ControllerInputCoalescer);
 
 				//and here's where the overrides managed by this API are pushed in
-				_inputManager.ActiveController.Overrides(_inputManager.ButtonOverrideAdapter);
+				_inputManager.ActiveController.Overrides(_inputManager.OverrideAdapter);
 			}
 			catch
 			{

--- a/src/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
@@ -67,19 +67,6 @@ namespace BizHawk.Client.Common
 				var buttonToSet = controller == null ? button : $"P{controller} {button}";
 				if (state == null) _inputManager.OverrideAdapter.UnSet(buttonToSet);
 				else _inputManager.OverrideAdapter.SetButton(buttonToSet, state.Value);
-
-				//"Overrides" is a gross line of code in that flushes overrides into the current controller.
-				//That's not really the way it was meant to work which was that it should pull all its values through the filters before ever using them.
-				//Of course the code that does that is in the main loop and the lua API wouldnt know how to do it.
-				//I regret the whole hotkey filter chain OOP soup approach. Anyway, the code that
-
-				//in a crude, CRUDE, *CRUDE* approximation of what the main loop does, we need to pull the physical input again before it's freshly overridded
-				//but really, everything the main loop does needs to be done here again.
-				//I'm not doing that now.
-				_inputManager.ActiveController.LatchFromPhysical(_inputManager.ControllerInputCoalescer);
-
-				//and here's where the overrides managed by this API are pushed in
-				_inputManager.ActiveController.Overrides(_inputManager.OverrideAdapter);
 			}
 			catch
 			{

--- a/src/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
@@ -74,16 +74,40 @@ namespace BizHawk.Client.Common
 			}
 		}
 
+		[Obsolete("Use the overload with non-nullable int instead.")]
 		public void SetAnalog(IReadOnlyDictionary<string, int?> controls, int? controller = null)
 		{
-			foreach (var (k, v) in controls) SetAnalog(k, v, controller);
+			foreach (var (k, v) in controls)
+			{
+				// This obsolete method has diffent behavior than the new overload.
+				try
+				{
+					_inputManager.StickyHoldController.SetAxisHold(controller == null ? k : $"P{controller} {k}", v);
+				}
+				catch
+				{
+					// ignored
+				}
+			}
+		}
+
+		public void SetAnalog(IReadOnlyDictionary<string, int> controls, int? controller = null)
+		{
+			// If a controller is specified, we need to iterate over unique button names. If not, we iterate over
+			// ALL button names with P{controller} prefixes
+			foreach (var axis in _inputManager.ActiveController.ToAxisControlNameList(controller))
+			{
+				SetAnalog(axis, controls.TryGetValue(axis, out var state) ? state : null, controller);
+			}
 		}
 
 		public void SetAnalog(string control, int? value = null, int? controller = null)
 		{
 			try
 			{
-				_inputManager.StickyHoldController.SetAxisHold(controller == null ? control : $"P{controller} {control}", value);
+				var axisToSet = controller == null ? control : $"P{controller} {control}";
+				if (value == null) _inputManager.OverrideAdapter.UnSetAxis(axisToSet);
+				else _inputManager.OverrideAdapter.SetAxis(axisToSet, value.Value);
 			}
 			catch
 			{

--- a/src/BizHawk.Client.Common/Api/Interfaces/IJoypadApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IJoypadApi.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Client.Common
 		void SetFromMnemonicStr(string inputLogEntry);
 		void Set(IReadOnlyDictionary<string, bool> buttons, int? controller = null);
 		void Set(string button, bool? state = null, int? controller = null);
-		void SetAnalog(IReadOnlyDictionary<string, int?> controls, int? controller = null);
+		void SetAnalog(IReadOnlyDictionary<string, int> controls, int? controller = null);
 		void SetAnalog(string control, int? value = null, int? controller = null);
 	}
 }

--- a/src/BizHawk.Client.Common/Api/Interfaces/IJoypadApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IJoypadApi.cs
@@ -9,10 +9,30 @@ namespace BizHawk.Client.Common
 		IReadOnlyDictionary<string, object> Get(int? controller = null);
 		IReadOnlyDictionary<string, object> GetWithMovie(int? controller = null);
 		IReadOnlyDictionary<string, object> GetImmediate(int? controller = null);
+
+		/// <summary>
+		/// Sets the input for the current frame, as if the inputs came from the user. String will be interpreted the same way an entry from a movie input log would be.
+		/// </summary>
 		void SetFromMnemonicStr(string inputLogEntry);
+
+		/// <summary>
+		/// Sets the given buttons to their provided values for the current frame, as if the inputs came from the user. Any buttons previously set but missing from the given dictionary will be unset.
+		/// </summary>
 		void Set(IReadOnlyDictionary<string, bool> buttons, int? controller = null);
+
+		/// <summary>
+		/// Sets the given button to the provided state for the current frame, as if the input came from the user.
+		/// </summary>
 		void Set(string button, bool? state = null, int? controller = null);
+
+		/// <summary>
+		/// Sets the given analog controls to their provided values for the current frame, as if the inputs came from the user. Any analog inputs previously set but missing from the given dictionary will be unset.
+		/// </summary>
 		void SetAnalog(IReadOnlyDictionary<string, int> controls, int? controller = null);
+
+		/// <summary>
+		/// Sets the given analog control to the provided value for the current frame, as if the input came from the user.
+		/// </summary>
 		void SetAnalog(string control, int? value = null, int? controller = null);
 	}
 }

--- a/src/BizHawk.Client.Common/Api/Interfaces/IJoypadApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IJoypadApi.cs
@@ -12,7 +12,11 @@ namespace BizHawk.Client.Common
 		void SetFromMnemonicStr(string inputLogEntry);
 		void Set(IReadOnlyDictionary<string, bool> buttons, int? controller = null);
 		void Set(string button, bool? state = null, int? controller = null);
+
+		[Obsolete("Use the overload with non-nullable int instead.")]
 		void SetAnalog(IReadOnlyDictionary<string, int?> controls, int? controller = null);
+
+		void SetAnalog(IReadOnlyDictionary<string, int> controls, int? controller = null);
 		void SetAnalog(string control, int? value = null, int? controller = null);
 	}
 }

--- a/src/BizHawk.Client.Common/Api/Interfaces/IJoypadApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IJoypadApi.cs
@@ -9,14 +9,33 @@ namespace BizHawk.Client.Common
 		IReadOnlyDictionary<string, object> Get(int? controller = null);
 		IReadOnlyDictionary<string, object> GetWithMovie(int? controller = null);
 		IReadOnlyDictionary<string, object> GetImmediate(int? controller = null);
+
+		/// <summary>
+		/// Sets the input for the current frame, as if the inputs came from the user. String will be interpreted the same way an entry from a movie input log would be.
+		/// </summary>
 		void SetFromMnemonicStr(string inputLogEntry);
+
+		/// <summary>
+		/// Sets the given buttons to their provided values for the current frame, as if the inputs came from the user. Any buttons previously set but missing from the given dictionary will be unset.
+		/// </summary>
 		void Set(IReadOnlyDictionary<string, bool> buttons, int? controller = null);
+
+		/// <summary>
+		/// Sets the given button to the provided state for the current frame, as if the input came from the user.
+		/// </summary>
 		void Set(string button, bool? state = null, int? controller = null);
 
 		[Obsolete("Use the overload with non-nullable int instead.")]
 		void SetAnalog(IReadOnlyDictionary<string, int?> controls, int? controller = null);
 
+		/// <summary>
+		/// Sets the given analog controls to their provided values for the current frame, as if the inputs came from the user. Any analog inputs previously set but missing from the given dictionary will be unset.
+		/// </summary>
 		void SetAnalog(IReadOnlyDictionary<string, int> controls, int? controller = null);
+
+		/// <summary>
+		/// Sets the given analog control to the provided value for the current frame, as if the input came from the user.
+		/// </summary>
 		void SetAnalog(string control, int? value = null, int? controller = null);
 	}
 }

--- a/src/BizHawk.Client.Common/Controller.cs
+++ b/src/BizHawk.Client.Common/Controller.cs
@@ -190,20 +190,8 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		public void Overrides(OverrideAdapter controller)
-		{
-			foreach (var button in controller.Overrides)
-			{
-				_buttons[button] = controller.IsPressed(button);
-			}
-
-			foreach (var button in controller.AxisOverrides)
-			{
-				_axes[button] = controller.AxisValue(button);
-			}
-
-			foreach (var button in controller.InversedButtons) _buttons[button] = !_buttons.GetValueOrDefault(button);
-		}
+		public void OverrideButton(string button, bool value)
+			=> _buttons[button] = value;
 
 		public void BindMulti(string button, string controlString)
 		{

--- a/src/BizHawk.Client.Common/Controller.cs
+++ b/src/BizHawk.Client.Common/Controller.cs
@@ -178,8 +178,6 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		public void OR_FromLogical(IController controller)
 		{
-			// change: or from each button that the other input controller has
-			// foreach (string button in type.BoolButtons)
 			if (controller.Definition != null)
 			{
 				foreach (var button in controller.Definition.BoolButtons)

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -7,33 +7,46 @@ using BizHawk.Emulation.Common;
 namespace BizHawk.Client.Common
 {
 
-	// don't take my word for it, but here is a guide...
-	// user -> Input -> ActiveController -> UDLR -> StickyXORPlayerInputAdapter -> TurboAdapter(TBD) -> Lua(?TBD?) -> ..
-	// .. -> MovieInputSourceAdapter -> (MovieSession) -> MovieOutputAdapter -> ControllerOutput(1) -> Game
-	// (1)->Input Display
+	// Input chain:
+	// ControllerInputCoalescer (host inputs) -> ActiveController and AutoFireController and ClientControls (with an indirect route into sticky toggles too)
+	// Output is: ((OverrideAdapter ?? ActiveController) || AutoFireController || ClickyController) ^ (StickyHoldController || StickyAutofireController)
+
 #pragma warning disable MA0104 // unlikely to conflict with System.Windows.Input.InputManager
 	public class InputManager
 #pragma warning restore MA0104
 	{
-		// the original source controller, bound to the user, sort of the "input" port for the chain, i think
+		/// <summary>
+		/// the "main" controller that is bound to regular user inputs
+		/// </summary>
 		public Controller ActiveController { get; private set; }
 
-		// rapid fire version on the user controller, has its own key bindings and is OR'ed against ActiveController
+		/// <summary>
+		/// rapid fire version on the user controller, has its own key bindings and is OR'ed against <see cref="ActiveController"/>
+		/// </summary>
 		public AutofireController AutoFireController { get; private set; }
 
-		// the "output" port for the controller chain.
+		/// <summary>
+		/// the "output" port for the controller chain; this is what gets sent to the core
+		/// </summary>
 		public CopyControllerAdapter ControllerOutput { get; } = new CopyControllerAdapter();
 
-		private UdlrControllerAdapter UdLRControllerAdapter { get; } = new UdlrControllerAdapter();
-
+		/// <summary>
+		/// a controller for auto-hold, that may be used by tools; XOR'ed with user inputs
+		/// also used when the user sets a auto-hold via the auto-hold hotkey
+		/// </summary>
 		public StickyHoldController StickyHoldController { get; private set; }
+
+		/// <summary>
+		/// a controller for auto-fire, that may be used by tools; XOR'ed with user inputs
+		/// also used when the user sets a auto-fire via the auto-fire hotkey (this is separate from normal autofire controller)
+		/// </summary>
 		public StickyAutofireController StickyAutofireController { get; private set; }
 
 		// StickyHold OR StickyAutofire
 		public IController StickyController { get; private set; }
 
 		/// <summary>
-		/// Used to AND to another controller, used for <see cref="IJoypadApi.Set(IReadOnlyDictionary{string, bool}, int?)">JoypadApi.Set</see>
+		/// Used to override a subset of inputs on another controller, used for <see cref="IJoypadApi.Set(IReadOnlyDictionary{string, bool}, int?)">JoypadApi.Set</see>
 		/// </summary>
 		public OverrideAdapter OverrideAdapter { get; } = new OverrideAdapter();
 
@@ -65,19 +78,17 @@ namespace BizHawk.Client.Common
 			StickyHoldController = new StickyHoldController(def);
 			StickyAutofireController = new StickyAutofireController(def, config.AutofireOn, config.AutofireOff);
 
-			// allow propagating controls that are in the current controller definition but not in the prebaked one
-			// these two lines shouldn't be required anymore under the new system? --natt 2013
-			// they were *mostly* not required, see https://github.com/TASEmulators/BizHawk/issues/3458 --yoshi 2022
-			ClickyController.Definition = def;
+			ClickyController.Definition = def; // We don't need a new instance, but we do need the definitions to match.
 
-			// Wire up input chain
+			// Wire up input chain (some things also happen in RunControllerChain)
 
-			UdLRControllerAdapter.Source = ActiveController.Or(AutoFireController);
-			UdLRControllerAdapter.OpposingDirPolicy = config.OpposingDirPolicy;
+			UdlrControllerAdapter udLRControllerAdapter = new UdlrControllerAdapter();
+			udLRControllerAdapter.Source = ActiveController.Or(AutoFireController);
+			udLRControllerAdapter.OpposingDirPolicy = config.OpposingDirPolicy;
 
 			StickyController = StickyHoldController.Or(StickyAutofireController);
 
-			session.MovieIn = UdLRControllerAdapter.Xor(StickyController);
+			session.MovieIn = udLRControllerAdapter.Xor(StickyController);
 			session.StickySource = StickyController;
 			ControllerOutput.Source = session.MovieOut;
 		}
@@ -235,6 +246,7 @@ namespace BizHawk.Client.Common
 			ClientControls.LatchFromPhysical(_hotkeyCoalescer);
 
 			// controller, which actually has a chain
+			// Note: ControllerOutput gets a bunch of stuff from a controller chain set up in SyncControls
 			List<string> oldPressedButtons = ActiveController.PressedButtons;
 
 			ActiveController.LatchFromPhysical(ControllerInputCoalescer);
@@ -246,6 +258,9 @@ namespace BizHawk.Client.Common
 				ActiveController.ApplyAxisConstraints("Natural Circle");
 			}
 
+			ActiveController.Overrides(OverrideAdapter);
+
+			// This method is where we can most easily detect presses, so handle sticky toggles here
 			if (ClientControls["Autohold"] || ClientControls["Autofire"])
 			{
 				List<string> newPressedButtons = ActiveController.PressedButtons;
@@ -266,10 +281,6 @@ namespace BizHawk.Client.Common
 					}
 				}
 			}
-
-			// last, inputs set via Joypad API should override everything else
-			// TODO: Autofire gets OR'd in outside of InputManager, so it currently can override joypad.set({A = false})
-			ActiveController.Overrides(OverrideAdapter);
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -35,12 +35,12 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Used to AND to another controller, used for <see cref="IJoypadApi.Set(IReadOnlyDictionary{string, bool}, int?)">JoypadApi.Set</see>
 		/// </summary>
-		public OverrideAdapter ButtonOverrideAdapter { get; } = new OverrideAdapter();
+		public OverrideAdapter OverrideAdapter { get; } = new OverrideAdapter();
 
 		/// <summary>
 		/// fire off one-frame logical button clicks here. useful for things like ti-83 virtual pad and reset buttons
 		/// </summary>
-		public ClickyVirtualPadController ClickyVirtualPadController { get; } = new ClickyVirtualPadController();
+		public ClickyVirtualPadController ClickyController { get; } = new ClickyVirtualPadController();
 
 		// Input state for game controller inputs are coalesced here
 		// This relies on a client specific implementation!
@@ -68,7 +68,7 @@ namespace BizHawk.Client.Common
 			// allow propagating controls that are in the current controller definition but not in the prebaked one
 			// these two lines shouldn't be required anymore under the new system? --natt 2013
 			// they were *mostly* not required, see https://github.com/TASEmulators/BizHawk/issues/3458 --yoshi 2022
-			ClickyVirtualPadController.Definition = def;
+			ClickyController.Definition = def;
 
 			// Wire up input chain
 
@@ -238,7 +238,7 @@ namespace BizHawk.Client.Common
 			List<string> oldPressedButtons = ActiveController.PressedButtons;
 
 			ActiveController.LatchFromPhysical(ControllerInputCoalescer);
-			ActiveController.OR_FromLogical(ClickyVirtualPadController);
+			ActiveController.OR_FromLogical(ClickyController);
 			AutoFireController.LatchFromPhysical(ControllerInputCoalescer);
 
 			if (config.N64UseCircularAnalogConstraint)
@@ -267,8 +267,9 @@ namespace BizHawk.Client.Common
 				}
 			}
 
-			// autohold/autofire must not be affected by the following inputs
-			ActiveController.Overrides(ButtonOverrideAdapter);
+			// last, inputs set via Joypad API should override everything else
+			// TODO: Autofire gets OR'd in outside of InputManager, so it currently can override joypad.set({A = false})
+			ActiveController.Overrides(OverrideAdapter);
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -282,5 +282,14 @@ namespace BizHawk.Client.Common
 				}
 			}
 		}
+
+		public void AfterFrame(bool isLagFrame, Config config)
+		{
+			ClickyController.FrameTick();
+			OverrideAdapter.FrameTick();
+
+			if (isLagFrame && config.AutofireLagFrames) AutoFireController.IncrementStarts();
+			StickyAutofireController.IncrementLoops(isLagFrame);
+		}
 	}
 }

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -21,7 +21,7 @@ namespace BizHawk.Client.Common
 		public Controller ActiveController { get; private set; }
 
 		/// <summary>
-		/// rapid fire version on the user controller, has its own key bindings and is OR'ed against <see cref="ActiveController"/>
+		/// rapid fire version on the user controller, has its own key bindings and is OR'ed against <see cref="OverrideAdapter"/>
 		/// </summary>
 		public AutofireController AutoFireController { get; private set; }
 
@@ -48,7 +48,7 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Used to override a subset of inputs on another controller, used for <see cref="IJoypadApi.Set(IReadOnlyDictionary{string, bool}, int?)">JoypadApi.Set</see>
 		/// </summary>
-		public OverrideAdapter OverrideAdapter { get; } = new OverrideAdapter();
+		public OverrideAdapter OverrideAdapter { get; private set; }
 
 		/// <summary>
 		/// fire off one-frame logical button clicks here. useful for things like ti-83 virtual pad and reset buttons
@@ -77,13 +77,14 @@ namespace BizHawk.Client.Common
 			AutoFireController = BindToDefinitionAF(emulator, config.AllTrollersAutoFire, config.AutofireOn, config.AutofireOff);
 			StickyHoldController = new StickyHoldController(def);
 			StickyAutofireController = new StickyAutofireController(def, config.AutofireOn, config.AutofireOff);
+			OverrideAdapter = new(ActiveController);
 
 			ClickyController.Definition = def; // We don't need a new instance, but we do need the definitions to match.
 
 			// Wire up input chain (some things also happen in RunControllerChain)
 
 			UdlrControllerAdapter udLRControllerAdapter = new UdlrControllerAdapter();
-			udLRControllerAdapter.Source = ActiveController.Or(AutoFireController);
+			udLRControllerAdapter.Source = OverrideAdapter.Or(AutoFireController);
 			udLRControllerAdapter.OpposingDirPolicy = config.OpposingDirPolicy;
 
 			StickyController = StickyHoldController.Or(StickyAutofireController);
@@ -257,8 +258,6 @@ namespace BizHawk.Client.Common
 			{
 				ActiveController.ApplyAxisConstraints("Natural Circle");
 			}
-
-			ActiveController.Overrides(OverrideAdapter);
 
 			// This method is where we can most easily detect presses, so handle sticky toggles here
 			if (ClientControls["Autohold"] || ClientControls["Autofire"])

--- a/src/BizHawk.Client.Common/inputAdapters/OverrideAdapter.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/OverrideAdapter.cs
@@ -50,6 +50,11 @@ namespace BizHawk.Client.Common
 			_inverses.Remove(button);
 		}
 
+		public void UnSetAxis(string name)
+		{
+			_axisOverrides.Remove(name);
+		}
+
 		public void SetInverse(string button)
 		{
 			_inverses.Add(button);

--- a/src/BizHawk.Client.Common/inputAdapters/OverrideAdapter.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/OverrideAdapter.cs
@@ -4,34 +4,36 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
 {
-	/// <summary>
-	/// Used to pass into an Override method to manage the logic overriding input
-	/// This only works with bool buttons!
-	/// </summary>
-	public class OverrideAdapter : IController
+	public class OverrideAdapter : IInputAdapter
 	{
-		public ControllerDefinition Definition { get; private set; }
+		public IController Source { get; set; }
+
+		public ControllerDefinition Definition => Source.Definition;
 
 		private readonly Dictionary<string, bool> _overrides = new Dictionary<string, bool>();
 		private readonly Dictionary<string, int> _axisOverrides = new Dictionary<string, int>();
 		private readonly List<string> _inverses = new List<string>();
 
+		public OverrideAdapter(IController source)
+		{
+			this.Source = source;
+		}
+
 		/// <exception cref="InvalidOperationException"><paramref name="button"/> not overridden</exception>
 		public bool IsPressed(string button)
-			=> _overrides.TryGetValue(button, out var b) ? b : throw new InvalidOperationException();
+		{
+			if (_overrides.TryGetValue(button, out var b)) return b;
+
+			bool invert = _inverses.Contains(button);
+			return Source.IsPressed(button) ^ invert;
+		}
 
 		public int AxisValue(string name)
-			=> _axisOverrides.TryGetValue(name, out var i) ? i : 0;
+			=> _axisOverrides.TryGetValue(name, out var i) ? i : Source.AxisValue(name);
 
 		public IReadOnlyCollection<(string Name, int Strength)> GetHapticsSnapshot() => throw new NotImplementedException(); // no idea --yoshi
 
 		public void SetHapticChannelStrength(string name, int strength) => throw new NotImplementedException(); // no idea --yoshi
-
-		public IEnumerable<string> Overrides => _overrides.Keys;
-
-		public IEnumerable<string> AxisOverrides => _axisOverrides.Keys;
-
-		public IEnumerable<string> InversedButtons => _inverses;
 
 		public void SetAxis(string name, int value)
 			=> _axisOverrides[name] = value;

--- a/src/BizHawk.Client.Common/lua/CommonLibs/JoypadLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/JoypadLuaLibrary.cs
@@ -28,12 +28,12 @@ namespace BizHawk.Client.Common
 			=> _th.DictToTable(APIs.Joypad.GetImmediate(controller));
 
 		[LuaMethodExample("joypad.setfrommnemonicstr( \"|    0,    0,    0,  100,...R..B....|\" );")]
-		[LuaMethod("setfrommnemonicstr", "sets the given buttons to their provided values for the current frame, string will be interpreted the same way an entry from a movie input log would be")]
+		[LuaMethod("setfrommnemonicstr", "Sets the input for the current frame, as if the inputs came from the user. String will be interpreted the same way an entry from a movie input log would be.")]
 		public void SetFromMnemonicStr(string inputLogEntry)
 			=> APIs.Joypad.SetFromMnemonicStr(inputLogEntry);
 
 		[LuaMethodExample("joypad.set( { [\"Left\"] = true, [ \"A\" ] = true, [ \"B\" ] = true } );")]
-		[LuaMethod("set", "sets the given buttons to their provided values for the current frame")]
+		[LuaMethod("set", "Sets the given buttons to their provided values for the current frame, as if the inputs came from the user. Any buttons previously set but missing from the given table will be unset.")]
 		public void Set(LuaTable buttons, int? controller = null)
 		{
 			var dict = new Dictionary<string, bool>();

--- a/src/BizHawk.Client.Common/lua/CommonLibs/JoypadLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/JoypadLuaLibrary.cs
@@ -45,13 +45,13 @@ namespace BizHawk.Client.Common
 		}
 
 		[LuaMethodExample("joypad.setanalog( { [ \"Tilt X\" ] = -63, [ \"Tilt Y\" ] = 127 } );")]
-		[LuaMethod("setanalog", "Sets the given analog controls to their provided values as autoholds. Set axes to the empty string to clear individual holds.")]
+		[LuaMethod("setanalog", "Sets the given analog controls to their provided values for the current frame, as if the inputs came from the user. Any analog inputs previously set but missing from the given table will be unset.")]
 		public void SetAnalog(LuaTable controls, int? controller = null)
 		{
-			var dict = new Dictionary<string, int?>();
+			var dict = new Dictionary<string, int>();
 			foreach (var (k, v) in controls)
 			{
-				dict[k.ToString()] = long.TryParse(v.ToString(), out var d) ? (int) d : null;
+				dict[k.ToString()] = int.Parse(v.ToString());
 			}
 			APIs.Joypad.SetAnalog(dict, controller);
 		}

--- a/src/BizHawk.Client.Common/lua/CommonLibs/JoypadLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/JoypadLuaLibrary.cs
@@ -44,14 +44,27 @@ namespace BizHawk.Client.Common
 			APIs.Joypad.Set(dict, controller);
 		}
 
-		[LuaMethodExample("joypad.setanalog( { [ \"Tilt X\" ] = -63, [ \"Tilt Y\" ] = 127 } );")]
-		[LuaMethod("setanalog", "Sets the given analog controls to their provided values as autoholds. Set axes to the empty string to clear individual holds.")]
-		public void SetAnalog(LuaTable controls, int? controller = null)
+		[LuaDeprecatedMethod]
+		[Obsolete($"Use {nameof(SetAnalog)}")]
+		[LuaMethod("setanalog", "Use set_analog instead. This function does not work correctly and will be removed in a future version.")]
+		public void SetAnalog_Deprecated(LuaTable controls, int? controller = null)
 		{
 			var dict = new Dictionary<string, int?>();
 			foreach (var (k, v) in controls)
 			{
 				dict[k.ToString()] = long.TryParse(v.ToString(), out var d) ? (int) d : null;
+			}
+			APIs.Joypad.SetAnalog(dict, controller);
+		}
+
+		[LuaMethodExample("joypad.set_analog( { [ \"Tilt X\" ] = -63, [ \"Tilt Y\" ] = 127 } );")]
+		[LuaMethod("set_analog", "Sets the given analog controls to their provided values for the current frame, as if the inputs came from the user. Any analog inputs previously set but missing from the given table will be unset.")]
+		public void SetAnalog(LuaTable controls, int? controller = null)
+		{
+			var dict = new Dictionary<string, int>();
+			foreach (var (k, v) in controls)
+			{
+				dict[k.ToString()] = int.Parse(v.ToString());
 			}
 			APIs.Joypad.SetAnalog(dict, controller);
 		}

--- a/src/BizHawk.Client.EmuHawk/MainForm.VSystem.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.VSystem.cs
@@ -674,7 +674,7 @@ namespace BizHawk.Client.EmuHawk
 		private void FdsEjectDiskMenuItem_Click(object sender, EventArgs e)
 		{
 			if (MovieSession.Movie.IsPlaying()) return;
-			InputManager.ClickyVirtualPadController.Click("FDS Eject");
+			InputManager.ClickyController.Click("FDS Eject");
 			AddOnScreenMessage("FDS disk ejected.");
 		}
 
@@ -694,21 +694,21 @@ namespace BizHawk.Client.EmuHawk
 		private void VsInsertCoinP1MenuItem_Click(object sender, EventArgs e)
 		{
 			if (MovieSession.Movie.IsPlaying() || !LoadedCoreIsNesHawkInVSMode) return;
-			InputManager.ClickyVirtualPadController.Click("Insert Coin P1");
+			InputManager.ClickyController.Click("Insert Coin P1");
 			AddOnScreenMessage("P1 Coin Inserted");
 		}
 
 		private void VsInsertCoinP2MenuItem_Click(object sender, EventArgs e)
 		{
 			if (MovieSession.Movie.IsPlaying() || !LoadedCoreIsNesHawkInVSMode) return;
-			InputManager.ClickyVirtualPadController.Click("Insert Coin P2");
+			InputManager.ClickyController.Click("Insert Coin P2");
 			AddOnScreenMessage("P2 Coin Inserted");
 		}
 
 		private void VsServiceSwitchMenuItem_Click(object sender, EventArgs e)
 		{
 			if (MovieSession.Movie.IsPlaying() || !LoadedCoreIsNesHawkInVSMode) return;
-			InputManager.ClickyVirtualPadController.Click("Service Switch");
+			InputManager.ClickyController.Click("Service Switch");
 			AddOnScreenMessage("Service Switch Pressed");
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2454,7 +2454,7 @@ namespace BizHawk.Client.EmuHawk
 			if (Emulator.ControllerDefinition.BoolButtons.Contains("Reset")
 				&& !MovieSession.Movie.IsPlaying())
 			{
-				InputManager.ClickyVirtualPadController.Click("Reset");
+				InputManager.ClickyController.Click("Reset");
 				AddOnScreenMessage("Reset button pressed.");
 			}
 		}
@@ -2465,7 +2465,7 @@ namespace BizHawk.Client.EmuHawk
 			if (Emulator.ControllerDefinition.BoolButtons.Contains("Power")
 				&& !MovieSession.Movie.IsPlaying())
 			{
-				InputManager.ClickyVirtualPadController.Click("Power");
+				InputManager.ClickyController.Click("Power");
 				AddOnScreenMessage("Power button pressed.");
 			}
 		}
@@ -2730,7 +2730,7 @@ namespace BizHawk.Client.EmuHawk
 				if (Emulator.ControllerDefinition.BoolButtons.Contains(button)
 					&& !MovieSession.Movie.IsPlaying())
 				{
-					InputManager.ClickyVirtualPadController.Click(button);
+					InputManager.ClickyController.Click(button);
 					AddOnScreenMessage(msg);
 				}
 			});
@@ -2924,8 +2924,8 @@ namespace BizHawk.Client.EmuHawk
 				CheatList.Pulse();
 
 				// zero 03-may-2014 - moved this before call to UpdateToolsBefore(), since it seems to clear the state which a lua event.framestart is going to want to alter
-				InputManager.ClickyVirtualPadController.FrameTick();
-				InputManager.ButtonOverrideAdapter.FrameTick();
+				InputManager.ClickyController.FrameTick();
+				InputManager.OverrideAdapter.FrameTick();
 
 				if (IsTurboing && !atTurboSeekEnd)
 				{

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2923,10 +2923,6 @@ namespace BizHawk.Client.EmuHawk
 
 				CheatList.Pulse();
 
-				// zero 03-may-2014 - moved this before call to UpdateToolsBefore(), since it seems to clear the state which a lua event.framestart is going to want to alter
-				InputManager.ClickyController.FrameTick();
-				InputManager.OverrideAdapter.FrameTick();
-
 				if (IsTurboing && !atTurboSeekEnd)
 				{
 					Tools.FastUpdateBefore();
@@ -3015,6 +3011,9 @@ namespace BizHawk.Client.EmuHawk
 				}
 
 				CheatList.Pulse();
+
+				InputManager.ClickyController.FrameTick();
+				InputManager.OverrideAdapter.FrameTick();
 
 				if (Emulator.CanPollInput() && Emulator.AsInputPollable().IsLagFrame && Config.AutofireLagFrames)
 				{

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3012,15 +3012,7 @@ namespace BizHawk.Client.EmuHawk
 
 				CheatList.Pulse();
 
-				InputManager.ClickyController.FrameTick();
-				InputManager.OverrideAdapter.FrameTick();
-
-				if (Emulator.CanPollInput() && Emulator.AsInputPollable().IsLagFrame && Config.AutofireLagFrames)
-				{
-					InputManager.AutoFireController.IncrementStarts();
-				}
-
-				InputManager.StickyAutofireController.IncrementLoops(Emulator.CanPollInput() && Emulator.AsInputPollable().IsLagFrame);
+				InputManager.AfterFrame(Emulator.CanPollInput() && Emulator.AsInputPollable().IsLagFrame, Config);
 
 				PressFrameAdvance = false;
 

--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Hardcore.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RetroAchievements.Hardcore.cs
@@ -60,8 +60,6 @@ namespace BizHawk.Client.EmuHawk
 			[typeof(Snes9x)] = new[] { "ShowBg0", "ShowBg1", "ShowBg2", "ShowBg3", "ShowSprites0", "ShowSprites1", "ShowSprites2", "ShowSprites3", "ShowWindow", "ShowTransparency" },
 		};
 
-		private readonly OverrideAdapter _hardcoreHotkeyOverrides = new();
-
 		protected abstract void HandleHardcoreModeDisable(string reason);
 
 		protected void CheckHardcoreModeConditions()
@@ -85,10 +83,8 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			// suppress rewind and frame advance hotkeys
-			_hardcoreHotkeyOverrides.FrameTick();
-			_hardcoreHotkeyOverrides.SetButton("Frame Advance", false);
-			_hardcoreHotkeyOverrides.SetButton("Rewind", false);
-			_inputManager.ClientControls.Overrides(_hardcoreHotkeyOverrides);
+			_inputManager.ClientControls.OverrideButton("Frame Advance", false);
+			_inputManager.ClientControls.OverrideButton("Rewind", false);
 			_mainForm.FrameInch = false;
 
 			var fastForward = _mainForm.IsFastForwarding;

--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
@@ -441,7 +441,7 @@ namespace BizHawk.Client.EmuHawk
 			foreach (var button in controller.Definition.BoolButtons)
 			{
 				// TODO: make an input adapter specifically for the bot?
-				InputManager.ButtonOverrideAdapter.SetButton(button, controller.IsPressed(button));
+				InputManager.OverrideAdapter.SetButton(button, controller.IsPressed(button));
 			}
 
 			InputManager.SyncControls(Emulator, MovieSession, Config);
@@ -862,7 +862,7 @@ namespace BizHawk.Client.EmuHawk
 					foreach (var button in controller.Definition.BoolButtons)
 					{
 						// TODO: make an input adapter specifically for the bot?
-						InputManager.ButtonOverrideAdapter.SetButton(button, controller.IsPressed(button));
+						InputManager.OverrideAdapter.SetButton(button, controller.IsPressed(button));
 					}
 
 					InputManager.SyncControls(Emulator, MovieSession, Config);
@@ -991,12 +991,12 @@ namespace BizHawk.Client.EmuHawk
 				double probability = _cachedControlProbabilities[button];
 				bool pressed = rand.Next(100) < probability;
 
-				InputManager.ClickyVirtualPadController.SetBool(button, pressed);
+				InputManager.ClickyController.SetBool(button, pressed);
 			}
 			InputManager.SyncControls(Emulator, MovieSession, Config);
 
 			if (clear_log) { _currentBotAttempt.Log.Clear(); }
-			_currentBotAttempt.Log.Add(Bk2LogEntryGenerator.GenerateLogEntry(InputManager.ClickyVirtualPadController));
+			_currentBotAttempt.Log.Add(Bk2LogEntryGenerator.GenerateLogEntry(InputManager.ClickyController));
 		}
 
 		private void StartBot()

--- a/src/BizHawk.Client.EmuHawk/tools/TI83/TI83KeyPad.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TI83/TI83KeyPad.cs
@@ -43,7 +43,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void KeyClick(string name)
 		{
-			InputManager.ClickyVirtualPadController.Click(name);
+			InputManager.ClickyController.Click(name);
 		}
 
 		private void SetToolTips()

--- a/src/BizHawk.Tests.Client.Common/Api/JoypadApiTests.cs
+++ b/src/BizHawk.Tests.Client.Common/Api/JoypadApiTests.cs
@@ -128,7 +128,7 @@ namespace BizHawk.Tests.Client.Common.Api
 			Context context = new();
 
 			// act
-			context.api.SetAnalog(new Dictionary<string, int?>() { ["Stick"] = 2 });
+			context.api.SetAnalog(new Dictionary<string, int>() { ["Stick"] = 2 });
 
 			// assert
 			Assert.AreEqual(2, context.OutputController.AxisValue("Stick"));
@@ -159,7 +159,7 @@ namespace BizHawk.Tests.Client.Common.Api
 			inputsWithStick["Stick"] = 2;
 
 			// act
-			context.api.SetAnalog(new Dictionary<string, int?>() { ["Stick"] = 2});
+			context.api.SetAnalog(new Dictionary<string, int>() { ["Stick"] = 2});
 			var inputs = context.api.Get();
 
 			// assert
@@ -188,7 +188,7 @@ namespace BizHawk.Tests.Client.Common.Api
 			context.Press("S");
 
 			// act
-			context.api.SetAnalog(new Dictionary<string, int?>() { ["Stick"] = 2});
+			context.api.SetAnalog(new Dictionary<string, int>() { ["Stick"] = 2});
 
 			// assert
 			Assert.AreEqual(2, context.OutputController.AxisValue("Stick"));
@@ -213,10 +213,10 @@ namespace BizHawk.Tests.Client.Common.Api
 		{
 			// arrange
 			Context context = new();
-			context.api.SetAnalog(new Dictionary<string, int?>() { ["Stick"] = 2 });
+			context.api.SetAnalog(new Dictionary<string, int>() { ["Stick"] = 2 });
 
 			// act
-			context.api.SetAnalog(new Dictionary<string, int?>());
+			context.api.SetAnalog(new Dictionary<string, int>());
 
 			// assert
 			Assert.AreEqual(FakeEmulator.Definition.Axes["Stick"].Neutral, context.OutputController.AxisValue("Stick"));

--- a/src/BizHawk.Tests.Client.Common/Api/JoypadApiTests.cs
+++ b/src/BizHawk.Tests.Client.Common/Api/JoypadApiTests.cs
@@ -1,0 +1,225 @@
+﻿using System.Collections.Generic;
+
+using BizHawk.Client.Common;
+using BizHawk.Emulation.Common;
+using BizHawk.Tests.Client.Common.Movie;
+
+namespace BizHawk.Tests.Client.Common.Api
+{
+	[TestClass]
+	public class JoypadApiTests
+	{
+		private static Dictionary<string, object> DefaultInputs;
+		static JoypadApiTests()
+		{
+			FakeEmulator e = new();
+			DefaultInputs = new();
+			foreach (string b in e.ControllerDefinition.BoolButtons)
+				DefaultInputs[b] = false;
+			foreach (var kvp in e.ControllerDefinition.Axes)
+				DefaultInputs[kvp.Key] = kvp.Value.Neutral;
+		}
+
+		private class Context
+		{
+
+			public InputManagerTests.Context inputContext;
+			public JoypadApi api;
+
+			public IController OutputController => inputContext.manager.ControllerOutput;
+
+			public Context()
+			{
+				FakeEmulator emulator = new();
+				FakeMovieSession movieSession = new(emulator);
+				inputContext = new(emulator, movieSession);
+				api = new(null, inputContext.manager, movieSession);
+
+				inputContext.manager.ActiveController.BindMulti("A", "A");
+				inputContext.manager.ActiveController.BindMulti("B", "B");
+				inputContext.manager.ActiveController.BindAxis("Stick", new AnalogBind("", 1f, 0f, "S", ""));
+			}
+
+			public void Press(string button)
+			{
+				inputContext.source.MakePressEvent(button, 0);
+				inputContext.BasicInputProcessing();
+			}
+
+			public void Release(string button)
+			{
+				inputContext.source.MakeReleaseEvent(button, 0);
+				inputContext.BasicInputProcessing();
+			}
+		}
+
+		private static void AssertDictMatches(IReadOnlyDictionary<string, object> expected, IReadOnlyDictionary<string, object> actual)
+		{
+			foreach (var kvp in expected)
+			{
+				Assert.IsTrue(actual.TryGetValue(kvp.Key, out object value), $"Expected to find key {kvp.Key} but did not.");
+				Assert.AreEqual(kvp.Value, value, $"Value of {kvp.Key} did not match. Expected {kvp.Value}, got {value}.");
+			}
+			Assert.AreEqual(expected.Count, actual.Count);
+		}
+
+		[TestMethod]
+		public void GetDefaultInputs()
+		{
+			// arrange
+			Context context = new();
+
+			// act
+			var inputs = context.api.Get();
+
+			// assert
+			AssertDictMatches(DefaultInputs, inputs);
+		}
+
+		[TestMethod]
+		public void SetButton()
+		{
+			// arrange
+			Context context = new();
+
+			// act
+			context.api.Set(new Dictionary<string, bool>() { ["A"] = true });
+
+			// assert
+			Assert.IsTrue(context.OutputController.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void GetPressedButton()
+		{
+			// arrange
+			Context context = new();
+			context.Press("A");
+			var inputsWithA = DefaultInputs.ToDictionary();
+			inputsWithA["A"] = true;
+
+			// act
+			var inputs = context.api.Get();
+
+			// assert
+			AssertDictMatches(inputsWithA, inputs);
+		}
+
+		[TestMethod]
+		public void RoundTripButton()
+		{
+			// arrange
+			Context context = new();
+			var inputsWithA = DefaultInputs.ToDictionary();
+			inputsWithA["A"] = true;
+
+			// act
+			context.api.Set(new Dictionary<string, bool>() { ["A"] = true });
+			var inputs = context.api.Get();
+
+			// assert
+			AssertDictMatches(inputsWithA, inputs);
+		}
+
+		[TestMethod]
+		public void SetAnalog()
+		{
+			// arrange
+			Context context = new();
+
+			// act
+			context.api.SetAnalog(new Dictionary<string, int?>() { ["Stick"] = 2 });
+
+			// assert
+			Assert.AreEqual(2, context.OutputController.AxisValue("Stick"));
+		}
+
+		[TestMethod]
+		public void GetAnalog()
+		{
+			// arrange
+			Context context = new();
+			context.Press("S");
+			var inputsWithStick = DefaultInputs.ToDictionary();
+			inputsWithStick["Stick"] = FakeEmulator.Definition.Axes["Stick"].Max;
+
+			// act
+			var inputs = context.api.Get();
+
+			// assert
+			AssertDictMatches(inputsWithStick, inputs);
+		}
+
+		[TestMethod]
+		public void RoundTripAnalog()
+		{
+			// arrange
+			Context context = new();
+			var inputsWithStick = DefaultInputs.ToDictionary();
+			inputsWithStick["Stick"] = 2;
+
+			// act
+			context.api.SetAnalog(new Dictionary<string, int?>() { ["Stick"] = 2});
+			var inputs = context.api.Get();
+
+			// assert
+			AssertDictMatches(inputsWithStick, inputs);
+		}
+
+		[TestMethod]
+		public void OverridesButton()
+		{
+			// arrange
+			Context context = new();
+			context.Press("A");
+
+			// act
+			context.api.Set(new Dictionary<string, bool>() { ["A"] = false });
+
+			// assert
+			Assert.IsFalse(context.OutputController.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void OverridesAnalog()
+		{
+			// arrange
+			Context context = new();
+			context.Press("S");
+
+			// act
+			context.api.SetAnalog(new Dictionary<string, int?>() { ["Stick"] = 2});
+
+			// assert
+			Assert.AreEqual(2, context.OutputController.AxisValue("Stick"));
+		}
+
+		[TestMethod]
+		public void UnsetButton()
+		{
+			// arrange
+			Context context = new();
+			context.api.Set(new Dictionary<string, bool>() { ["A"] = true });
+
+			// act
+			context.api.Set(new Dictionary<string, bool>());
+
+			// assert
+			Assert.IsFalse(context.OutputController.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void UnsetAnalog()
+		{
+			// arrange
+			Context context = new();
+			context.api.SetAnalog(new Dictionary<string, int?>() { ["Stick"] = 2 });
+
+			// act
+			context.api.SetAnalog(new Dictionary<string, int?>());
+
+			// assert
+			Assert.AreEqual(FakeEmulator.Definition.Axes["Stick"].Neutral, context.OutputController.AxisValue("Stick"));
+		}
+	}
+}

--- a/src/BizHawk.Tests.Client.Common/InputManagerTests.cs
+++ b/src/BizHawk.Tests.Client.Common/InputManagerTests.cs
@@ -37,15 +37,21 @@ namespace BizHawk.Tests.Client.Common
 				_hotkeys = hotkeys;
 			}
 
+			/// <summary>
+			/// After running this, <see cref="InputManager.ControllerOutput"/> will hold the values for the NEXT frame, not the one just simulated.
+			/// </summary>
 			public void EmulateFrameAdvance(bool lag = false)
 			{
-				emulator.FrameAdvance(manager.ControllerOutput, false);
 				BasicInputProcessing();
-
-				if (lag) manager.AutoFireController.IncrementStarts();
-				manager.StickyAutofireController.IncrementLoops(lag);
+				emulator.FrameAdvance(manager.ControllerOutput, false);
+				manager.AfterFrame(lag, config);
+				BasicInputProcessing(); // must call this again to ensure asserts on ControllerOutput see all the results of AfterFrame
 			}
 
+			/// <summary>
+			/// Process all the simulated inputs, and update the controllers.
+			/// Call this before (or instead of) <see cref="EmulateFrameAdvance(bool)"/> when you need to test the input that will be given to the next frame.
+			/// </summary>
 			public void BasicInputProcessing()
 			{
 				manager.ProcessInput(source, ProcessHotkey, config, (_, _) => { });
@@ -507,6 +513,164 @@ namespace BizHawk.Tests.Client.Common
 			context.BasicInputProcessing();
 
 			Assert.IsTrue(manager.ControllerOutput.IsPressed("Down"));
+		}
+
+		[TestMethod]
+		public void ClickyController()
+		{
+			// arrange
+			Context context = new();
+			InputManager manager = context.manager;
+			manager.ClickyController.Click("A");
+
+			// act + assert
+			context.BasicInputProcessing();
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+			context.EmulateFrameAdvance();
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void StickyHoldControllerButton()
+		{
+			// arrange
+			Context context = new();
+			InputManager manager = context.manager;
+			manager.StickyHoldController.SetButtonHold("A", true);
+
+			// act + assert
+			context.BasicInputProcessing();
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+			context.EmulateFrameAdvance();
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void StickyButtonPlusUserEqualsOff()
+		{
+			// arrange
+			Context context = new();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindMulti("A", "Q");
+			source.MakePressEvent("Q");
+			manager.StickyHoldController.SetButtonHold("A", true);
+
+			// act
+			context.BasicInputProcessing();
+
+			// assert
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void StickyHoldControllerAxis()
+		{
+			// arrange
+			Context context = new();
+			InputManager manager = context.manager;
+			manager.StickyHoldController.SetAxisHold("Stick", 2);
+
+			// act + assert
+			context.BasicInputProcessing();
+			Assert.AreEqual(2, manager.ControllerOutput.AxisValue("Stick"));
+			context.EmulateFrameAdvance();
+			Assert.AreEqual(2, manager.ControllerOutput.AxisValue("Stick"));
+		}
+
+		[TestMethod]
+		public void StickyAutofireControllerButton()
+		{
+			// arrange
+			Context context = new();
+			InputManager manager = context.manager;
+			manager.StickyAutofireController.SetButtonAutofire("A", true);
+
+			// act + assert
+			context.BasicInputProcessing();
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+			context.EmulateFrameAdvance();
+			Assert.IsFalse(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void StickyAutofireControllerAxis()
+		{
+			// arrange
+			Context context = new();
+			InputManager manager = context.manager;
+			manager.StickyAutofireController.SetAxisAutofire("Stick", 2);
+
+			// act + assert
+			context.BasicInputProcessing();
+			Assert.AreEqual(2, manager.ControllerOutput.AxisValue("Stick"));
+			context.EmulateFrameAdvance();
+			Assert.AreEqual(context.emulator.ControllerDefinition.Axes["Stick"].Neutral, manager.ControllerOutput.AxisValue("Stick"));
+		}
+
+		[TestMethod]
+		public void OverrideAdapterButton()
+		{
+			// arrange
+			Context context = new();
+			InputManager manager = context.manager;
+			manager.OverrideAdapter.SetButton("A", true);
+
+			// act
+			context.BasicInputProcessing();
+
+			// assert
+			Assert.IsTrue(manager.ControllerOutput.IsPressed("A"));
+		}
+
+		[TestMethod]
+		public void OverrideAdapterAxis()
+		{
+			// arrange
+			Context context = new();
+			InputManager manager = context.manager;
+			manager.OverrideAdapter.SetAxis("Stick", 2);
+
+			// act
+			context.BasicInputProcessing();
+
+			// assert
+			Assert.AreEqual(2, manager.ControllerOutput.AxisValue("Stick"));
+		}
+
+		[TestMethod]
+		public void RegularAxisInput()
+		{
+			// arrange
+			Context context = new();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.ActiveController.BindAxis("Stick", new AnalogBind("", 1f, 0f, "Q", ""));
+			source.MakePressEvent("Q");
+
+			// act
+			context.BasicInputProcessing();
+
+			// assert
+			Assert.AreEqual(100, manager.ControllerOutput.AxisValue("Stick"));
+		}
+
+		[TestMethod]
+		public void OverrideAdapterAxisOverridesNonNeutral()
+		{
+			// arrange
+			Context context = new();
+			InputManager manager = context.manager;
+			FakeInputSource source = context.source;
+			manager.OverrideAdapter.SetAxis("Stick", 2);
+			manager.ActiveController.BindAxis("Stick", new AnalogBind("", 1f, 0f, "Q", ""));
+			source.MakePressEvent("Q");
+
+			// act
+			context.BasicInputProcessing();
+
+			// assert
+			Assert.AreEqual(2, manager.ControllerOutput.AxisValue("Stick"));
 		}
 #pragma warning restore BHI1600
 	}

--- a/src/BizHawk.Tests.Client.Common/InputManagerTests.cs
+++ b/src/BizHawk.Tests.Client.Common/InputManagerTests.cs
@@ -37,6 +37,19 @@ namespace BizHawk.Tests.Client.Common
 				_hotkeys = hotkeys;
 			}
 
+			public Context(IEmulator emulator, IMovieSession movieSession)
+			{
+				this.emulator = emulator;
+				manager.SyncControls(emulator, movieSession, config);
+
+				_hotkeys = [ ];
+				ControllerDefinition cd = new("fake")
+				{
+					BoolButtons = _hotkeys.ToList(),
+				};
+				manager.ClientControls = new Controller(cd.MakeImmutable());
+			}
+
 			/// <summary>
 			/// After running this, <see cref="InputManager.ControllerOutput"/> will hold the values for the NEXT frame, not the one just simulated.
 			/// </summary>

--- a/src/BizHawk.Tests.Client.Common/Movie/FakeEmulator.cs
+++ b/src/BizHawk.Tests.Client.Common/Movie/FakeEmulator.cs
@@ -11,7 +11,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 		private BasicServiceProvider _serviceProvider;
 		public IEmulatorServiceProvider ServiceProvider => _serviceProvider;
 
-		private static readonly ControllerDefinition _cd = new ControllerDefinition("fake controller")
+		public static readonly ControllerDefinition Definition = new ControllerDefinition("fake controller")
 		{
 			BoolButtons = { "A", "B" },
 		}
@@ -20,10 +20,10 @@ namespace BizHawk.Tests.Client.Common.Movie
 
 		static FakeEmulator()
 		{
-			_cd.BuildMnemonicsCache("fake");
+			Definition.BuildMnemonicsCache("fake");
 		}
 
-		public ControllerDefinition ControllerDefinition => _cd;
+		public ControllerDefinition ControllerDefinition => Definition;
 
 		public int Frame { get; set; }
 


### PR DESCRIPTION
This PR changes both `JoypadApi.SetAnalog` overloads, so that they behave similarly to the `Set` methods for buttons. This means (1) using `OverrideAdapter` instead of the sticky controller [fixes the Lua issue observed in #4766], (2) changing the way analog values are unset in the dictionary overload is by passing a dictionary without the relevant keys [allowing it to set neutral axis values], and (3) for Lua, throwing an exception if the input value cannot be converted to an int [instead of silently failing].

The old behavior is still available in a `[Obosolete]` overload. External tools wishing to make use of this fix will need to be updated for the new method signature. The C# method signature for Lua is identical, so the fixed version uses an updated name `set_analog`. Lua scripts using `setanalog` wishing to make use of this fix will need to be updated.

The documentation for the set methods are updated to include "as if the inputs came from the user" (same as the new SetAnalog). This implies that #4769 is indented behavior; auto-fire will obviously work when the button is not otherwise held. Sticky holds and autofires will also interact with buttons held by `joypad.set`. But this implication is probably not very obvious and better documentation may still be beneficial. Alternatively, we might want to change the behavior.

It also fixes the behavior of the set methods when called from the frame start event, adds tests, and cleans up some code a little bit.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant