### PR TITLE
Updated Vs. System Mapper

### DIFF
--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/VS_M99.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/VS_M99.cs
@@ -66,7 +66,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			}
 			else
 			{
-				addr -= 0x2000;
+				addr &= 0x0FFF;
 				if (addr<0x800)
 				{
 					return NES.CIRAM[addr];
@@ -87,7 +87,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			}
 			else
 			{
-				addr -= 0x2000;
+				addr &= 0x0FFF;
 				if (addr < 0x800)
 				{
 					NES.CIRAM[addr] = value;
@@ -96,6 +96,30 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				{
 					CIRAM_VS[addr-0x800] = value;
 				}
+			}
+		}
+
+		public override byte ReadReg2xxx(int addr)
+		{
+			if ((addr & 7) == 4)
+			{
+				return NES.ppu.ppu_open_bus; // The Vs. System uses an RGB PPU, which cannot read from $2004
+			}
+			else
+			{
+				return NES.ppu.ReadReg(addr & 7);
+			}
+		}
+
+		public override byte PeekReg2xxx(int addr)
+		{
+			if ((addr & 7) == 4)
+			{
+				return NES.ppu.ppu_open_bus; // The Vs. System uses an RGB PPU, which cannot read from $2004
+			}
+			else
+			{
+				return NES.ppu.PeekReg(addr & 7);
 			}
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/VS_M99.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/VS_M99.cs
@@ -101,25 +101,25 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 		public override byte ReadReg2xxx(int addr)
 		{
-			if ((addr & 7) == 4)
+			if ((addr & 0b111) is 0b100)
 			{
 				return NES.ppu.ppu_open_bus; // The Vs. System uses an RGB PPU, which cannot read from $2004
 			}
 			else
 			{
-				return NES.ppu.ReadReg(addr & 7);
+				return NES.ppu.ReadReg(addr & 0b111);
 			}
 		}
 
 		public override byte PeekReg2xxx(int addr)
 		{
-			if ((addr & 7) == 4)
+			if ((addr & 0b111) is 0b100)
 			{
 				return NES.ppu.ppu_open_bus; // The Vs. System uses an RGB PPU, which cannot read from $2004
 			}
 			else
 			{
-				return NES.ppu.PeekReg(addr & 7);
+				return NES.ppu.PeekReg(addr & 0b111);
 			}
 		}
 


### PR DESCRIPTION
Prevented array index out of bounds error, and corrected nametable mirroring.
 - If you attempted to read from VRAM address $3000 through $3EFF, instead of reading from a mirror of the nametable, bizhawk would crash.
- This crash can be reproduced in VS Super Mario Bros. using the attached .bk2 file.
[Crash.zip](https://github.com/user-attachments/files/30912359/Crash.zip)

Prevented the Vs. System from reading from $2004.
 - The RGB PPU found inside the Vs. System never had any revisions capable of reading from OAM DATA.

The RGB PPU would also be incapable of reading from Palette RAM, though I have not made that change.

Check if completed:

- [ ] I have run any relevant test suites.
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
