### PR TITLE
Change how EmuHawk handles SRAM

### DIFF
--- a/src/BizHawk.Client.Common/FilesystemFilter.cs
+++ b/src/BizHawk.Client.Common/FilesystemFilter.cs
@@ -65,6 +65,8 @@ namespace BizHawk.Client.Common
 
 		public static readonly FilesystemFilter PNGs = new FilesystemFilter("PNG Files", new[] { "png" });
 
+		public static readonly FilesystemFilter SaveRams = new FilesystemFilter("SaveRAM Files", new[] { "SaveRAM", "bin" });
+
 		public static readonly FilesystemFilter TAStudioProjects = new FilesystemFilter("TAS Project Files", new[] { MovieService.TasMovieExtension });
 
 		public static readonly FilesystemFilter TextFiles = new FilesystemFilter("Text Files", new[] { "txt" });

--- a/src/BizHawk.Client.Common/LoadRomArgs.cs
+++ b/src/BizHawk.Client.Common/LoadRomArgs.cs
@@ -1,7 +1,10 @@
+#nullable enable
+
 namespace BizHawk.Client.Common
 {
 	public sealed record class LoadRomArgs(
 		IOpenAdvanced OpenAdvanced,
-		string/*?*/ ForcedSysID = null,
-		bool? Deterministic = null);
+		string? ForcedSysID = null,
+		bool? Deterministic = null,
+		string? SaveRamPath = null);
 }

--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -197,6 +197,8 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		public int FlushSaveRamFrames { get; set; }
 
+		public bool WarnLoadSramReboots { get; set; } = true;
+
 		public bool TurboSeek { get; set; }
 
 		public ClientProfile SelectedProfile { get; set; } = ClientProfile.Unknown;

--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -190,12 +190,12 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Whether to make AutoSave files at periodic intervals
 		/// </summary>
-		public bool AutosaveSaveRAM { get; set; }
+		public bool AutosaveSaveRAM { get; set; } = true;
 
 		/// <summary>
 		/// Intervals at which to make AutoSave files
 		/// </summary>
-		public int FlushSaveRamFrames { get; set; }
+		public int FlushSaveRamFrames { get; set; } = 5 * 60 * 60; // 5 minutes (it assumes 60 fps)
 
 		public bool WarnLoadSramReboots { get; set; } = true;
 

--- a/src/BizHawk.Client.Common/config/PathEntryCollectionExtensions.cs
+++ b/src/BizHawk.Client.Common/config/PathEntryCollectionExtensions.cs
@@ -244,6 +244,14 @@ namespace BizHawk.Client.Common
 			return $"{Path.Combine(collection.AbsolutePathFor(pathEntry.Path, game.System), name)}.SaveRAM";
 		}
 
+		public static string SaveRamAbsolutePath(this PathEntryCollection collection, string system)
+		{
+			var pathEntry = collection[system, "Save RAM"]
+				?? collection[system, "Base"];
+
+			return collection.AbsolutePathFor(pathEntry.Path, system);
+		}
+
 		// Shenanigans
 		public static string RetroSaveRamAbsolutePath(this PathEntryCollection collection, string coreName)
 		{

--- a/src/BizHawk.Client.Common/config/PathEntryCollectionExtensions.cs
+++ b/src/BizHawk.Client.Common/config/PathEntryCollectionExtensions.cs
@@ -264,12 +264,6 @@ namespace BizHawk.Client.Common
 			return Path.Combine(collection.AbsolutePathFor(pathEntry.Path, VSystemID.Raw.Libretro), coreName);
 		}
 
-		public static string AutoSaveRamAbsolutePath(this PathEntryCollection collection, IGameInfo game)
-		{
-			var path = collection.SaveRamAbsolutePath(game);
-			return path.Insert(path.Length - 8, ".AutoSaveRAM");
-		}
-
 		public static string CheatsAbsolutePath(this PathEntryCollection collection, string systemId)
 		{
 			var pathEntry = collection[systemId, "Cheats"]

--- a/src/BizHawk.Client.Common/config/PathEntryCollectionExtensions.cs
+++ b/src/BizHawk.Client.Common/config/PathEntryCollectionExtensions.cs
@@ -230,13 +230,9 @@ namespace BizHawk.Client.Common
 			return collection.AbsolutePathFor(path.Path, systemId);
 		}
 
-		public static string SaveRamAbsolutePath(this PathEntryCollection collection, IGameInfo game, IMovie movie)
+		public static string SaveRamAbsolutePath(this PathEntryCollection collection, IGameInfo game)
 		{
 			var name = game.FilesystemSafeName();
-			if (movie.IsActive())
-			{
-				name += $".{Path.GetFileNameWithoutExtension(movie.Filename)}";
-			}
 
 			var pathEntry = collection[game.System, "Save RAM"]
 				?? collection[game.System, "Base"];
@@ -268,9 +264,9 @@ namespace BizHawk.Client.Common
 			return Path.Combine(collection.AbsolutePathFor(pathEntry.Path, VSystemID.Raw.Libretro), coreName);
 		}
 
-		public static string AutoSaveRamAbsolutePath(this PathEntryCollection collection, IGameInfo game, IMovie movie)
+		public static string AutoSaveRamAbsolutePath(this PathEntryCollection collection, IGameInfo game)
 		{
-			var path = collection.SaveRamAbsolutePath(game, movie);
+			var path = collection.SaveRamAbsolutePath(game);
 			return path.Insert(path.Length - 8, ".AutoSaveRAM");
 		}
 

--- a/src/BizHawk.Client.EmuHawk/CustomControls/MsgBox.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/MsgBox.cs
@@ -18,13 +18,16 @@ namespace BizHawk.Client.EmuHawk.CustomControls
 		// The min required width of the button and checkbox row. Sum of button widths + checkbox width + margins.
 		private int _minButtonRowWidth;
 
+		public bool UserSaysDontShowAgain => chkBx.Checked;
+
 		/// <summary>
 		/// Create a new instance of the dialog box with a message and title and a standard windows MessageBox icon.
 		/// </summary>
 		/// <param name="message">Message text.</param>
 		/// <param name="title">Dialog Box title.</param>
 		/// <param name="boxIcon">Standard system MessageBox icon.</param>
-		public MsgBox(string message, string title, MessageBoxIcon boxIcon)
+		/// <param name="showCheckbox">Show a checkbox letting the user say "don't show this again".</param>
+		public MsgBox(string message, string title, MessageBoxIcon boxIcon, bool showCheckbox = false)
 		{
 			var icon = GetMessageBoxIcon(boxIcon);
 			InitializeComponent();
@@ -39,6 +42,8 @@ namespace BizHawk.Client.EmuHawk.CustomControls
 			{
 				messageLbl.Location = new Point(FormXMargin, FormYMargin);
 			}
+
+			chkBx.Visible = showCheckbox;
 		}
 
 		/// <summary>

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -75,6 +75,7 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveRAMSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.FlushSaveRAMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveSramAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadSramMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripMenuItem2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.MovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ReadonlyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -711,7 +712,8 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.FlushSaveRAMMenuItem,
-            this.SaveSramAsMenuItem});
+            this.SaveSramAsMenuItem,
+            this.LoadSramMenuItem});
 			this.SaveRAMSubMenu.Text = "Save &RAM";
 			this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
 			// 
@@ -724,6 +726,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SaveSramAsMenuItem.Text = "Save SRAM &As";
 			this.SaveSramAsMenuItem.Click += new System.EventHandler(this.SaveSramAsMenuItem_Click);
+			// 
+			// LoadSramMenuItem
+			// 
+			this.LoadSramMenuItem.Text = "L&oad SRAM";
+			this.LoadSramMenuItem.Click += new System.EventHandler(this.LoadSramMenuItem_Click);
 			// 
 			// MovieSubMenu
 			// 
@@ -2724,6 +2731,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveRAMSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FlushSaveRAMMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveSramAsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadSramMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXDiscControlsMenuItem;
 		private BizHawk.WinForms.Controls.StatusLabelEx UpdateNotification;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXControllerSettingsMenuItem;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -74,6 +74,7 @@ namespace BizHawk.Client.EmuHawk
 			this.LoadCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveRAMSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.FlushSaveRAMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveSramAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripMenuItem2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.MovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ReadonlyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -709,7 +710,8 @@ namespace BizHawk.Client.EmuHawk
 			// SaveRAMSubMenu
 			// 
 			this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.FlushSaveRAMMenuItem});
+            this.FlushSaveRAMMenuItem,
+            this.SaveSramAsMenuItem});
 			this.SaveRAMSubMenu.Text = "Save &RAM";
 			this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
 			// 
@@ -717,6 +719,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
 			this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
+			// 
+			// SaveSramAsMenuItem
+			// 
+			this.SaveSramAsMenuItem.Text = "Save SRAM &As";
+			this.SaveSramAsMenuItem.Click += new System.EventHandler(this.SaveSramAsMenuItem_Click);
 			// 
 			// MovieSubMenu
 			// 
@@ -2716,6 +2723,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXOptionsMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveRAMSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FlushSaveRAMMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveSramAsMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXDiscControlsMenuItem;
 		private BizHawk.WinForms.Controls.StatusLabelEx UpdateNotification;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXControllerSettingsMenuItem;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -382,7 +382,7 @@ namespace BizHawk.Client.EmuHawk
 			// copy the file
 			File.Copy(
 				sourceFileName: fileToLoad,
-				destFileName: Config.PathEntries.SaveRamAbsolutePath(Game, movie: null),
+				destFileName: Config.PathEntries.SaveRamAbsolutePath(Game),
 				overwrite: true);
 
 			// reboot
@@ -1341,7 +1341,7 @@ namespace BizHawk.Client.EmuHawk
 
 			ConfigContextMenuItem.Visible = _inFullscreen;
 
-			ClearSRAMContextMenuItem.Visible = File.Exists(Config.PathEntries.SaveRamAbsolutePath(Game, MovieSession.Movie));
+			ClearSRAMContextMenuItem.Visible = File.Exists(Config.PathEntries.SaveRamAbsolutePath(Game));
 
 			ContextSeparator_AfterROM.Visible = OpenRomContextMenuItem.Visible || LoadLastRomContextMenuItem.Visible;
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -338,12 +338,11 @@ namespace BizHawk.Client.EmuHawk
 				filter: filterset);
 			if (shouldSaveResult is not null)
 			{
-				byte[] saveram = Emulator.AsSaveRam().CloneSaveRam();
-				if (saveram == null)
-					return;
-				ShowMessageIfError(
-					() => FileWriter.Write(shouldSaveResult, saveram),
-					"Unable to save Save RAM.");
+				string normalPath = CurrentlyOpenRomArgs.SaveRamPath ?? Config.PathEntries.SaveRamAbsolutePath(Game);
+				string oldAutoPath = MakeSaveRamAutosavePath(normalPath);
+				CurrentlyOpenRomArgs = CurrentlyOpenRomArgs with { SaveRamPath = shouldSaveResult };
+				FlushSaveRAMMenuItem_Click(sender, e);
+				try { File.Delete(oldAutoPath); } catch { /* nothing */ }
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -379,14 +379,8 @@ namespace BizHawk.Client.EmuHawk
 				filter: filterset);
 			if (fileToLoad == null) return;
 
-			// copy the file
-			File.Copy(
-				sourceFileName: fileToLoad,
-				destFileName: Config.PathEntries.SaveRamAbsolutePath(Game),
-				overwrite: true);
-
 			// reboot
-			RebootCore(false);
+			RebootCore(fileToLoad);
 		}
 
 		private void ReadonlyMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -347,6 +347,48 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		private void LoadSramMenuItem_Click(object sender, EventArgs e)
+		{
+			if (Config.WarnLoadSramReboots)
+			{
+				MsgBox box = new(
+					message: "Loading Save RAM requires a core reboot. Proceed?",
+					title: "Reboot?",
+					boxIcon: MessageBoxIcon.Warning,
+					showCheckbox: true);
+				box.SetButtons([ "Yes", "No" ], [ DialogResult.Yes, DialogResult.Cancel ]);
+				DialogResult result = box.ShowDialog();
+				if (box.UserSaysDontShowAgain) Config.WarnLoadSramReboots = false;
+				if (result == DialogResult.Cancel) return;
+			}
+
+			// get the file
+			string sramFolderPath = Config.PathEntries.SaveRamAbsolutePath(Game.System);
+			// Create folder if it doesn't already exist
+			try
+			{
+				Directory.CreateDirectory(sramFolderPath);
+			}
+			catch (IOException) { /* ignored */ }
+			catch (UnauthorizedAccessException) { /* ignored */ }
+
+			FilesystemFilterSet filterset = new(FilesystemFilter.SaveRams);
+			string fileToLoad = this.ShowFileOpenDialog(
+				initDir: sramFolderPath,
+				discardCWDChange: true,
+				filter: filterset);
+			if (fileToLoad == null) return;
+
+			// copy the file
+			File.Copy(
+				sourceFileName: fileToLoad,
+				destFileName: Config.PathEntries.SaveRamAbsolutePath(Game, movie: null),
+				overwrite: true);
+
+			// reboot
+			RebootCore(false);
+		}
+
 		private void ReadonlyMenuItem_Click(object sender, EventArgs e)
 		{
 			ToggleReadOnly();

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -318,6 +318,35 @@ namespace BizHawk.Client.EmuHawk
 			ShowMessageIfError(() => FlushSaveRAM(), "Failed to flush saveram!");
 		}
 
+		private void SaveSramAsMenuItem_Click(object sender, EventArgs e)
+		{
+			string sramFolderPath = Config.PathEntries.SaveRamAbsolutePath(Game.System);
+
+			// Create folder if it doesn't already exist
+			try
+			{
+				Directory.CreateDirectory(sramFolderPath);
+			}
+			catch (IOException) { /* ignored */ }
+			catch (UnauthorizedAccessException) { /* ignored */ }
+
+			FilesystemFilterSet filterset = new(FilesystemFilter.SaveRams);
+			var shouldSaveResult = this.ShowFileSaveDialog(
+				initDir: sramFolderPath,
+				discardCWDChange: true,
+				fileExt: $".{filterset.Filters[0].Extensions.First()}",
+				filter: filterset);
+			if (shouldSaveResult is not null)
+			{
+				byte[] saveram = Emulator.AsSaveRam().CloneSaveRam();
+				if (saveram == null)
+					return;
+				ShowMessageIfError(
+					() => FileWriter.Write(shouldSaveResult, saveram),
+					"Unable to save Save RAM.");
+			}
+		}
+
 		private void ReadonlyMenuItem_Click(object sender, EventArgs e)
 		{
 			ToggleReadOnly();

--- a/src/BizHawk.Client.EmuHawk/MainForm.Movie.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Movie.cs
@@ -21,6 +21,8 @@ namespace BizHawk.Client.EmuHawk
 {
 	public partial class MainForm
 	{
+		private bool _hadMovie = false;
+
 		public bool StartNewMovie(IMovie movie, bool newMovie)
 		{
 			if (movie is null) throw new ArgumentNullException(paramName: nameof(movie));
@@ -63,6 +65,7 @@ namespace BizHawk.Client.EmuHawk
 				Config.RecentMovies.Add(movie.Filename);
 
 				MovieSession.RunQueuedMovie(newMovie, Emulator);
+				_hadMovie = true;
 				if (newMovie)
 				{
 					PopulateWithDefaultHeaderValues(movie);

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2980,7 +2980,7 @@ namespace BizHawk.Client.EmuHawk
 
 				RA?.OnFrameAdvance();
 
-				if (Config.AutosaveSaveRAM)
+				if (Config.AutosaveSaveRAM && !_hadMovie)
 				{
 					AutoFlushSaveRamIn--;
 					if (AutoFlushSaveRamIn <= 0)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1138,6 +1138,8 @@ namespace BizHawk.Client.EmuHawk
 		public bool IsFastForwarding => InputManager.ClientControls["Fast Forward"] || IsTurboing;
 		public bool IsRewinding { get; private set; }
 
+		private bool _saveSramOnReboot = true;
+
 		/// <summary>
 		/// Used to disable secondary throttling (e.g. vsync, audio) for unthrottled modes or when the primary (clock) throttle is taking over (e.g. during fast forward/rewind).
 		/// </summary>
@@ -1311,7 +1313,9 @@ namespace BizHawk.Client.EmuHawk
 			base.OnDeactivate(e);
 		}
 
-		public bool RebootCore()
+		public bool RebootCore() => RebootCore(true);
+
+		private bool RebootCore(bool saveSram)
 		{
 			if (ToolControllingReboot is { } tool)
 			{
@@ -1321,9 +1325,17 @@ namespace BizHawk.Client.EmuHawk
 			else
 			{
 				if (CurrentlyOpenRomArgs == null) return true;
-				return LoadRom(
-					CurrentlyOpenRomArgs.OpenAdvanced.SimplePath,
-					CurrentlyOpenRomArgs with { ForcedSysID = Emulator.SystemId });
+				if (!saveSram) _saveSramOnReboot = false;
+				try
+				{
+					return LoadRom(
+						CurrentlyOpenRomArgs.OpenAdvanced.SimplePath,
+						CurrentlyOpenRomArgs with { ForcedSysID = Emulator.SystemId });
+				}
+				finally
+				{
+					_saveSramOnReboot = true;
+				}
 			}
 		}
 
@@ -3952,7 +3964,7 @@ namespace BizHawk.Client.EmuHawk
 					}
 				}
 			}
-			else if (Emulator.HasSaveRam())
+			else if (Emulator.HasSaveRam() && _saveSramOnReboot)
 			{
 				TryAgainResult flushResult = this.DoWithTryAgainBox(
 					() => FlushSaveRAM(),

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1138,8 +1138,6 @@ namespace BizHawk.Client.EmuHawk
 		public bool IsFastForwarding => InputManager.ClientControls["Fast Forward"] || IsTurboing;
 		public bool IsRewinding { get; private set; }
 
-		private bool _saveSramOnReboot = true;
-
 		/// <summary>
 		/// Used to disable secondary throttling (e.g. vsync, audio) for unthrottled modes or when the primary (clock) throttle is taking over (e.g. during fast forward/rewind).
 		/// </summary>
@@ -1313,9 +1311,9 @@ namespace BizHawk.Client.EmuHawk
 			base.OnDeactivate(e);
 		}
 
-		public bool RebootCore() => RebootCore(true);
+		public bool RebootCore() => RebootCore(CurrentlyOpenRomArgs?.SaveRamPath);
 
-		private bool RebootCore(bool saveSram)
+		private bool RebootCore(string/*?*/ saveRamPath)
 		{
 			if (ToolControllingReboot is { } tool)
 			{
@@ -1325,17 +1323,9 @@ namespace BizHawk.Client.EmuHawk
 			else
 			{
 				if (CurrentlyOpenRomArgs == null) return true;
-				if (!saveSram) _saveSramOnReboot = false;
-				try
-				{
-					return LoadRom(
-						CurrentlyOpenRomArgs.OpenAdvanced.SimplePath,
-						CurrentlyOpenRomArgs with { ForcedSysID = Emulator.SystemId });
-				}
-				finally
-				{
-					_saveSramOnReboot = true;
-				}
+				return LoadRom(
+					CurrentlyOpenRomArgs.OpenAdvanced.SimplePath,
+					CurrentlyOpenRomArgs with { ForcedSysID = Emulator.SystemId, SaveRamPath = saveRamPath });
 			}
 		}
 
@@ -1873,12 +1863,17 @@ namespace BizHawk.Client.EmuHawk
 		// Better is to just keep the game and rom hashes as properties and then generate the rom info from this
 		private string _defaultRomDetails = "";
 
+		private static string MakeSaveRamAutosavePath(string sramPath)
+		{
+			return sramPath.Insert(sramPath.Length - 8, ".AutoSaveRAM");
+		}
+
 		private void LoadSaveRam()
 		{
 			if (Emulator.HasSaveRam())
 			{
-				var saveRam = new FileInfo(Config.PathEntries.SaveRamAbsolutePath(Game));
-				var autoSaveRam = new FileInfo(Config.PathEntries.AutoSaveRamAbsolutePath(Game));
+				var saveRam = new FileInfo(CurrentlyOpenRomArgs.SaveRamPath ?? Config.PathEntries.SaveRamAbsolutePath(Game));
+				var autoSaveRam = new FileInfo(MakeSaveRamAutosavePath(saveRam.FullName));
 
 				FileInfo saveramToLoad;
 				if (saveRam.Exists && (!autoSaveRam.Exists || autoSaveRam.LastWriteTimeUtc <= saveRam.LastWriteTimeUtc))
@@ -1947,14 +1942,10 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (Emulator.HasSaveRam())
 			{
-				string path;
+				string path = CurrentlyOpenRomArgs.SaveRamPath ?? Config.PathEntries.SaveRamAbsolutePath(Game);
 				if (autosave)
 				{
-					path = Config.PathEntries.AutoSaveRamAbsolutePath(Game);
-				}
-				else
-				{
-					path = Config.PathEntries.SaveRamAbsolutePath(Game);
+					path = MakeSaveRamAutosavePath(path);
 				}
 
 				var saveram = Emulator.AsSaveRam().CloneSaveRam();
@@ -3789,16 +3780,16 @@ namespace BizHawk.Client.EmuHawk
 						Console.WriteLine("Core reported BoardID: \"{0}\"", Emulator.AsBoardInfo().BoardName);
 					}
 
+					var previousRom = CurrentlyOpenRom;
+					CurrentlyOpenRom = oaOpenrom?.Path ?? openAdvancedArgs;
+					CurrentlyOpenRomArgs = args;
+
 					// Don't load Save Ram if a movie is being loaded
 					if (!MovieSession.NewMovieQueued)
 					{
 						LoadSaveRam();
 						AutoFlushSaveRamIn = Config.FlushSaveRamFrames;
 					}
-
-					var previousRom = CurrentlyOpenRom;
-					CurrentlyOpenRom = oaOpenrom?.Path ?? openAdvancedArgs;
-					CurrentlyOpenRomArgs = args;
 
 					Tools.Restart(Config, Emulator, Game);
 
@@ -3964,7 +3955,7 @@ namespace BizHawk.Client.EmuHawk
 					}
 				}
 			}
-			else if (Emulator.HasSaveRam() && _saveSramOnReboot && !_hadMovie)
+			else if (Emulator.HasSaveRam() && !_hadMovie)
 			{
 				TryAgainResult flushResult = this.DoWithTryAgainBox(
 					() => FlushSaveRAM(),

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1877,8 +1877,8 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (Emulator.HasSaveRam())
 			{
-				var saveRam = new FileInfo(Config.PathEntries.SaveRamAbsolutePath(Game, MovieSession.Movie));
-				var autoSaveRam = new FileInfo(Config.PathEntries.AutoSaveRamAbsolutePath(Game, MovieSession.Movie));
+				var saveRam = new FileInfo(Config.PathEntries.SaveRamAbsolutePath(Game));
+				var autoSaveRam = new FileInfo(Config.PathEntries.AutoSaveRamAbsolutePath(Game));
 
 				FileInfo saveramToLoad;
 				if (saveRam.Exists && (!autoSaveRam.Exists || autoSaveRam.LastWriteTimeUtc <= saveRam.LastWriteTimeUtc))
@@ -1950,11 +1950,11 @@ namespace BizHawk.Client.EmuHawk
 				string path;
 				if (autosave)
 				{
-					path = Config.PathEntries.AutoSaveRamAbsolutePath(Game, MovieSession.Movie);
+					path = Config.PathEntries.AutoSaveRamAbsolutePath(Game);
 				}
 				else
 				{
-					path = Config.PathEntries.SaveRamAbsolutePath(Game, MovieSession.Movie);
+					path = Config.PathEntries.SaveRamAbsolutePath(Game);
 				}
 
 				var saveram = Emulator.AsSaveRam().CloneSaveRam();
@@ -3943,7 +3943,7 @@ namespace BizHawk.Client.EmuHawk
 
 			if (clearSram)
 			{
-				var path = Config.PathEntries.SaveRamAbsolutePath(Game, MovieSession.Movie);
+				var path = Config.PathEntries.SaveRamAbsolutePath(Game);
 				if (File.Exists(path))
 				{
 					TryAgainResult clearResult = this.DoWithTryAgainBox(() => {
@@ -3964,13 +3964,14 @@ namespace BizHawk.Client.EmuHawk
 					}
 				}
 			}
-			else if (Emulator.HasSaveRam() && _saveSramOnReboot)
+			else if (Emulator.HasSaveRam() && _saveSramOnReboot && !_hadMovie)
 			{
 				TryAgainResult flushResult = this.DoWithTryAgainBox(
 					() => FlushSaveRAM(),
 					"Failed flushing the game's Save RAM to your disk.");
 				if (flushResult == TryAgainResult.Canceled) return false;
 			}
+			_hadMovie = false;
 
 			TryAgainResult stateSaveResult = this.DoWithTryAgainBox(AutoSaveStateIfConfigured, "Failed to auto-save state.");
 			if (stateSaveResult == TryAgainResult.Canceled) return false;

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1942,16 +1942,22 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (Emulator.HasSaveRam())
 			{
-				string path = CurrentlyOpenRomArgs.SaveRamPath ?? Config.PathEntries.SaveRamAbsolutePath(Game);
-				if (autosave)
-				{
-					path = MakeSaveRamAutosavePath(path);
-				}
+				string normalPath = CurrentlyOpenRomArgs.SaveRamPath ?? Config.PathEntries.SaveRamAbsolutePath(Game);
+				string autoPath = MakeSaveRamAutosavePath(normalPath);
 
 				var saveram = Emulator.AsSaveRam().CloneSaveRam();
 				if (saveram == null)
 					return new();
-				return FileWriter.Write(path, saveram, $"{path}.bak");
+
+				if (autosave)
+				{
+					// No backup: autosave is already a backup
+					return FileWriter.Write(autoPath, saveram);
+				}
+				else
+				{
+					return FileWriter.Write(normalPath, saveram, Config.BackupSaveram ? $"{normalPath}.bak" : null);
+				}
 			}
 
 			return new();
@@ -3954,13 +3960,6 @@ namespace BizHawk.Client.EmuHawk
 						return false;
 					}
 				}
-			}
-			else if (Emulator.HasSaveRam() && !_hadMovie)
-			{
-				TryAgainResult flushResult = this.DoWithTryAgainBox(
-					() => FlushSaveRAM(),
-					"Failed flushing the game's Save RAM to your disk.");
-				if (flushResult == TryAgainResult.Canceled) return false;
 			}
 			_hadMovie = false;
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1742,6 +1742,8 @@ namespace BizHawk.Client.EmuHawk
 		public int AutoFlushSaveRamIn { get; set; }
 		private bool AutoFlushSaveRamFailed;
 
+		private int _lastSaveRamFlush = -1;
+
 		private void SetStatusBar()
 		{
 			if (!_inFullscreen)
@@ -1956,7 +1958,10 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					return FileWriter.Write(normalPath, saveram, Config.BackupSaveram ? $"{normalPath}.bak" : null);
+					FileWriteResult result = FileWriter.Write(normalPath, saveram, Config.BackupSaveram ? $"{normalPath}.bak" : null);
+					if (!result.IsError) _lastSaveRamFlush = Emulator.Frame;
+					try { File.Delete(autoPath); } catch { /* nothing */ }
+					return result;
 				}
 			}
 
@@ -3796,6 +3801,7 @@ namespace BizHawk.Client.EmuHawk
 						LoadSaveRam();
 						AutoFlushSaveRamIn = Config.FlushSaveRamFrames;
 					}
+					_lastSaveRamFlush = -1;
 
 					Tools.Restart(Config, Emulator, Game);
 
@@ -3958,6 +3964,28 @@ namespace BizHawk.Client.EmuHawk
 					if (clearResult == TryAgainResult.Canceled)
 					{
 						return false;
+					}
+				}
+			}
+			else if (!_hadMovie)
+			{
+				ISaveRam sramService = Emulator.AsSaveRam();
+				// if (sramService.SaveRamModified) // not a good idea because some core always return true (do any return false negative?)
+				if (sramService != null && _lastSaveRamFlush < Emulator.Frame)
+				{
+					if (this.ShowMessageBox2(
+						text: "Flsuh Save RAM?",
+						caption: "Save?",
+						icon: EMsgBoxIcon.Question))
+					{
+						TryAgainResult saveSramResult = this.DoWithTryAgainBox(() => FlushSaveRAM(), "Failed to save Save RAM.");
+						if (saveSramResult == TryAgainResult.Canceled) return false;
+					}
+					else
+					{
+						// either way, we don't need to keep a backup if the user explicitly said they don't want a save
+						string normalPath = CurrentlyOpenRomArgs.SaveRamPath ?? Config.PathEntries.SaveRamAbsolutePath(Game);
+						try { File.Delete(MakeSaveRamAutosavePath(normalPath)); } catch { /* nothing */ }
 					}
 				}
 			}


### PR DESCRIPTION
1) User can manually load a SRAM file
2) Users can do SRAM "save as"
3) Do not automatically save SRAM when closing/rebooting: ask the user instead, but only if no movie had been started
4) Save on close and "flush save ram" menu item write to whichever file was opened (or "save as"d)
5) Enable AutoSaveRam (the one that saves while playing) by default
6) Disable AutoSaveRam when a movie has been loaded
7) Delete the auto save file whenever SRAM is manually saved (or the user says no to saving on close)

This means EmuHawk will never automatically overwrite any SRAM file, and will not clutter the SRAM folder with files from movies.

I'm not fully happy with this, but I am not sure how to make it better. The dialog asking the user if they want to save on close could probably use a "remember my choice" option. A better flow for loading a ROM with a specific SRAM might be something to implement.

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [x] I have run any relevant test suites
- [x] I, the commit author, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-06-22) and am compliant
