### PR TITLE
Track whether the cursor is over the menubar or status bar, and ignore LMB inputs when true

### DIFF
--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -58,7 +58,7 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// This is used to prevent mouse clicks from being used as input when clicking on menu items.
 		/// </summary>
-		public Func<bool> GetMouseOverMenu { get; set; }
+		public bool MouseOverMenu { get; set; } = false;
 
 		public void SyncControls(IEmulator emulator, IMovieSession session, Config config)
 		{
@@ -175,7 +175,7 @@ namespace BizHawk.Client.Common
 
 				if (ie.EventType == InputEventType.Press && ie.ToString().Contains("WMouse L"))
 				{
-					if (GetMouseOverMenu?.Invoke() == true) continue;
+					if (MouseOverMenu) continue;
 				}
 
 				// TODO - wonder what happens if we pop up something interactive as a response to one of these hotkeys? may need to purge further processing

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -55,6 +55,11 @@ namespace BizHawk.Client.Common
 
 		public Func<(Point Pos, long Scroll, bool LMB, bool MMB, bool RMB, bool X1MB, bool X2MB)> GetMainFormMouseInfo { get; set; }
 
+		/// <summary>
+		/// This is used to prevent mouse clicks from being used as input when clicking on menu items.
+		/// </summary>
+		public Func<bool> GetMouseOverMenu { get; set; }
+
 		public void SyncControls(IEmulator emulator, IMovieSession session, Config config)
 		{
 			var def = emulator.ControllerDefinition;
@@ -166,6 +171,11 @@ namespace BizHawk.Client.Common
 				{
 					processSpecialInput(ie, false);
 					continue;
+				}
+
+				if (ie.EventType == InputEventType.Press && ie.ToString().Contains("WMouse L"))
+				{
+					if (GetMouseOverMenu?.Invoke() == true) continue;
 				}
 
 				// TODO - wonder what happens if we pop up something interactive as a response to one of these hotkeys? may need to purge further processing

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -217,10 +217,10 @@ namespace BizHawk.Client.EmuHawk
 			DOSSubMenu.DropDownOpened += (_, _) => DOSExportHDDImageToolStripMenuItem.Enabled = Emulator is DOSBox dosbox && dosbox.HasValidHDD();
 			_ = MainformMenu.Items.InsertAfter(NullHawkVSysSubmenu, insert: DOSSubMenu);
 
-			MainStatusBar.MouseEnter += (s, e) => _mouseOverMenu = true;
-			MainStatusBar.MouseLeave += (s, e) => _mouseOverMenu = false;
-			MainformMenu.MouseEnter += (s, e) => _mouseOverMenu = true;
-			MainformMenu.MouseLeave += (s, e) => _mouseOverMenu = false;
+			MainStatusBar.MouseEnter += (s, e) => InputManager.MouseOverMenu = true;
+			MainStatusBar.MouseLeave += (s, e) => InputManager.MouseOverMenu = false;
+			MainformMenu.MouseEnter += (s, e) => InputManager.MouseOverMenu = true;
+			MainformMenu.MouseLeave += (s, e) => InputManager.MouseOverMenu = false;
 
 			// Hide Status bar icons and general StatusBar prep
 			MainStatusBar.Padding = new Padding(MainStatusBar.Padding.Left, MainStatusBar.Padding.Top, MainStatusBar.Padding.Left, MainStatusBar.Padding.Bottom); // Workaround to remove extra padding on right
@@ -493,7 +493,6 @@ namespace BizHawk.Client.EmuHawk
 						(b & MouseButtons.XButton2) != 0
 					);
 				},
-				GetMouseOverMenu = () => _mouseOverMenu,
 			};
 			FirmwareManager = new FirmwareManager();
 			movieSession = MovieSession = new MovieSession(
@@ -1115,11 +1114,6 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		public bool BlockFrameAdvance { get; set; }
-
-		/// <summary>
-		/// This is used to prevent mouse clicks from being used as input when clicking on menu items.
-		/// </summary>
-		private bool _mouseOverMenu = false;
 
 		public string CurrentlyOpenRom { get; private set; } // todo - delete me and use only args instead
 		public LoadRomArgs CurrentlyOpenRomArgs { get; private set; }

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -217,6 +217,11 @@ namespace BizHawk.Client.EmuHawk
 			DOSSubMenu.DropDownOpened += (_, _) => DOSExportHDDImageToolStripMenuItem.Enabled = Emulator is DOSBox dosbox && dosbox.HasValidHDD();
 			_ = MainformMenu.Items.InsertAfter(NullHawkVSysSubmenu, insert: DOSSubMenu);
 
+			MainStatusBar.MouseEnter += (s, e) => _mouseOverMenu = true;
+			MainStatusBar.MouseLeave += (s, e) => _mouseOverMenu = false;
+			MainformMenu.MouseEnter += (s, e) => _mouseOverMenu = true;
+			MainformMenu.MouseLeave += (s, e) => _mouseOverMenu = false;
+
 			// Hide Status bar icons and general StatusBar prep
 			MainStatusBar.Padding = new Padding(MainStatusBar.Padding.Left, MainStatusBar.Padding.Top, MainStatusBar.Padding.Left, MainStatusBar.Padding.Bottom); // Workaround to remove extra padding on right
 			PlayRecordStatusButton.Visible = false;
@@ -488,6 +493,7 @@ namespace BizHawk.Client.EmuHawk
 						(b & MouseButtons.XButton2) != 0
 					);
 				},
+				GetMouseOverMenu = () => _mouseOverMenu,
 			};
 			FirmwareManager = new FirmwareManager();
 			movieSession = MovieSession = new MovieSession(
@@ -1109,6 +1115,11 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		public bool BlockFrameAdvance { get; set; }
+
+		/// <summary>
+		/// This is used to prevent mouse clicks from being used as input when clicking on menu items.
+		/// </summary>
+		private bool _mouseOverMenu = false;
 
 		public string CurrentlyOpenRom { get; private set; } // todo - delete me and use only args instead
 		public LoadRomArgs CurrentlyOpenRomArgs { get; private set; }


### PR DESCRIPTION
Feels like a bit of a hack, but that's normal for input stuff I guess.

There is still another issue related to mouse + menus: if you click a menu item to open a sub-menu (for example, click "File") then wave your mouse around until it's over the game area but no menus are open, mouse inputs don't work. That input is blocked by `FormBase.MenuIsOpen` which can block all inputs while a menu is open.

Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
